### PR TITLE
Add support for composite primary keys

### DIFF
--- a/pkg/wal/processor/search/helper_test.go
+++ b/pkg/wal/processor/search/helper_test.go
@@ -108,7 +108,7 @@ func newTestDataEvent(action string) *wal.Event {
 		Table:  testTableName,
 		Metadata: wal.Metadata{
 			TablePgstreamID:    testTableID,
-			InternalColID:      "col-1",
+			InternalColIDs:     []string{"col-1"},
 			InternalColVersion: "col-2",
 		},
 	}

--- a/pkg/wal/processor/translator/helper_test.go
+++ b/pkg/wal/processor/translator/helper_test.go
@@ -94,7 +94,7 @@ func newTestDataEventWithMetadata(action string) *wal.Event {
 	d.Data.Metadata = wal.Metadata{
 		SchemaID:           testSchemaID,
 		TablePgstreamID:    testTableID,
-		InternalColID:      fmt.Sprintf("%s_col-1", testTableID),
+		InternalColIDs:     []string{fmt.Sprintf("%s_col-1", testTableID)},
 		InternalColVersion: fmt.Sprintf("%s_col-2", testTableID),
 	}
 	return d

--- a/pkg/wal/processor/translator/wal_translator_test.go
+++ b/pkg/wal/processor/translator/wal_translator_test.go
@@ -365,7 +365,7 @@ func TestTranslator_translate(t *testing.T) {
 				d.Metadata = wal.Metadata{
 					SchemaID:        testSchemaID,
 					TablePgstreamID: testTableID,
-					InternalColID:   fmt.Sprintf("%s_col-1", testTableID),
+					InternalColIDs:  []string{fmt.Sprintf("%s_col-1", testTableID)},
 				}
 				return d
 			}(),
@@ -479,10 +479,10 @@ func Test_primaryKeyFinder(t *testing.T) {
 				PrimaryKeyColumns: []string{"col-1", "col-2"},
 			},
 
-			wantFound: false,
+			wantFound: true,
 		},
 		{
-			name: "composite primary key and unique not null column",
+			name: "unique not null column with composite primary key",
 			col: &schemalog.Column{
 				Name: "col-3",
 			},
@@ -493,7 +493,7 @@ func Test_primaryKeyFinder(t *testing.T) {
 				PrimaryKeyColumns: []string{"col-1", "col-2"},
 			},
 
-			wantFound: true,
+			wantFound: false,
 		},
 	}
 


### PR DESCRIPTION
This PR updates the translator to support multiple internal identity columns (composite primary key), and the search adapter to combine the values of the multiple identities to form the document id. If multiple identities are used, the search indexer will add the individual fields to the document, to enable search by field, since the document ID will be a combination of them.