### PR TITLE
Add commit position to wal data

### DIFF
--- a/pkg/wal/listener/kafka/wal_kafka_reader_test.go
+++ b/pkg/wal/listener/kafka/wal_kafka_reader_test.go
@@ -22,14 +22,20 @@ func TestReader_Listen(t *testing.T) {
 	t.Parallel()
 
 	testMessage := &kafka.Message{
-		Key:   []byte("test-key"),
-		Value: []byte("test-value"),
+		Topic:     "test-topic",
+		Partition: 0,
+		Offset:    1,
+		Key:       []byte("test-key"),
+		Value:     []byte("test-value"),
 	}
 
 	testWalData := wal.Data{
 		Action: "I",
 		Schema: "test_schema",
 		Table:  "test_table",
+		CommitPosition: wal.CommitPosition{
+			KafkaPos: testMessage,
+		},
 	}
 
 	errTest := errors.New("oh noes")
@@ -61,7 +67,7 @@ func TestReader_Listen(t *testing.T) {
 					},
 				}
 			},
-			processRecord: func(ctx context.Context, d *wal.Data, cp wal.CommitPosition) error {
+			processRecord: func(ctx context.Context, d *wal.Data) error {
 				require.Equal(t, &testWalData, d)
 				return nil
 			},
@@ -79,7 +85,7 @@ func TestReader_Listen(t *testing.T) {
 					},
 				}
 			},
-			processRecord: func(ctx context.Context, d *wal.Data, cp wal.CommitPosition) error {
+			processRecord: func(ctx context.Context, d *wal.Data) error {
 				return fmt.Errorf("processRecord: should not be called")
 			},
 
@@ -96,7 +102,7 @@ func TestReader_Listen(t *testing.T) {
 					},
 				}
 			},
-			processRecord: func(ctx context.Context, d *wal.Data, cp wal.CommitPosition) error {
+			processRecord: func(ctx context.Context, d *wal.Data) error {
 				return errTest
 			},
 
@@ -113,7 +119,7 @@ func TestReader_Listen(t *testing.T) {
 					},
 				}
 			},
-			processRecord: func(ctx context.Context, d *wal.Data, cp wal.CommitPosition) error {
+			processRecord: func(ctx context.Context, d *wal.Data) error {
 				return context.Canceled
 			},
 
@@ -130,7 +136,7 @@ func TestReader_Listen(t *testing.T) {
 					},
 				}
 			},
-			processRecord: func(ctx context.Context, d *wal.Data, cp wal.CommitPosition) error {
+			processRecord: func(ctx context.Context, d *wal.Data) error {
 				return errors.New("processRecord: should not be called")
 			},
 			unmarshaler: func(b []byte, a any) error { return errTest },

--- a/pkg/wal/listener/postgres/wal_pg_listener.go
+++ b/pkg/wal/listener/postgres/wal_pg_listener.go
@@ -34,7 +34,7 @@ type Listener struct {
 }
 
 // listenerProcessWalEvent is the function type callback to process WAL events.
-type listenerProcessWalEvent func(context.Context, *wal.Data, wal.CommitPosition) error
+type listenerProcessWalEvent func(context.Context, *wal.Data) error
 
 type Config struct {
 	Conn            pgx.ConnConfig
@@ -173,8 +173,9 @@ func (l *Listener) processWALEvent(ctx context.Context, msgData *replication.Mes
 	if err := l.walDataDeserialiser(msgData.Data, &event); err != nil {
 		return fmt.Errorf("error unmarshaling wal data: %w", err)
 	}
+	event.CommitPosition = wal.CommitPosition{PGPos: msgData.LSN}
 
-	if err := l.processEvent(ctx, event, wal.CommitPosition{PGPos: msgData.LSN}); err != nil {
+	if err := l.processEvent(ctx, event); err != nil {
 		return err
 	}
 

--- a/pkg/wal/listener/postgres/wal_pg_listener_test.go
+++ b/pkg/wal/listener/postgres/wal_pg_listener_test.go
@@ -37,7 +37,7 @@ func TestListener_Listen(t *testing.T) {
 	}
 
 	errTest := errors.New("oh noes")
-	okProcessEvent := func(context.Context, *wal.Data, wal.CommitPosition) error { return nil }
+	okProcessEvent := func(context.Context, *wal.Data) error { return nil }
 
 	tests := []struct {
 		name               string
@@ -256,7 +256,7 @@ func TestListener_Listen(t *testing.T) {
 				}
 				return h
 			},
-			processEventFn: func(context.Context, *wal.Data, wal.CommitPosition) error { return errTest },
+			processEventFn: func(context.Context, *wal.Data) error { return errTest },
 
 			wantSyncCalls: 0,
 			wantErr:       errTest,
@@ -275,7 +275,7 @@ func TestListener_Listen(t *testing.T) {
 				}
 				return h
 			},
-			processEventFn: func(context.Context, *wal.Data, wal.CommitPosition) error { return context.Canceled },
+			processEventFn: func(context.Context, *wal.Data) error { return context.Canceled },
 
 			wantSyncCalls: 1,
 			wantErr:       nil,

--- a/pkg/wal/processor/mocks/mock_processor.go
+++ b/pkg/wal/processor/mocks/mock_processor.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Processor struct {
-	ProcessWALEventFn func(ctx context.Context, walEvent *wal.Data, pos wal.CommitPosition) error
+	ProcessWALEventFn func(ctx context.Context, walEvent *wal.Data) error
 }
 
-func (m *Processor) ProcessWALEvent(ctx context.Context, walEvent *wal.Data, pos wal.CommitPosition) error {
-	return m.ProcessWALEventFn(ctx, walEvent, pos)
+func (m *Processor) ProcessWALEvent(ctx context.Context, walEvent *wal.Data) error {
+	return m.ProcessWALEventFn(ctx, walEvent)
 }

--- a/pkg/wal/processor/search/errors.go
+++ b/pkg/wal/processor/search/errors.go
@@ -52,5 +52,5 @@ var (
 	errNilIDValue      = errors.New("id has nil value")
 	errNilVersionValue = errors.New("version has nil value")
 	errMetadataMissing = errors.New("missing wal event metadata")
-	errEmptyQueueItem  = errors.New("invalid empty queue item")
+	errEmptyQueueMsg   = errors.New("invalid empty queue message")
 )

--- a/pkg/wal/processor/search/helper_test.go
+++ b/pkg/wal/processor/search/helper_test.go
@@ -15,11 +15,11 @@ import (
 )
 
 type mockAdapter struct {
-	walDataToQueueItemFn func(*wal.Data) (*queueItem, error)
+	walDataToMsgFn func(*wal.Data) (*msg, error)
 }
 
-func (m *mockAdapter) walDataToQueueItem(d *wal.Data) (*queueItem, error) {
-	return m.walDataToQueueItemFn(d)
+func (m *mockAdapter) walDataToMsg(d *wal.Data) (*msg, error) {
+	return m.walDataToMsgFn(d)
 }
 
 type mockStore struct {

--- a/pkg/wal/processor/search/search_adapter.go
+++ b/pkg/wal/processor/search/search_adapter.go
@@ -14,7 +14,7 @@ import (
 )
 
 type walAdapter interface {
-	walDataToQueueItem(*wal.Data) (*queueItem, error)
+	walDataToMsg(*wal.Data) (*msg, error)
 }
 
 type adapter struct {
@@ -33,7 +33,7 @@ func newAdapter(m Mapper) *adapter {
 	}
 }
 
-func (a *adapter) walDataToQueueItem(d *wal.Data) (*queueItem, error) {
+func (a *adapter) walDataToMsg(d *wal.Data) (*msg, error) {
 	if processor.IsSchemaLogEvent(d) {
 		// we only care about inserts - updates can happen when the schema log
 		// is acked
@@ -46,7 +46,7 @@ func (a *adapter) walDataToQueueItem(d *wal.Data) (*queueItem, error) {
 			return nil, err
 		}
 
-		return &queueItem{
+		return &msg{
 			schemaChange: logEntry,
 			bytesSize:    size,
 		}, nil
@@ -67,7 +67,7 @@ func (a *adapter) walDataToQueueItem(d *wal.Data) (*queueItem, error) {
 			return nil, fmt.Errorf("calculating document size: %w", err)
 		}
 
-		return &queueItem{
+		return &msg{
 			write:     doc,
 			bytesSize: size,
 		}, nil
@@ -77,7 +77,7 @@ func (a *adapter) walDataToQueueItem(d *wal.Data) (*queueItem, error) {
 			schemaName: d.Schema,
 			tableID:    d.Metadata.TablePgstreamID,
 		}
-		return &queueItem{
+		return &msg{
 			truncate:  truncateItem,
 			bytesSize: len(truncateItem.schemaName) + len(truncateItem.tableID),
 		}, nil

--- a/pkg/wal/processor/translator/wal_translator.go
+++ b/pkg/wal/processor/translator/wal_translator.go
@@ -62,7 +62,7 @@ func New(cfg *Config, p processor.Processor, skipSchema schemaFilter, idFinder, 
 	}, nil
 }
 
-func (t *Translator) ProcessWALEvent(ctx context.Context, data *wal.Data, pos wal.CommitPosition) error {
+func (t *Translator) ProcessWALEvent(ctx context.Context, data *wal.Data) error {
 	if t.skipSchema(data.Schema) {
 		return nil
 	}
@@ -110,7 +110,7 @@ func (t *Translator) ProcessWALEvent(ctx context.Context, data *wal.Data, pos wa
 		}
 	}
 
-	return t.processor.ProcessWALEvent(ctx, data, pos)
+	return t.processor.ProcessWALEvent(ctx, data)
 }
 
 func (t *Translator) Close() error {

--- a/pkg/wal/processor/translator/wal_translator_test.go
+++ b/pkg/wal/processor/translator/wal_translator_test.go
@@ -71,7 +71,7 @@ func TestTranslator_ProcessWALEvent(t *testing.T) {
 				},
 			},
 			processor: &mocks.Processor{
-				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Data, pos wal.CommitPosition) error {
+				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Data) error {
 					require.Equal(t, newTestSchemaChangeEvent("I"), walEvent)
 					return nil
 				},
@@ -88,7 +88,7 @@ func TestTranslator_ProcessWALEvent(t *testing.T) {
 				},
 			},
 			processor: &mocks.Processor{
-				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Data, pos wal.CommitPosition) error {
+				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Data) error {
 					require.Equal(t, newTestSchemaChangeEvent("I"), walEvent)
 					return nil
 				},
@@ -106,7 +106,7 @@ func TestTranslator_ProcessWALEvent(t *testing.T) {
 				},
 			},
 			processor: &mocks.Processor{
-				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Data, pos wal.CommitPosition) error {
+				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Data) error {
 					require.Equal(t, newTestDataEventWithMetadata("I"), walEvent)
 					return nil
 				},
@@ -123,7 +123,7 @@ func TestTranslator_ProcessWALEvent(t *testing.T) {
 				},
 			},
 			processor: &mocks.Processor{
-				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Data, pos wal.CommitPosition) error {
+				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Data) error {
 					require.Equal(t, newTestDataEvent("I"), walEvent)
 					return nil
 				},
@@ -140,7 +140,7 @@ func TestTranslator_ProcessWALEvent(t *testing.T) {
 				},
 			},
 			processor: &mocks.Processor{
-				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Data, pos wal.CommitPosition) error {
+				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Data) error {
 					wantData := newTestDataEvent("I")
 					wantData.Metadata = wal.Metadata{
 						SchemaID:        testSchemaID,
@@ -170,7 +170,7 @@ func TestTranslator_ProcessWALEvent(t *testing.T) {
 				},
 			},
 			processor: &mocks.Processor{
-				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Data, pos wal.CommitPosition) error {
+				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Data) error {
 					return errTest
 				},
 			},
@@ -205,7 +205,7 @@ func TestTranslator_ProcessWALEvent(t *testing.T) {
 				translator.skipSchema = tc.skipSchema
 			}
 
-			err := translator.ProcessWALEvent(context.Background(), tc.data, wal.CommitPosition{})
+			err := translator.ProcessWALEvent(context.Background(), tc.data)
 			require.ErrorIs(t, err, tc.wantErr)
 		})
 	}

--- a/pkg/wal/processor/wal_processor.go
+++ b/pkg/wal/processor/wal_processor.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Processor interface {
-	ProcessWALEvent(ctx context.Context, walEvent *wal.Data, commitPos wal.CommitPosition) error
+	ProcessWALEvent(ctx context.Context, walEvent *wal.Data) error
 }
 
 var (

--- a/pkg/wal/wal_data.go
+++ b/pkg/wal/wal_data.go
@@ -9,14 +9,15 @@ import (
 )
 
 type Data struct {
-	Action    string   `json:"action"`    // "I" -- insert, "U" -- update, "D" -- delete, "T" -- truncate
-	Timestamp string   `json:"timestamp"` // ISO8601, i.e. 2019-12-29 04:58:34.806671
-	LSN       string   `json:"lsn"`
-	Schema    string   `json:"schema"`
-	Table     string   `json:"table"`
-	Columns   []Column `json:"columns"`
-	Identity  []Column `json:"identity"`
-	Metadata  Metadata `json:"metadata"` // pgstream specific metadata
+	Action         string         `json:"action"`    // "I" -- insert, "U" -- update, "D" -- delete, "T" -- truncate
+	Timestamp      string         `json:"timestamp"` // ISO8601, i.e. 2019-12-29 04:58:34.806671
+	LSN            string         `json:"lsn"`
+	Schema         string         `json:"schema"`
+	Table          string         `json:"table"`
+	Columns        []Column       `json:"columns"`
+	Identity       []Column       `json:"identity"`
+	Metadata       Metadata       `json:"metadata"` // pgstream specific metadata
+	CommitPosition CommitPosition `json:"-"`
 }
 
 type Metadata struct {


### PR DESCRIPTION
This PR moves the commit position to the wal data type, instead of passing them separately. In the future, the commit position needs to be optimised, as we currently already have the LSN in the `wal.Data`, and we would need a way of keeping track of the kafka offset as well. 

The `queueItem` type is removed/replaced by the `msg` type since it no longer serves a purpose.