### PR TITLE
Use the same kafka reader for fetching and committing messages

### DIFF
--- a/pkg/stream/config.go
+++ b/pkg/stream/config.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/xataio/pgstream/pkg/kafka"
 	kafkacheckpoint "github.com/xataio/pgstream/pkg/wal/checkpointer/kafka"
-	kafkalistener "github.com/xataio/pgstream/pkg/wal/listener/kafka"
 	kafkaprocessor "github.com/xataio/pgstream/pkg/wal/processor/kafka"
 	"github.com/xataio/pgstream/pkg/wal/processor/search"
 	"github.com/xataio/pgstream/pkg/wal/processor/search/opensearch"
@@ -32,7 +32,7 @@ type PostgresListenerConfig struct {
 }
 
 type KafkaListenerConfig struct {
-	Reader       kafkalistener.ReaderConfig
+	Reader       kafka.ReaderConfig
 	Checkpointer kafkacheckpoint.Config
 }
 

--- a/pkg/stream/integration/helper_test.go
+++ b/pkg/stream/integration/helper_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/xataio/pgstream/pkg/tls"
 	"github.com/xataio/pgstream/pkg/wal"
 	kafkacheckpoint "github.com/xataio/pgstream/pkg/wal/checkpointer/kafka"
-	kafkalistener "github.com/xataio/pgstream/pkg/wal/listener/kafka"
 	kafkaprocessor "github.com/xataio/pgstream/pkg/wal/processor/kafka"
 	"github.com/xataio/pgstream/pkg/wal/processor/search/opensearch"
 	"github.com/xataio/pgstream/pkg/wal/processor/translator"
@@ -105,18 +104,13 @@ func testPostgresListenerCfg() stream.ListenerConfig {
 }
 
 func testKafkaListenerCfg() stream.ListenerConfig {
-	readerCfg := kafkalistener.ReaderConfig{
-		Kafka: kafkalib.ReaderConfig{
-			Conn:            testKafkaCfg(),
-			ConsumerGroupID: "integration-test-group",
-		},
-	}
 	return stream.ListenerConfig{
 		Kafka: &stream.KafkaListenerConfig{
-			Reader: readerCfg,
-			Checkpointer: kafkacheckpoint.Config{
-				Reader: readerCfg.Kafka,
+			Reader: kafkalib.ReaderConfig{
+				Conn:            testKafkaCfg(),
+				ConsumerGroupID: "integration-test-group",
 			},
+			Checkpointer: kafkacheckpoint.Config{},
 		},
 	}
 }


### PR DESCRIPTION
This PR updates the kafka checkpointer and listener to use the same kafka reader. This will ensure the messages are fetched and committed by the same reader, which has shown to cause sporadic connection issues at startup when the reader connects to kafka, failing to receive any messages.