### PR TITLE
Add search schema cleaner

### DIFF
--- a/pkg/wal/processor/search/search_schema_cleaner.go
+++ b/pkg/wal/processor/search/search_schema_cleaner.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package search
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/xataio/pgstream/internal/backoff"
+
+	"github.com/rs/zerolog/log"
+)
+
+type schemaCleaner struct {
+	deleteSchemaQueue   chan string
+	store               store
+	backoffProvider     backoff.Provider
+	registrationTimeout time.Duration
+}
+
+type store interface {
+	DeleteSchema(ctx context.Context, schemaName string) error
+}
+
+const (
+	maxDeleteQueueSize         = 5000
+	defaultRegistrationTimeout = 5 * time.Second
+)
+
+var errRegistrationTimeout = errors.New("timeout registering schema for clean up")
+
+func newSchemaCleaner(cfg *backoff.Config, store store) *schemaCleaner { //nolint:unused
+	return &schemaCleaner{
+		deleteSchemaQueue:   make(chan string, maxDeleteQueueSize),
+		store:               store,
+		registrationTimeout: defaultRegistrationTimeout,
+		backoffProvider: func(ctx context.Context) backoff.Backoff {
+			return backoff.NewExponentialBackoff(ctx, cfg)
+		},
+	}
+}
+
+// deleteSchema writes a delete schema item to the delete queue. Times out and returns an error after 5 seconds.
+func (sc *schemaCleaner) deleteSchema(_ context.Context, schemaName string) error {
+	select {
+	case sc.deleteSchemaQueue <- schemaName:
+		return nil
+	case <-time.After(sc.registrationTimeout):
+		return errRegistrationTimeout
+	}
+}
+
+// start will continuously process schema items from the local delete queue
+func (sc *schemaCleaner) start(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case schema := <-sc.deleteSchemaQueue:
+			bo := sc.backoffProvider(ctx)
+			err := bo.RetryNotify(
+				func() error {
+					return getRetryError(sc.store.DeleteSchema(ctx, schema))
+				},
+				func(err error, duration time.Duration) {
+					log.Ctx(ctx).Warn().Err(err).
+						Dur("backoff", duration).
+						Str("schema", schema).
+						Msg("search schema cleaner: delete schema retry failed")
+				})
+			if err != nil {
+				log.Ctx(ctx).Error().Err(err).
+					Str("schema", schema).
+					Msg("search schema cleaner: delete schema")
+			}
+		}
+	}
+}
+
+// stop will stop the processing of delete items from the queue and release
+// internal resources
+func (sc schemaCleaner) stop() {
+	close(sc.deleteSchemaQueue)
+}
+
+// getRetryError returns a backoff permanent error if the given error is not
+// retryable
+func getRetryError(err error) error {
+	if err != nil {
+		if errors.Is(err, ErrRetriable) {
+			return err
+		}
+		return fmt.Errorf("%w: %w", err, backoff.ErrPermanent)
+	}
+	return nil
+}

--- a/pkg/wal/processor/search/search_schema_cleaner_test.go
+++ b/pkg/wal/processor/search/search_schema_cleaner_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package search
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/internal/backoff"
+	"github.com/xataio/pgstream/internal/backoff/mocks"
+)
+
+func TestSchemaCleaner_deleteSchema(t *testing.T) {
+	t.Parallel()
+
+	testSchemaName := "test_schema"
+
+	tests := []struct {
+		name      string
+		queueSize uint
+
+		wantErr error
+	}{
+		{
+			name:      "ok",
+			queueSize: 10,
+
+			wantErr: nil,
+		},
+		{
+			name:      "error - registration timeout",
+			queueSize: 0,
+
+			wantErr: errRegistrationTimeout,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			schemaCleaner := &schemaCleaner{
+				registrationTimeout: time.Second,
+				deleteSchemaQueue:   make(chan string, tc.queueSize),
+			}
+			defer schemaCleaner.stop()
+
+			err := schemaCleaner.deleteSchema(context.Background(), testSchemaName)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestSchemaCleaner_start(t *testing.T) {
+	t.Parallel()
+
+	testSchemaName := "test_schema"
+	errTest := errors.New("oh noes")
+
+	tests := []struct {
+		name            string
+		store           store
+		backoffProvider func(doneChan chan struct{}) backoff.Provider
+	}{
+		{
+			name: "ok",
+			store: &mockStore{
+				deleteSchemaFn: func(ctx context.Context, schemaName string) error {
+					require.Equal(t, testSchemaName, schemaName)
+					return nil
+				},
+			},
+			backoffProvider: func(doneChan chan struct{}) backoff.Provider {
+				once := sync.Once{}
+				return func(ctx context.Context) backoff.Backoff {
+					return &mocks.Backoff{
+						RetryNotifyFn: func(o backoff.Operation, n backoff.Notify) error {
+							defer once.Do(func() { doneChan <- struct{}{} })
+							return o()
+						},
+					}
+				}
+			},
+		},
+		{
+			name: "error deleting schema",
+			store: &mockStore{
+				deleteSchemaFn: func(ctx context.Context, schemaName string) error {
+					return errTest
+				},
+			},
+			backoffProvider: func(doneChan chan struct{}) backoff.Provider {
+				once := sync.Once{}
+				return func(ctx context.Context) backoff.Backoff {
+					return &mocks.Backoff{
+						RetryNotifyFn: func(o backoff.Operation, n backoff.Notify) error {
+							defer once.Do(func() { doneChan <- struct{}{} })
+							err := o()
+							if err != nil {
+								n(err, 50*time.Millisecond)
+							}
+							return err
+						},
+					}
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			doneChan := make(chan struct{}, 1)
+			defer close(doneChan)
+
+			schemaCleaner := &schemaCleaner{
+				store:               tc.store,
+				backoffProvider:     tc.backoffProvider(doneChan),
+				registrationTimeout: defaultRegistrationTimeout,
+				deleteSchemaQueue:   make(chan string, 100),
+			}
+			defer schemaCleaner.stop()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				schemaCleaner.start(ctx)
+			}()
+
+			schemaCleaner.deleteSchemaQueue <- testSchemaName
+
+			for {
+				select {
+				case <-ctx.Done():
+					t.Errorf("test timeout reached")
+					wg.Wait()
+					return
+				case <-doneChan:
+					cancel()
+					wg.Wait()
+					return
+				}
+			}
+		})
+	}
+}
+
+type mockStore struct {
+	deleteSchemaFn func(context.Context, string) error
+}
+
+func (m *mockStore) DeleteSchema(ctx context.Context, schemaName string) error {
+	return m.deleteSchemaFn(ctx, schemaName)
+}

--- a/pkg/wal/processor/search/store.go
+++ b/pkg/wal/processor/search/store.go
@@ -4,6 +4,7 @@ package search
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/xataio/pgstream/pkg/schemalog"
@@ -55,3 +56,5 @@ type ErrSchemaNotFound struct {
 func (e ErrSchemaNotFound) Error() string {
 	return fmt.Sprintf("schema [%s] not found", e.SchemaName)
 }
+
+var ErrRetriable = errors.New("retriable error")


### PR DESCRIPTION
This PR adds a schema cleaner that will keep an internal delete queue for the search schemas that have been dropped. This will allow us to not spend more time than necessary when processing the WAL events from the search indexer, by making the clean up asynchronous.