### PR TITLE
Add `walDataToQueueItem` to search adapter

### DIFF
--- a/pkg/wal/processor/search/errors.go
+++ b/pkg/wal/processor/search/errors.go
@@ -53,4 +53,5 @@ var (
 	errIDNotFound      = errors.New("id column not found")
 	errNilIDValue      = errors.New("id has nil value")
 	errNilVersionValue = errors.New("version has nil value")
+	errMetadataMissing = errors.New("missing wal event metadata")
 )

--- a/pkg/wal/processor/search/helper_test.go
+++ b/pkg/wal/processor/search/helper_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package search
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rs/xid"
+	"github.com/xataio/pgstream/pkg/schemalog"
+	"github.com/xataio/pgstream/pkg/wal"
+)
+
+type mockStore struct {
+	getMapperFn            func() Mapper
+	applySchemaChangeFn    func(ctx context.Context, le *schemalog.LogEntry) error
+	deleteSchemaFn         func(ctx context.Context, schemaName string) error
+	deleteTableDocumentsFn func(ctx context.Context, schemaName string, tableIDs []string) error
+	sendDocumentsFn        func(ctx context.Context, i uint, docs []Document) ([]DocumentError, error)
+	sendDocumentsCalls     uint
+}
+
+func (m *mockStore) GetMapper() Mapper {
+	return m.getMapperFn()
+}
+
+func (m *mockStore) ApplySchemaChange(ctx context.Context, le *schemalog.LogEntry) error {
+	return m.applySchemaChangeFn(ctx, le)
+}
+
+func (m *mockStore) DeleteSchema(ctx context.Context, schemaName string) error {
+	return m.deleteSchemaFn(ctx, schemaName)
+}
+
+func (m *mockStore) DeleteTableDocuments(ctx context.Context, schemaName string, tableIDs []string) error {
+	return m.deleteTableDocumentsFn(ctx, schemaName, tableIDs)
+}
+
+func (m *mockStore) SendDocuments(ctx context.Context, docs []Document) ([]DocumentError, error) {
+	m.sendDocumentsCalls++
+	return m.sendDocumentsFn(ctx, m.sendDocumentsCalls, docs)
+}
+
+const (
+	testSchemaName = "test_schema"
+	testTableName  = "test_table"
+	testTableID    = "t1"
+)
+
+var errTest = errors.New("oh noes")
+
+func newTestSchemaChangeEvent(action string, id xid.ID, now time.Time) *wal.Data {
+	nowStr := now.Format("2006-01-02 15:04:05")
+	return &wal.Data{
+		Action: action,
+		Schema: schemalog.SchemaName,
+		Table:  schemalog.TableName,
+		Columns: []wal.Column{
+			{ID: "id", Name: "id", Type: "text", Value: id.String()},
+			{ID: "version", Name: "version", Type: "integer", Value: 0},
+			{ID: "schema_name", Name: "schema_name", Type: "text", Value: testSchemaName},
+			{ID: "created_at", Name: "created_at", Type: "timestamp", Value: nowStr},
+		},
+	}
+}
+
+func newTestDataEvent(action string) *wal.Data {
+	cols := []wal.Column{
+		{ID: "col-1", Name: "id", Type: "text", Value: "id-1"},
+		{ID: "col-2", Name: "version", Type: "integer", Value: int64(0)},
+		{ID: "col-3", Name: "name", Type: "text", Value: "a"},
+	}
+	d := &wal.Data{
+		Action: action,
+		Schema: testSchemaName,
+		Table:  testTableName,
+		Metadata: wal.Metadata{
+			TablePgstreamID:    testTableID,
+			InternalColID:      "col-1",
+			InternalColVersion: "col-2",
+		},
+	}
+
+	if d.Action == "D" {
+		d.Identity = cols
+	} else {
+		d.Columns = cols
+	}
+
+	return d
+}
+
+type testDocOption func(*Document)
+
+func newTestDocument(opts ...testDocOption) *Document {
+	doc := &Document{
+		Schema:  testSchemaName,
+		ID:      fmt.Sprintf("%s_id-1", testTableID),
+		Version: 0,
+		Data: map[string]any{
+			"_table": testTableID,
+			"col-3":  "a",
+		},
+	}
+
+	for _, opt := range opts {
+		opt(doc)
+	}
+	return doc
+}
+
+func newTestLogEntry(id xid.ID, now time.Time) *schemalog.LogEntry {
+	return &schemalog.LogEntry{
+		ID:         id,
+		Version:    0,
+		SchemaName: testSchemaName,
+		CreatedAt:  schemalog.NewSchemaCreatedAtTimestamp(now),
+	}
+}

--- a/pkg/wal/processor/search/search_schema_cleaner_test.go
+++ b/pkg/wal/processor/search/search_schema_cleaner_test.go
@@ -155,11 +155,3 @@ func TestSchemaCleaner_start(t *testing.T) {
 		})
 	}
 }
-
-type mockStore struct {
-	deleteSchemaFn func(context.Context, string) error
-}
-
-func (m *mockStore) DeleteSchema(ctx context.Context, schemaName string) error {
-	return m.deleteSchemaFn(ctx, schemaName)
-}

--- a/pkg/wal/processor/search/store.go
+++ b/pkg/wal/processor/search/store.go
@@ -37,6 +37,18 @@ type DocumentError struct {
 	Error    string
 }
 
+type queueItem struct {
+	write        *Document
+	truncate     *truncateItem
+	schemaChange *schemalog.LogEntry
+	bytesSize    int
+}
+
+type truncateItem struct {
+	schemaName string
+	tableID    string
+}
+
 type Severity uint
 
 const (


### PR DESCRIPTION
This PR adds the logic to convert between `wal.Data` and the `queueItem` types, which will be used by the search indexer. The size in the `queueItem` type will be used to allocate space in the internal queue to optimise the memory usage given the variable size of the incoming wal data events.