### PR TITLE
Update backoff library

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -106,9 +106,11 @@ func parseKafkaCheckpointConfig(readerCfg *kafkalistener.ReaderConfig) kafkachec
 	return kafkacheckpoint.Config{
 		Reader: readerCfg.Kafka,
 		CommitBackoff: backoff.Config{
-			InitialInterval: viper.GetDuration("PGSTREAM_KAFKA_COMMIT_BACKOFF_INITIAL_INTERVAL"),
-			MaxInterval:     viper.GetDuration("PGSTREAM_KAFKA_COMMIT_BACKOFF_MAX_INTERVAL"),
-			MaxRetries:      viper.GetUint("PGSTREAM_KAFKA_COMMIT_BACKOFF_MAX_RETRIES"),
+			Exponential: &backoff.ExponentialConfig{
+				InitialInterval: viper.GetDuration("PGSTREAM_KAFKA_COMMIT_BACKOFF_INITIAL_INTERVAL"),
+				MaxInterval:     viper.GetDuration("PGSTREAM_KAFKA_COMMIT_BACKOFF_MAX_INTERVAL"),
+				MaxRetries:      viper.GetUint("PGSTREAM_KAFKA_COMMIT_BACKOFF_MAX_RETRIES"),
+			},
 		},
 	}
 }
@@ -168,9 +170,11 @@ func parseSearchProcessorConfig() *stream.SearchProcessorConfig {
 			BatchSize: viper.GetInt("PGSTREAM_SEARCH_INDEXER_BATCH_SIZE"),
 			BatchTime: viper.GetDuration("PGSTREAM_SEARCH_INDEXER_BATCH_TIMEOUT"),
 			CleanupBackoff: backoff.Config{
-				InitialInterval: viper.GetDuration("PGSTREAM_SEARCH_INDEXER_CLEANUP_BACKOFF_INITIAL_INTERVAL"),
-				MaxInterval:     viper.GetDuration("PGSTREAM_SEARCH_INDEXER_CLEANUP_BACKOFF_MAX_INTERVAL"),
-				MaxRetries:      viper.GetUint("PGSTREAM_SEARCH_INDEXER_CLEANUP_BACKOFF_MAX_RETRIES"),
+				Exponential: &backoff.ExponentialConfig{
+					InitialInterval: viper.GetDuration("PGSTREAM_SEARCH_INDEXER_CLEANUP_BACKOFF_INITIAL_INTERVAL"),
+					MaxInterval:     viper.GetDuration("PGSTREAM_SEARCH_INDEXER_CLEANUP_BACKOFF_MAX_INTERVAL"),
+					MaxRetries:      viper.GetUint("PGSTREAM_SEARCH_INDEXER_CLEANUP_BACKOFF_MAX_RETRIES"),
+				},
 			},
 		},
 		Store: opensearch.Config{
@@ -178,9 +182,11 @@ func parseSearchProcessorConfig() *stream.SearchProcessorConfig {
 		},
 		Retrier: &search.StoreRetryConfig{
 			Backoff: backoff.Config{
-				InitialInterval: viper.GetDuration("PGSTREAM_SEARCH_STORE_BACKOFF_INITIAL_INTERVAL"),
-				MaxInterval:     viper.GetDuration("PGSTREAM_SEARCH_STORE_BACKOFF_MAX_INTERVAL"),
-				MaxRetries:      viper.GetUint("PGSTREAM_SEARCH_STORE_BACKOFF_MAX_RETRIES"),
+				Exponential: &backoff.ExponentialConfig{
+					InitialInterval: viper.GetDuration("PGSTREAM_SEARCH_STORE_BACKOFF_INITIAL_INTERVAL"),
+					MaxInterval:     viper.GetDuration("PGSTREAM_SEARCH_STORE_BACKOFF_MAX_INTERVAL"),
+					MaxRetries:      viper.GetUint("PGSTREAM_SEARCH_STORE_BACKOFF_MAX_RETRIES"),
+				},
 			},
 		},
 	}

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -12,6 +12,7 @@ import (
 
 type Backoff interface {
 	RetryNotify(Operation, Notify) error
+	Retry(Operation) error
 }
 
 type (
@@ -20,9 +21,19 @@ type (
 )
 
 type Config struct {
+	Exponential *ExponentialConfig
+	Constant    *ConstantConfig
+}
+
+type ExponentialConfig struct {
 	InitialInterval time.Duration
 	MaxInterval     time.Duration
 	MaxRetries      uint
+}
+
+type ConstantConfig struct {
+	Interval   time.Duration
+	MaxRetries uint
 }
 
 // ExponentialBackoff is a wrapper around the cenkalti exponential backoff
@@ -34,7 +45,26 @@ var ErrPermanent = errors.New("permanent error, do not retry")
 
 type Provider func(ctx context.Context) Backoff
 
-func NewExponentialBackoff(ctx context.Context, cfg *Config) *ExponentialBackoff {
+// NewProvider returns a backoff provider based on the config on input. If no
+// valid input is provided, a no retry backoff provider is returned instead.
+func NewProvider(cfg *Config) Provider {
+	switch {
+	case cfg.Constant != nil:
+		return func(ctx context.Context) Backoff {
+			return NewConstantBackoff(ctx, cfg.Constant)
+		}
+	case cfg.Exponential != nil:
+		return func(ctx context.Context) Backoff {
+			return NewExponentialBackoff(ctx, cfg.Exponential)
+		}
+	default:
+		return func(ctx context.Context) Backoff {
+			return NewStopBackoff()
+		}
+	}
+}
+
+func NewExponentialBackoff(ctx context.Context, cfg *ExponentialConfig) *ExponentialBackoff {
 	exp := backoff.NewExponentialBackOff()
 	exp.InitialInterval = cfg.InitialInterval
 	exp.MaxElapsedTime = cfg.MaxInterval
@@ -50,7 +80,58 @@ func NewExponentialBackoff(ctx context.Context, cfg *Config) *ExponentialBackoff
 	}
 }
 
+func (ebo *ExponentialBackoff) Retry(op Operation) error {
+	return retryNotify(ebo, op, nil)
+}
+
 func (ebo *ExponentialBackoff) RetryNotify(op Operation, notify Notify) error {
+	return retryNotify(ebo, op, notify)
+}
+
+type ConstantBackoff struct {
+	backoff.BackOff
+}
+
+func NewConstantBackoff(ctx context.Context, cfg *ConstantConfig) *ConstantBackoff {
+	exp := backoff.NewConstantBackOff(cfg.Interval)
+	var bo backoff.BackOff = exp
+	if cfg.MaxRetries > 0 {
+		bo = backoff.WithMaxRetries(bo, uint64(cfg.MaxRetries))
+	}
+	bo = backoff.WithContext(bo, ctx)
+
+	return &ConstantBackoff{
+		BackOff: bo,
+	}
+}
+
+func (cbo *ConstantBackoff) Retry(op Operation) error {
+	return retryNotify(cbo, op, nil)
+}
+
+func (cbo *ConstantBackoff) RetryNotify(op Operation, notify Notify) error {
+	return retryNotify(cbo, op, notify)
+}
+
+type StopBackoff struct {
+	backoff.BackOff
+}
+
+func NewStopBackoff() *StopBackoff {
+	return &StopBackoff{
+		BackOff: &backoff.StopBackOff{},
+	}
+}
+
+func (sbo *StopBackoff) Retry(op Operation) error {
+	return retryNotify(sbo, op, nil)
+}
+
+func (sbo *StopBackoff) RetryNotify(op Operation, notify Notify) error {
+	return retryNotify(sbo, op, notify)
+}
+
+func retryNotify(b backoff.BackOff, op Operation, notify Notify) error {
 	boOp := func() error {
 		err := op()
 		if errors.Is(err, ErrPermanent) {
@@ -58,5 +139,5 @@ func (ebo *ExponentialBackoff) RetryNotify(op Operation, notify Notify) error {
 		}
 		return err
 	}
-	return backoff.RetryNotify(boOp, ebo, backoff.Notify(notify))
+	return backoff.RetryNotify(boOp, b, backoff.Notify(notify))
 }

--- a/internal/backoff/mocks/mock_backoff.go
+++ b/internal/backoff/mocks/mock_backoff.go
@@ -6,8 +6,13 @@ import "github.com/xataio/pgstream/internal/backoff"
 
 type Backoff struct {
 	RetryNotifyFn func(backoff.Operation, backoff.Notify) error
+	RetryFn       func(backoff.Operation) error
 }
 
 func (m *Backoff) RetryNotify(op backoff.Operation, not backoff.Notify) error {
 	return m.RetryNotifyFn(op, not)
+}
+
+func (m *Backoff) Retry(op backoff.Operation) error {
+	return m.RetryFn(op)
 }

--- a/pkg/wal/checkpointer/kafka/wal_kafka_checkpointer.go
+++ b/pkg/wal/checkpointer/kafka/wal_kafka_checkpointer.go
@@ -33,10 +33,8 @@ type Option func(c *Checkpointer)
 
 func New(ctx context.Context, cfg Config, opts ...Option) (*Checkpointer, error) {
 	c := &Checkpointer{
-		logger: loglib.NewNoopLogger(),
-		backoffProvider: func(ctx context.Context) backoff.Backoff {
-			return backoff.NewExponentialBackoff(ctx, &cfg.CommitBackoff)
-		},
+		logger:          loglib.NewNoopLogger(),
+		backoffProvider: backoff.NewProvider(&cfg.CommitBackoff),
 	}
 
 	for _, opt := range opts {

--- a/pkg/wal/processor/search/search_schema_cleaner.go
+++ b/pkg/wal/processor/search/search_schema_cleaner.go
@@ -43,9 +43,7 @@ func newSchemaCleaner(cfg *backoff.Config, store store, logger loglib.Logger) *s
 		deleteSchemaQueue:   make(chan string, maxDeleteQueueSize),
 		store:               store,
 		registrationTimeout: defaultRegistrationTimeout,
-		backoffProvider: func(ctx context.Context) backoff.Backoff {
-			return backoff.NewExponentialBackoff(ctx, cfg)
-		},
+		backoffProvider:     backoff.NewProvider(cfg),
 	}
 }
 

--- a/pkg/wal/processor/search/search_store_retrier.go
+++ b/pkg/wal/processor/search/search_store_retrier.go
@@ -30,11 +30,9 @@ var errPartialDocumentSend = errors.New("failed to send some or all documents")
 
 func NewStoreRetrier(s Store, cfg *StoreRetryConfig, opts ...StoreOption) *StoreRetrier {
 	sr := &StoreRetrier{
-		inner:  s,
-		logger: loglib.NewNoopLogger(),
-		backoffProvider: func(ctx context.Context) backoff.Backoff {
-			return backoff.NewExponentialBackoff(ctx, &cfg.Backoff)
-		},
+		inner:           s,
+		logger:          loglib.NewNoopLogger(),
+		backoffProvider: backoff.NewProvider(&cfg.Backoff),
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
This PR improves the backoff library to add constant and no retry backoff policies. The backoff provider constructor available takes care of initialising the relevant backoff strategy based on the configuration provided, and has a default provider with no retries if the retry policy is not configured. 