### PR TITLE
Update lib hooks

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -169,7 +169,7 @@ func parseSearchProcessorConfig() *stream.SearchProcessorConfig {
 		Store: opensearch.Config{
 			URL: searchStore,
 		},
-		Retrier: &search.StoreRetryConfig{
+		Retrier: search.StoreRetryConfig{
 			Backoff: parseBackoffConfig("PGSTREAM_SEARCH_STORE"),
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pglogrepl v0.0.0-20240307033717-828fbfe908e9
-	github.com/jackc/pgx/v5 v5.5.5
+	github.com/jackc/pgx/v5 v5.6.0
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pterm/pterm v0.12.79

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.5.5 h1:amBjrZVmksIdNjxGW/IiIMzxMKZFelXbUoPNb+8sjQw=
-github.com/jackc/pgx/v5 v5.5.5/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
+github.com/jackc/pgx/v5 v5.6.0 h1:SWJzexBzPL5jb0GEsrPMLIsi/3jOo7RHlzTjcAeDrPY=
+github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
 github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=

--- a/pkg/schemalog/log_entry.go
+++ b/pkg/schemalog/log_entry.go
@@ -64,8 +64,6 @@ func (m *LogEntry) UnmarshalJSON(b []byte) error {
 			if err := json.Unmarshal([]byte(schemaStr), &m.Schema); err != nil {
 				return err
 			}
-		default:
-			panic(fmt.Sprintf("unmarshal LogEntry, got unexpected key when unmarshalling: %s", k))
 		}
 	}
 

--- a/pkg/stream/config.go
+++ b/pkg/stream/config.go
@@ -50,7 +50,7 @@ type KafkaProcessorConfig struct {
 type SearchProcessorConfig struct {
 	Indexer search.IndexerConfig
 	Store   opensearch.Config
-	Retrier *search.StoreRetryConfig
+	Retrier search.StoreRetryConfig
 }
 
 type WebhookProcessorConfig struct {

--- a/pkg/stream/stream_run.go
+++ b/pkg/stream/stream_run.go
@@ -112,10 +112,7 @@ func Run(ctx context.Context, logger loglib.Logger, config *Config, meter metric
 		if err != nil {
 			return err
 		}
-		if config.Processor.Search.Retrier != nil {
-			logger.Debug("using retry logic with search store...")
-			searchStore = search.NewStoreRetrier(searchStore, config.Processor.Search.Retrier, search.WithStoreLogger(logger))
-		}
+		searchStore = search.NewStoreRetrier(searchStore, config.Processor.Search.Retrier, search.WithStoreLogger(logger))
 
 		searchIndexer := search.NewBatchIndexer(ctx,
 			config.Processor.Search.Indexer,

--- a/pkg/wal/processor/search/opensearch/opensearch_index_name.go
+++ b/pkg/wal/processor/search/opensearch/opensearch_index_name.go
@@ -4,7 +4,13 @@ package opensearch
 
 import (
 	"fmt"
+	"strings"
 )
+
+type IndexNameAdapter interface {
+	SchemaNameToIndex(schemaName string) IndexName
+	IndexToSchemaName(index string) string
+}
 
 // IndexName represents an opensearch index name constructed from a schema name.
 type IndexName interface {
@@ -14,33 +20,47 @@ type IndexName interface {
 	SchemaName() string
 }
 
-type indexName struct {
+type defaultIndexNameAdapter struct{}
+
+func newDefaultIndexNameAdapter() IndexNameAdapter {
+	return &defaultIndexNameAdapter{}
+}
+
+func (i *defaultIndexNameAdapter) SchemaNameToIndex(schemaName string) IndexName {
+	return newDefaultIndexName(schemaName)
+}
+
+func (i *defaultIndexNameAdapter) IndexToSchemaName(index string) string {
+	return strings.TrimSuffix(index, "-1")
+}
+
+type defaultIndexName struct {
 	schemaName string
 	version    int
 }
 
 func newDefaultIndexName(schemaName string) IndexName {
-	return &indexName{
+	return &defaultIndexName{
 		schemaName: schemaName,
 		version:    1,
 	}
 }
 
-func (i indexName) SchemaName() string {
+func (i defaultIndexName) SchemaName() string {
 	return i.schemaName
 }
 
 // NameWithVersion represents the name of the index with the version number. This should
 // generally not be needed, in favour of `Name`.
-func (i indexName) NameWithVersion() string {
+func (i defaultIndexName) NameWithVersion() string {
 	return fmt.Sprintf("%s-%d", i.schemaName, i.version)
 }
 
 // Name returns the name we should use for querying the index.
-func (i *indexName) Name() string {
+func (i *defaultIndexName) Name() string {
 	return i.schemaName
 }
 
-func (i *indexName) Version() int {
+func (i *defaultIndexName) Version() int {
 	return i.version
 }

--- a/pkg/wal/processor/search/opensearch/opensearch_store_test.go
+++ b/pkg/wal/processor/search/opensearch/opensearch_store_test.go
@@ -506,7 +506,7 @@ func TestStore_getLastSchemaLogEntry(t *testing.T) {
 	tests := []struct {
 		name      string
 		client    es.SearchClient
-		adapter   Adapter
+		adapter   SearchAdapter
 		marshaler func(any) ([]byte, error)
 
 		wantLogEntry *schemalog.LogEntry

--- a/pkg/wal/processor/search/search_store_retrier.go
+++ b/pkg/wal/processor/search/search_store_retrier.go
@@ -37,7 +37,7 @@ const (
 
 var errPartialDocumentSend = errors.New("failed to send some or all documents")
 
-func NewStoreRetrier(s Store, cfg *StoreRetryConfig, opts ...StoreOption) *StoreRetrier {
+func NewStoreRetrier(s Store, cfg StoreRetryConfig, opts ...StoreOption) *StoreRetrier {
 	sr := &StoreRetrier{
 		inner:           s,
 		logger:          loglib.NewNoopLogger(),


### PR DESCRIPTION
This PR updates the hooks that allow to customise the use for the pgstream library:
- Add support to use a custom search index name adapter and a mapper
- Add granularity to filter wal data and schema events separately

Small improvements included:
- Update of pgx dependency 
- Removal of panic during log entry unmarshaling
- Apply search store retry logic by default (if no config is provided, there's a default that applies). If no retries are required, then the config must be explicitly updated accordingly.

The commits have been split for ease of reviewing.
