### PR TITLE
Add search batch indexer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/elastic/go-elasticsearch/v8 v8.13.1
 	github.com/golang-migrate/migrate/v4 v4.17.1
+	github.com/google/go-cmp v0.6.0
 	github.com/jackc/pglogrepl v0.0.0-20240307033717-828fbfe908e9
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/mitchellh/mapstructure v1.5.0

--- a/pkg/wal/processor/search/errors.go
+++ b/pkg/wal/processor/search/errors.go
@@ -54,4 +54,5 @@ var (
 	errNilIDValue      = errors.New("id has nil value")
 	errNilVersionValue = errors.New("version has nil value")
 	errMetadataMissing = errors.New("missing wal event metadata")
+	errEmptyQueueItem  = errors.New("invalid empty queue item")
 )

--- a/pkg/wal/processor/search/search_adapter.go
+++ b/pkg/wal/processor/search/search_adapter.go
@@ -13,7 +13,7 @@ import (
 	"github.com/xataio/pgstream/pkg/wal/processor"
 )
 
-type walAdapter interface { //nolint:unused
+type walAdapter interface {
 	walDataToQueueItem(*wal.Data) (*queueItem, error)
 }
 

--- a/pkg/wal/processor/search/search_batch_indexer.go
+++ b/pkg/wal/processor/search/search_batch_indexer.go
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package search
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"time"
+
+	"github.com/xataio/pgstream/internal/backoff"
+	synclib "github.com/xataio/pgstream/internal/sync"
+	"github.com/xataio/pgstream/pkg/schemalog"
+	"github.com/xataio/pgstream/pkg/wal"
+	"github.com/xataio/pgstream/pkg/wal/processor"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// BatchIndexer is the environment for ingesting the WAL logical
+// replication events into a search store using the pgstream flow
+type BatchIndexer struct {
+	store   Store
+	adapter walAdapter
+
+	// queueBytesSema is used to limit the amount of memory used by the
+	// unbuffered msg channel, optimising the channel performance for variable
+	// size messages, while preventing the process from running oom
+	queueBytesSema synclib.WeightedSemaphore
+	msgChan        chan (*msg)
+
+	batchSize         int
+	batchSendInterval time.Duration
+
+	skipSchema func(schemaName string) bool
+
+	// checkpoint callback to mark what was safely stored
+	checkpoint checkpoint
+
+	cleaner cleaner
+}
+
+type IndexerConfig struct {
+	BatchSize      int
+	BatchTime      time.Duration
+	CleanupBackoff backoff.Config
+	MaxQueueBytes  int
+}
+
+// checkpoint defines the way to confirm the positions that have been read.
+// The actual implementation depends on the source of events (postgres, kafka,...)
+type checkpoint func(ctx context.Context, positions []wal.CommitPosition) error
+
+const defaultMaxQueueBytes = 100 * 1024 * 1024 // 100MiB
+
+// NewBatchIndexer returns a processor of wal events that indexes data into the
+// search store provided on input.
+func NewBatchIndexer(ctx context.Context, config IndexerConfig, store Store) *BatchIndexer {
+	indexer := &BatchIndexer{
+		store: store,
+		// by default all schemas are processed
+		skipSchema:        func(string) bool { return false },
+		batchSize:         config.BatchSize,
+		batchSendInterval: config.BatchTime,
+		cleaner:           newSchemaCleaner(&config.CleanupBackoff, store),
+		adapter:           newAdapter(store.GetMapper()),
+		msgChan:           make(chan *msg),
+	}
+
+	// this allows us to bound and configure the memory used by the internal msg
+	// queue
+	maxQueueBytes := defaultMaxQueueBytes
+	if config.MaxQueueBytes > 0 {
+		maxQueueBytes = config.MaxQueueBytes
+	}
+	indexer.queueBytesSema = synclib.NewWeightedSemaphore(int64(maxQueueBytes))
+
+	// start a goroutine for processing schema deletes asynchronously.
+	// routine ends when the internal channel is closed.
+	go indexer.cleaner.start(ctx)
+	return indexer
+}
+
+// ProcessWALEvent is called on every new message from the WAL logical
+// replication The function is responsible for sending the data to the search
+// store and committing the event position.
+func (i *BatchIndexer) ProcessWALEvent(ctx context.Context, data *wal.Data, pos wal.CommitPosition) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Ctx(ctx).WithLevel(zerolog.PanicLevel).
+				Any("wal_data", data).
+				Any("panic", r).
+				Bytes("stack_trace", debug.Stack()).
+				Msg("[PANIC] Panic while processing replication event")
+
+			err = fmt.Errorf("search batch indexer: %w: %v", processor.ErrPanic, r)
+		}
+	}()
+
+	item, err := i.adapter.walDataToQueueItem(data)
+	if err != nil {
+		if errors.Is(err, errNilIDValue) || errors.Is(err, errNilVersionValue) || errors.Is(err, errMetadataMissing) {
+			log.Ctx(ctx).Warn().Msgf("invalid event, skipping message: %v", err)
+			return nil
+		}
+		return fmt.Errorf("wal data to queue item: %w", err)
+	}
+
+	if item == nil {
+		return nil
+	}
+
+	msg := newMsg(item, pos)
+	// make sure we don't reach the queue memory limit before adding the new
+	// message to the channel. This will block until messages have been read
+	// from the channel and their size is released
+	msgSize := int64(msg.size())
+	if !i.queueBytesSema.TryAcquire(msgSize) {
+		log.Ctx(ctx).Warn().Msg("search batch indexer: max queue bytes reached, processing blocked")
+		if err := i.queueBytesSema.Acquire(ctx, msgSize); err != nil {
+			return err
+		}
+	}
+	i.msgChan <- msg
+
+	return nil
+}
+
+func (i *BatchIndexer) Send(ctx context.Context) error {
+	// make sure we send to the search store on a separate go routine to isolate
+	// the IO operations and minimise the wait time between batch sending while
+	// continuously building new batches.
+	batchChan := make(chan *msgBatch)
+	defer close(batchChan)
+	sendErrChan := make(chan error, 1)
+	go func() {
+		defer close(sendErrChan)
+		for batch := range batchChan {
+			// If the send fails, this goroutine returns an error over the error channel and shuts down.
+			err := i.sendBatch(ctx, batch)
+			i.queueBytesSema.Release(int64(batch.totalBytes))
+			if err != nil {
+				log.Ctx(ctx).Error().Err(err).Msg("search batch indexer")
+				sendErrChan <- err
+				return
+			}
+		}
+	}()
+
+	ticker := time.NewTicker(i.batchSendInterval)
+	defer ticker.Stop()
+	msgBatch := &msgBatch{}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case sendErr := <-sendErrChan:
+			// if there's an error while sending the batch, return the error and
+			// stop sending batches
+			return sendErr
+		case <-ticker.C:
+			batchChan <- msgBatch.drain()
+		case msg := <-i.msgChan:
+			// trigger a send if we reached the configured batch size or if the
+			// event was for a schema change. We need to make sure any events
+			// following a schema change are processed using the right schema
+			// version
+			if msgBatch.size() >= i.batchSize || msg.isSchemaChange() {
+				batchChan <- msgBatch.drain()
+			}
+			msgBatch.add(msg)
+		}
+	}
+}
+
+func (i *BatchIndexer) SetCheckpoint(checkpoint checkpoint) {
+	i.checkpoint = checkpoint
+}
+
+func (i *BatchIndexer) Close() error {
+	close(i.msgChan)
+	i.cleaner.stop()
+	return nil
+}
+
+func (i *BatchIndexer) sendBatch(ctx context.Context, batch *msgBatch) error {
+	if len(batch.items) == 0 {
+		return nil
+	}
+
+	// we'll mostly process writes, so pre-allocate the "max" amount
+	writes := make([]Document, 0, len(batch.items))
+	flushWrites := func() error {
+		if len(writes) > 0 {
+			if _, err := i.store.SendDocuments(ctx, writes); err != nil {
+				return err
+			}
+			writes = writes[:0]
+		}
+		return nil
+	}
+
+	for _, item := range batch.items {
+		switch {
+		case item.write != nil:
+			writes = append(writes, *item.write)
+		case item.schemaChange != nil:
+			if err := flushWrites(); err != nil {
+				return err
+			}
+			if err := i.applySchemaChange(ctx, item.schemaChange); err != nil {
+				logDataLoss(ctx, item.schemaChange, err)
+				return nil
+			}
+		case item.truncate != nil:
+			if err := flushWrites(); err != nil {
+				return err
+			}
+			if err := i.truncateTable(ctx, item.truncate); err != nil {
+				return err
+			}
+		default:
+			return errEmptyQueueItem
+		}
+	}
+
+	if err := flushWrites(); err != nil {
+		return err
+	}
+
+	if i.checkpoint != nil {
+		if err := i.checkpoint(ctx, batch.positions); err != nil {
+			return fmt.Errorf("checkpointing positions: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (i *BatchIndexer) truncateTable(ctx context.Context, item *truncateItem) error {
+	return i.store.DeleteTableDocuments(ctx, item.schemaName, []string{item.tableID})
+}
+
+func (i *BatchIndexer) applySchemaChange(ctx context.Context, new *schemalog.LogEntry) error {
+	// schema is filtered out, nothing to do
+	if i.skipSchema(new.SchemaName) {
+		log.Ctx(ctx).Info().Msgf("applySchemaChange: skipping schema [%s]", new.SchemaName)
+		return nil
+	}
+
+	if new.Schema.Dropped {
+		if err := i.cleaner.deleteSchema(ctx, new.SchemaName); err != nil {
+			return fmt.Errorf("register schema for delete: %w", err)
+		}
+		return nil
+	}
+
+	log.Ctx(ctx).Info().Dict("logEntry", zerolog.Dict().
+		Str("ID", new.ID.String()).
+		Int64("version", new.Version).
+		Str("schema", new.SchemaName).
+		Bool("isDropped", new.Schema.Dropped)).Msg("search batch indexer: apply schema change")
+
+	if err := i.store.ApplySchemaChange(ctx, new); err != nil {
+		return fmt.Errorf("applying schema change: %w", err)
+	}
+
+	return nil
+}
+
+func logDataLoss(ctx context.Context, logEntry *schemalog.LogEntry, err error) {
+	log.Ctx(ctx).Error().Err(err).
+		Str("severity", "DATALOSS").
+		Dict("logEntry", zerolog.Dict().
+			Str("ID", logEntry.ID.String()).
+			Int64("version", logEntry.Version).
+			Str("schema", logEntry.SchemaName)).
+		Msg("search batch indexer")
+}

--- a/pkg/wal/processor/search/search_batch_indexer_test.go
+++ b/pkg/wal/processor/search/search_batch_indexer_test.go
@@ -1,0 +1,663 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package search
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	syncmocks "github.com/xataio/pgstream/internal/sync/mocks"
+	"github.com/xataio/pgstream/pkg/schemalog"
+	"github.com/xataio/pgstream/pkg/wal"
+	"github.com/xataio/pgstream/pkg/wal/processor"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchIndexer_ProcessWALEvent(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Round(time.Second)
+	id := xid.New()
+	testSchemaLogEntry := newTestLogEntry(id, now)
+	testCommitPos := newTestCommitPosition()
+	testSize := 10
+
+	tests := []struct {
+		name              string
+		weightedSemaphore *syncmocks.WeightedSemaphore
+		adapter           *mockAdapter
+		event             *wal.Data
+
+		wantMsgs []*msg
+		wantErr  error
+	}{
+		{
+			name: "ok",
+			weightedSemaphore: &syncmocks.WeightedSemaphore{
+				TryAcquireFn: func(i int64) bool {
+					require.Equal(t, int64(testSize), i)
+					return true
+				},
+			},
+			adapter: &mockAdapter{
+				walDataToQueueItemFn: func(*wal.Data) (*queueItem, error) {
+					return &queueItem{
+						schemaChange: testSchemaLogEntry,
+						bytesSize:    testSize,
+					}, nil
+				},
+			},
+			event: newTestSchemaChangeEvent("I", id, now),
+
+			wantMsgs: []*msg{
+				{
+					item: &queueItem{
+						schemaChange: testSchemaLogEntry,
+						bytesSize:    testSize,
+					},
+					pos: testCommitPos,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ok - nil queue item",
+			weightedSemaphore: &syncmocks.WeightedSemaphore{
+				TryAcquireFn: func(i int64) bool { return true },
+			},
+			adapter: &mockAdapter{
+				walDataToQueueItemFn: func(*wal.Data) (*queueItem, error) {
+					return nil, nil
+				},
+			},
+			event: newTestDataEvent("I"),
+
+			wantMsgs: nil,
+			wantErr:  nil,
+		},
+		{
+			name: "ok - skipped event",
+			weightedSemaphore: &syncmocks.WeightedSemaphore{
+				TryAcquireFn: func(i int64) bool { return true },
+			},
+			adapter: &mockAdapter{
+				walDataToQueueItemFn: func(*wal.Data) (*queueItem, error) {
+					return nil, errNilIDValue
+				},
+			},
+			event: newTestSchemaChangeEvent("I", id, now),
+
+			wantMsgs: nil,
+			wantErr:  nil,
+		},
+		{
+			name: "ok - waiting for semaphore",
+			weightedSemaphore: &syncmocks.WeightedSemaphore{
+				TryAcquireFn: func(i int64) bool { return false },
+				AcquireFn:    func(ctx context.Context, i int64) error { return nil },
+			},
+			adapter: &mockAdapter{
+				walDataToQueueItemFn: func(*wal.Data) (*queueItem, error) {
+					return &queueItem{schemaChange: testSchemaLogEntry}, nil
+				},
+			},
+			event: newTestSchemaChangeEvent("I", id, now),
+
+			wantMsgs: []*msg{
+				{
+					item: &queueItem{
+						schemaChange: testSchemaLogEntry,
+					},
+					pos: testCommitPos,
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "error - acquiring semaphore",
+			weightedSemaphore: &syncmocks.WeightedSemaphore{
+				TryAcquireFn: func(i int64) bool { return false },
+				AcquireFn:    func(ctx context.Context, i int64) error { return errTest },
+			},
+			adapter: &mockAdapter{
+				walDataToQueueItemFn: func(*wal.Data) (*queueItem, error) {
+					return &queueItem{schemaChange: testSchemaLogEntry}, nil
+				},
+			},
+			event: newTestSchemaChangeEvent("I", id, now),
+
+			wantMsgs: nil,
+			wantErr:  errTest,
+		},
+		{
+			name: "error - wal data to queue item",
+			weightedSemaphore: &syncmocks.WeightedSemaphore{
+				TryAcquireFn: func(i int64) bool { return true },
+			},
+			adapter: &mockAdapter{
+				walDataToQueueItemFn: func(*wal.Data) (*queueItem, error) {
+					return nil, errTest
+				},
+			},
+			event: newTestSchemaChangeEvent("I", id, now),
+
+			wantMsgs: nil,
+			wantErr:  errTest,
+		},
+		{
+			name: "error - panic recovery",
+			weightedSemaphore: &syncmocks.WeightedSemaphore{
+				TryAcquireFn: func(i int64) bool { return true },
+			},
+			adapter: &mockAdapter{
+				walDataToQueueItemFn: func(*wal.Data) (*queueItem, error) {
+					panic(errTest)
+				},
+			},
+			event: newTestDataEvent("I"),
+
+			wantMsgs: nil,
+			wantErr:  processor.ErrPanic,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			indexer := &BatchIndexer{
+				queueBytesSema: tc.weightedSemaphore,
+				msgChan:        make(chan *msg, 100),
+				adapter:        tc.adapter,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			go func() {
+				defer close(indexer.msgChan)
+				err := indexer.ProcessWALEvent(ctx, tc.event, testCommitPos)
+				require.ErrorIs(t, err, tc.wantErr)
+			}()
+
+			msgs := []*msg{}
+			for msg := range indexer.msgChan {
+				if ctx.Err() != nil {
+					t.Log("test timeout reached")
+					return
+				}
+				msgs = append(msgs, msg)
+			}
+			if len(msgs) == 0 {
+				msgs = nil
+			}
+
+			if diff := cmp.Diff(msgs, tc.wantMsgs, cmp.AllowUnexported(msg{}, queueItem{})); diff != "" {
+				t.Errorf("got: \n%v, \nwant \n%v, \ndiff: \n%s", msgs, tc.wantMsgs, diff)
+			}
+		})
+	}
+}
+
+func TestBatchIndexer_Send(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Round(time.Second)
+	id := xid.New()
+
+	testSchemaLogEntry := newTestLogEntry(id, now)
+	testDocument := newTestDocument()
+
+	testSize := 10
+
+	tests := []struct {
+		name      string
+		store     func(doneChan chan struct{}) *mockStore
+		msgs      []*msg
+		semaphore *syncmocks.WeightedSemaphore
+
+		wantErr error
+	}{
+		{
+			name: "ok - write",
+			store: func(doneChan chan struct{}) *mockStore {
+				once := sync.Once{}
+				return &mockStore{
+					sendDocumentsFn: func(ctx context.Context, _ uint, docs []Document) ([]DocumentError, error) {
+						defer once.Do(func() { doneChan <- struct{}{} })
+						require.Equal(t, []Document{*testDocument}, docs)
+						return nil, nil
+					},
+				}
+			},
+			msgs: []*msg{
+				{item: &queueItem{write: testDocument, bytesSize: testSize}},
+			},
+			semaphore: &syncmocks.WeightedSemaphore{
+				ReleaseFn: func(i uint64, bytes int64) {
+					if i == 0 {
+						require.Equal(t, int64(testSize), bytes)
+					}
+				},
+			},
+
+			wantErr: context.Canceled,
+		},
+		{
+			name: "ok - schema change",
+			store: func(doneChan chan struct{}) *mockStore {
+				once := sync.Once{}
+				return &mockStore{
+					applySchemaChangeFn: func(ctx context.Context, le *schemalog.LogEntry) error {
+						defer once.Do(func() { doneChan <- struct{}{} })
+						require.Equal(t, testSchemaLogEntry, le)
+						return nil
+					},
+				}
+			},
+			msgs: []*msg{
+				{item: &queueItem{schemaChange: testSchemaLogEntry, bytesSize: testSize}},
+			},
+			semaphore: &syncmocks.WeightedSemaphore{
+				ReleaseFn: func(i uint64, bytes int64) {
+					if i == 0 {
+						require.Equal(t, int64(testSize), bytes)
+					}
+				},
+			},
+
+			wantErr: context.Canceled,
+		},
+		{
+			name: "error - sending batch",
+			store: func(doneChan chan struct{}) *mockStore {
+				once := sync.Once{}
+				return &mockStore{
+					sendDocumentsFn: func(ctx context.Context, _ uint, docs []Document) ([]DocumentError, error) {
+						defer once.Do(func() { doneChan <- struct{}{} })
+						return nil, errTest
+					},
+				}
+			},
+			msgs: []*msg{
+				{item: &queueItem{write: testDocument, bytesSize: testSize}},
+			},
+			semaphore: &syncmocks.WeightedSemaphore{
+				ReleaseFn: func(i uint64, bytes int64) {
+					if i == 0 {
+						require.Equal(t, int64(testSize), bytes)
+					}
+				},
+			},
+
+			wantErr: errTest,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			doneChan := make(chan struct{}, 1)
+			defer close(doneChan)
+
+			indexer := &BatchIndexer{
+				msgChan:           make(chan *msg, 100),
+				store:             tc.store(doneChan),
+				batchSendInterval: 100 * time.Millisecond,
+				batchSize:         10,
+				skipSchema:        func(schemaName string) bool { return false },
+				queueBytesSema: &syncmocks.WeightedSemaphore{
+					ReleaseFn: func(_ uint64, _ int64) {},
+				},
+			}
+
+			if tc.semaphore != nil {
+				indexer.queueBytesSema = tc.semaphore
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				err := indexer.Send(ctx)
+				require.ErrorIs(t, err, tc.wantErr)
+			}()
+
+			for _, msg := range tc.msgs {
+				indexer.msgChan <- msg
+			}
+
+			for {
+				select {
+				case <-ctx.Done():
+					t.Log("test timeout reached")
+					wg.Wait()
+					return
+				case <-doneChan:
+					if errors.Is(tc.wantErr, context.Canceled) {
+						cancel()
+					}
+					wg.Wait()
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestBatchIndexer_sendBatch(t *testing.T) {
+	t.Parallel()
+
+	id := xid.New()
+	now := time.Now()
+	testLogEntry := newTestLogEntry(id, now)
+	testCommitPos := newTestCommitPosition()
+	testDocument1 := newTestDocument(withID("1"))
+	testDocument2 := newTestDocument(withID("2"))
+
+	tests := []struct {
+		name       string
+		store      Store
+		checkpoint checkpoint
+		batch      *msgBatch
+		skipSchema func(string) bool
+		cleaner    cleaner
+
+		wantErr error
+	}{
+		{
+			name:  "ok - no items in batch",
+			batch: &msgBatch{},
+
+			wantErr: nil,
+		},
+		{
+			name: "ok - write only batch",
+			batch: &msgBatch{
+				items: []*queueItem{
+					{write: testDocument1},
+					{write: testDocument2},
+				},
+				positions: []wal.CommitPosition{testCommitPos},
+			},
+			store: &mockStore{
+				sendDocumentsFn: func(ctx context.Context, _ uint, docs []Document) ([]DocumentError, error) {
+					require.Equal(t, []Document{*testDocument1, *testDocument2}, docs)
+					return nil, nil
+				},
+			},
+
+			wantErr: nil,
+		},
+		{
+			name: "ok - write and schema change batch",
+			batch: &msgBatch{
+				items: []*queueItem{
+					{write: testDocument1},
+					{schemaChange: testLogEntry},
+					{write: testDocument2},
+				},
+				positions: []wal.CommitPosition{testCommitPos},
+			},
+			store: &mockStore{
+				sendDocumentsFn: func(ctx context.Context, i uint, docs []Document) ([]DocumentError, error) {
+					switch i {
+					case 1:
+						require.Equal(t, []Document{*testDocument1}, docs)
+						return nil, nil
+					case 2:
+						require.Equal(t, []Document{*testDocument2}, docs)
+						return nil, nil
+					}
+					return nil, fmt.Errorf("sendDocumentsFn: unexpected call %d", i)
+				},
+				applySchemaChangeFn: func(ctx context.Context, le *schemalog.LogEntry) error {
+					require.Equal(t, testLogEntry, le)
+					return nil
+				},
+			},
+
+			wantErr: nil,
+		},
+		{
+			name: "ok - write and truncate batch",
+			batch: &msgBatch{
+				items: []*queueItem{
+					{write: testDocument1},
+					{truncate: &truncateItem{schemaName: testSchemaName, tableID: testTableName}},
+					{write: testDocument2},
+				},
+				positions: []wal.CommitPosition{testCommitPos},
+			},
+			store: &mockStore{
+				sendDocumentsFn: func(ctx context.Context, i uint, docs []Document) ([]DocumentError, error) {
+					switch i {
+					case 1:
+						require.Equal(t, []Document{*testDocument1}, docs)
+						return nil, nil
+					case 2:
+						require.Equal(t, []Document{*testDocument2}, docs)
+						return nil, nil
+					}
+					return nil, fmt.Errorf("sendDocumentsFn: unexpected call %d", i)
+				},
+				deleteTableDocumentsFn: func(ctx context.Context, schemaName string, tableIDs []string) error {
+					require.Equal(t, testSchemaName, schemaName)
+					require.Equal(t, []string{testTableName}, tableIDs)
+					return nil
+				},
+			},
+
+			wantErr: nil,
+		},
+		{
+			name: "ok - schema change skipped",
+			batch: &msgBatch{
+				items: []*queueItem{
+					{schemaChange: testLogEntry},
+				},
+				positions: []wal.CommitPosition{testCommitPos},
+			},
+			store:      &mockStore{},
+			skipSchema: func(s string) bool { return true },
+
+			wantErr: nil,
+		},
+		{
+			name: "ok - schema dropped",
+			batch: &msgBatch{
+				items: []*queueItem{
+					{
+						schemaChange: func() *schemalog.LogEntry {
+							le := newTestLogEntry(id, now)
+							le.Schema.Dropped = true
+							return le
+						}(),
+					},
+				},
+				positions: []wal.CommitPosition{testCommitPos},
+			},
+			store: &mockStore{},
+			cleaner: &mockCleaner{
+				deleteSchemaFn: func(ctx context.Context, s string) error {
+					require.Equal(t, testSchemaName, s)
+					return nil
+				},
+			},
+
+			wantErr: nil,
+		},
+		{
+			name: "error - applying schema change",
+			batch: &msgBatch{
+				items: []*queueItem{
+					{schemaChange: testLogEntry},
+				},
+				positions: []wal.CommitPosition{testCommitPos},
+			},
+			store: &mockStore{
+				applySchemaChangeFn: func(ctx context.Context, le *schemalog.LogEntry) error {
+					return errTest
+				},
+			},
+
+			wantErr: nil,
+		},
+		{
+			name: "error - applying schema delete",
+			batch: &msgBatch{
+				items: []*queueItem{
+					{
+						schemaChange: func() *schemalog.LogEntry {
+							le := newTestLogEntry(id, now)
+							le.Schema.Dropped = true
+							return le
+						}(),
+					},
+				},
+				positions: []wal.CommitPosition{testCommitPos},
+			},
+			store: &mockStore{},
+			cleaner: &mockCleaner{
+				deleteSchemaFn: func(ctx context.Context, s string) error {
+					return errTest
+				},
+			},
+
+			wantErr: nil,
+		},
+		{
+			name: "error - flushing writes before truncate",
+			batch: &msgBatch{
+				items: []*queueItem{
+					{write: testDocument1},
+					{truncate: &truncateItem{schemaName: testSchemaName, tableID: testTableName}},
+				},
+				positions: []wal.CommitPosition{testCommitPos},
+			},
+			store: &mockStore{
+				sendDocumentsFn: func(ctx context.Context, i uint, docs []Document) ([]DocumentError, error) {
+					return nil, errTest
+				},
+			},
+
+			wantErr: errTest,
+		},
+		{
+			name: "error - flushing writes before schema change",
+			batch: &msgBatch{
+				items: []*queueItem{
+					{write: testDocument1},
+					{schemaChange: testLogEntry},
+				},
+				positions: []wal.CommitPosition{testCommitPos},
+			},
+			store: &mockStore{
+				sendDocumentsFn: func(ctx context.Context, i uint, docs []Document) ([]DocumentError, error) {
+					return nil, errTest
+				},
+			},
+
+			wantErr: errTest,
+		},
+		{
+			name: "error - truncating table",
+			batch: &msgBatch{
+				items: []*queueItem{
+					{truncate: &truncateItem{schemaName: testSchemaName, tableID: testTableName}},
+				},
+				positions: []wal.CommitPosition{testCommitPos},
+			},
+			store: &mockStore{
+				deleteTableDocumentsFn: func(ctx context.Context, schemaName string, tableIDs []string) error {
+					return errTest
+				},
+			},
+
+			wantErr: errTest,
+		},
+		{
+			name: "error - sending documents",
+			batch: &msgBatch{
+				items: []*queueItem{
+					{write: testDocument1},
+					{write: testDocument2},
+				},
+				positions: []wal.CommitPosition{testCommitPos},
+			},
+			store: &mockStore{
+				sendDocumentsFn: func(ctx context.Context, _ uint, docs []Document) ([]DocumentError, error) {
+					return nil, errTest
+				},
+			},
+
+			wantErr: errTest,
+		},
+		{
+			name: "error - checkpointing",
+			batch: &msgBatch{
+				items: []*queueItem{
+					{write: testDocument1},
+					{write: testDocument2},
+				},
+				positions: []wal.CommitPosition{testCommitPos},
+			},
+			store: &mockStore{
+				sendDocumentsFn: func(ctx context.Context, _ uint, docs []Document) ([]DocumentError, error) {
+					return nil, nil
+				},
+			},
+			checkpoint: func(ctx context.Context, positions []wal.CommitPosition) error {
+				require.Equal(t, []wal.CommitPosition{testCommitPos}, positions)
+				return errTest
+			},
+
+			wantErr: errTest,
+		},
+		{
+			name: "error - empty queue item",
+			batch: &msgBatch{
+				items: []*queueItem{{}},
+			},
+
+			wantErr: errEmptyQueueItem,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			indexer := &BatchIndexer{
+				store:      tc.store,
+				skipSchema: func(schemaName string) bool { return false },
+			}
+			indexer.SetCheckpoint(tc.checkpoint)
+
+			if tc.skipSchema != nil {
+				indexer.skipSchema = tc.skipSchema
+			}
+
+			if tc.cleaner != nil {
+				indexer.cleaner = tc.cleaner
+			}
+
+			err := indexer.sendBatch(context.Background(), tc.batch)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}

--- a/pkg/wal/processor/search/search_msg_batch.go
+++ b/pkg/wal/processor/search/search_msg_batch.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package search
+
+import (
+	"github.com/xataio/pgstream/pkg/schemalog"
+	"github.com/xataio/pgstream/pkg/wal"
+)
+
+type msg struct {
+	item *queueItem
+	pos  wal.CommitPosition
+}
+
+type msgBatch struct {
+	items      []*queueItem
+	positions  []wal.CommitPosition
+	totalBytes int
+}
+
+type queueItem struct {
+	write        *Document
+	truncate     *truncateItem
+	schemaChange *schemalog.LogEntry
+	bytesSize    int
+}
+
+type truncateItem struct {
+	schemaName string
+	tableID    string
+}
+
+func newMsg(item *queueItem, pos wal.CommitPosition) *msg {
+	return &msg{
+		item: item,
+		pos:  pos,
+	}
+}
+
+func (m *msg) size() int {
+	return m.item.bytesSize
+}
+
+func (m *msg) isSchemaChange() bool {
+	return m.item != nil && m.item.schemaChange != nil
+}
+
+func (m *msgBatch) add(msg *msg) {
+	if msg == nil || msg.item == nil ||
+		(msg.item.write == nil && msg.item.schemaChange == nil && msg.item.truncate == nil) {
+		return
+	}
+
+	m.totalBytes += msg.size()
+	m.items = append(m.items, msg.item)
+	m.positions = append(m.positions, msg.pos)
+}
+
+func (m *msgBatch) drain() *msgBatch {
+	batch := &msgBatch{
+		items:      m.items,
+		positions:  m.positions,
+		totalBytes: m.totalBytes,
+	}
+	m.items = []*queueItem{}
+	m.positions = []wal.CommitPosition{}
+	m.totalBytes = 0
+	return batch
+}
+
+func (m *msgBatch) size() int {
+	return len(m.items)
+}

--- a/pkg/wal/processor/search/search_schema_cleaner.go
+++ b/pkg/wal/processor/search/search_schema_cleaner.go
@@ -13,15 +13,21 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+type cleaner interface {
+	deleteSchema(context.Context, string) error
+	start(context.Context)
+	stop()
+}
+
+type store interface {
+	DeleteSchema(ctx context.Context, schemaName string) error
+}
+
 type schemaCleaner struct {
 	deleteSchemaQueue   chan string
 	store               store
 	backoffProvider     backoff.Provider
 	registrationTimeout time.Duration
-}
-
-type store interface {
-	DeleteSchema(ctx context.Context, schemaName string) error
 }
 
 const (
@@ -31,7 +37,7 @@ const (
 
 var errRegistrationTimeout = errors.New("timeout registering schema for clean up")
 
-func newSchemaCleaner(cfg *backoff.Config, store store) *schemaCleaner { //nolint:unused
+func newSchemaCleaner(cfg *backoff.Config, store store) *schemaCleaner {
 	return &schemaCleaner{
 		deleteSchemaQueue:   make(chan string, maxDeleteQueueSize),
 		store:               store,

--- a/pkg/wal/processor/search/store.go
+++ b/pkg/wal/processor/search/store.go
@@ -37,18 +37,6 @@ type DocumentError struct {
 	Error    string
 }
 
-type queueItem struct {
-	write        *Document
-	truncate     *truncateItem
-	schemaChange *schemalog.LogEntry
-	bytesSize    int
-}
-
-type truncateItem struct {
-	schemaName string
-	tableID    string
-}
-
 type Severity uint
 
 const (

--- a/pkg/wal/processor/wal_processor.go
+++ b/pkg/wal/processor/wal_processor.go
@@ -4,6 +4,7 @@ package processor
 
 import (
 	"context"
+	"errors"
 
 	"github.com/xataio/pgstream/pkg/schemalog"
 	"github.com/xataio/pgstream/pkg/wal"
@@ -17,3 +18,5 @@ type Processor interface {
 func IsSchemaLogEvent(d *wal.Data) bool {
 	return d.Schema == schemalog.SchemaName && d.Table == schemalog.TableName
 }
+
+var ErrPanic = errors.New("panic while processing wal event")


### PR DESCRIPTION
This PR adds the search batch indexer. The batching uses the same logic as it's used for the kakfa batch writer to minimise the impact of the send operations while maximising the batch building time.

For now, a weighted semaphore is used to bound the memory usage of the internal queue. To do so, we have to marshal the event on input. If during benchmarks this proves to be a relevant performance hit, we can remove it in favour of allocating a constant number of queue items to remove the need for the marshaling step. The memory usage of the queue will be less efficient and optimised, but it's a trade-off we'll need to evaluate once we load test.