### PR TITLE
Improve instrumentation

### DIFF
--- a/pkg/kafka/instrumentation/instrumented_kafka_reader.go
+++ b/pkg/kafka/instrumentation/instrumented_kafka_reader.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package instrumentation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/xataio/pgstream/pkg/kafka"
+	"github.com/xataio/pgstream/pkg/otel"
+
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type Reader struct {
+	inner   kafka.MessageReader
+	meter   metric.Meter
+	tracer  trace.Tracer
+	metrics *readerMetrics
+}
+
+type readerMetrics struct {
+	msgBytes        metric.Int64Histogram
+	fetchLatency    metric.Int64Histogram
+	commitLatency   metric.Int64Histogram
+	commitBatchSize metric.Int64Histogram
+}
+
+func NewReader(inner kafka.MessageReader, instrumentation *otel.Instrumentation) (kafka.MessageReader, error) {
+	if instrumentation == nil {
+		return inner, nil
+	}
+
+	i := &Reader{
+		inner:   inner,
+		meter:   instrumentation.Meter,
+		tracer:  instrumentation.Tracer,
+		metrics: &readerMetrics{},
+	}
+
+	if err := i.initMetrics(); err != nil {
+		return nil, fmt.Errorf("error initialising kafka reader metrics: %w", err)
+	}
+
+	return i, nil
+}
+
+func (i *Reader) initMetrics() error {
+	if i.meter == nil {
+		return nil
+	}
+
+	var err error
+	i.metrics.msgBytes, err = i.meter.Int64Histogram("pgstream.kafka.reader.msg.bytes",
+		metric.WithUnit("bytes"),
+		metric.WithDescription("Distribution of message bytes read by the kafka reader"))
+	if err != nil {
+		return err
+	}
+
+	i.metrics.fetchLatency, err = i.meter.Int64Histogram("pgstream.kafka.reader.fetch.latency",
+		metric.WithUnit("ms"),
+		metric.WithDescription("Distribution of time taken by the reader to fetch messages from kafka"))
+	if err != nil {
+		return err
+	}
+
+	i.metrics.commitLatency, err = i.meter.Int64Histogram("pgstream.kafka.reader.commit.latency",
+		metric.WithUnit("ms"),
+		metric.WithDescription("Distribution of time taken by the reader to commit messages to kafka"))
+	if err != nil {
+		return err
+	}
+
+	i.metrics.commitBatchSize, err = i.meter.Int64Histogram("pgstream.kafka.reader.commit.batch.size",
+		metric.WithUnit("offsets"),
+		metric.WithDescription("Distribution of the offset batch size committed by the kafka reader"))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *Reader) FetchMessage(ctx context.Context) (msg *kafka.Message, err error) {
+	ctx, span := otel.StartSpan(ctx, i.tracer, "kafka.FetchMessages")
+	defer otel.CloseSpan(span, err)
+
+	if i.meter != nil {
+		startTime := time.Now()
+		defer func() {
+			i.metrics.fetchLatency.Record(ctx, time.Since(startTime).Milliseconds())
+		}()
+
+	}
+
+	msg, err = i.inner.FetchMessage(ctx)
+	if msg != nil && i.meter != nil {
+		i.metrics.msgBytes.Record(ctx, int64(len(msg.Value)))
+	}
+
+	return msg, err
+}
+
+func (i *Reader) CommitOffsets(ctx context.Context, offsets ...*kafka.Offset) (err error) {
+	ctx, span := otel.StartSpan(ctx, i.tracer, "kafka.CommitOffsets")
+	defer otel.CloseSpan(span, err)
+
+	if i.meter != nil {
+		startTime := time.Now()
+		defer func() {
+			i.metrics.commitLatency.Record(ctx, time.Since(startTime).Milliseconds())
+		}()
+		i.metrics.commitBatchSize.Record(ctx, int64(len(offsets)))
+	}
+
+	return i.inner.CommitOffsets(ctx, offsets...)
+}
+
+func (i *Reader) Close() error {
+	return i.inner.Close()
+}

--- a/pkg/kafka/kafka_reader.go
+++ b/pkg/kafka/kafka_reader.go
@@ -10,6 +10,12 @@ import (
 	loglib "github.com/xataio/pgstream/pkg/log"
 )
 
+type MessageReader interface {
+	FetchMessage(ctx context.Context) (*Message, error)
+	CommitOffsets(ctx context.Context, offsets ...*Offset) error
+	Close() error
+}
+
 type Reader struct {
 	reader *kafka.Reader
 }

--- a/pkg/otel/otel.go
+++ b/pkg/otel/otel.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package otel
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type Instrumentation struct {
+	Meter  metric.Meter
+	Tracer trace.Tracer
+}
+
+func (i *Instrumentation) IsEnabled() bool {
+	return i.Meter != nil || i.Tracer != nil
+}
+
+// StartSpan will start a span using the tracer on input. If the tracer is nil,
+// the context returned is the same as on input, and the span will be nil.
+func StartSpan(ctx context.Context, tracer trace.Tracer, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	if tracer == nil {
+		return ctx, nil
+	}
+	return tracer.Start(ctx, name, opts...)
+}
+
+// CloseSpan closes a span and records the given error if not nil. If the span
+// is nil, this is a noop.
+func CloseSpan(span trace.Span, err error) {
+	if span == nil {
+		return
+	}
+	recordSpanResult(span, err)
+	span.End()
+}
+
+func recordSpanResult(span trace.Span, err error) {
+	if err == nil {
+		return
+	}
+
+	span.RecordError(err)
+	span.SetStatus(codes.Error, "")
+}

--- a/pkg/otel/otel.go
+++ b/pkg/otel/otel.go
@@ -16,7 +16,7 @@ type Instrumentation struct {
 }
 
 func (i *Instrumentation) IsEnabled() bool {
-	return i.Meter != nil || i.Tracer != nil
+	return i != nil && (i.Meter != nil || i.Tracer != nil)
 }
 
 // StartSpan will start a span using the tracer on input. If the tracer is nil,

--- a/pkg/schemalog/instrumentation/instrumented_store.go
+++ b/pkg/schemalog/instrumentation/instrumented_store.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package instrumentation
+
+import (
+	"context"
+
+	"github.com/xataio/pgstream/pkg/otel"
+	"github.com/xataio/pgstream/pkg/schemalog"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type Store struct {
+	inner  schemalog.Store
+	tracer trace.Tracer
+}
+
+func NewStore(inner schemalog.Store, instrumentation *otel.Instrumentation) schemalog.Store {
+	if instrumentation == nil {
+		return inner
+	}
+
+	return &Store{
+		inner:  inner,
+		tracer: instrumentation.Tracer,
+	}
+}
+
+func (s *Store) Fetch(ctx context.Context, schemaName string, acked bool) (le *schemalog.LogEntry, err error) {
+	ctx, span := otel.StartSpan(ctx, s.tracer, "schemalogstore.Fetch", trace.WithAttributes(attribute.String("schema", schemaName)))
+	defer otel.CloseSpan(span, err)
+	return s.inner.Fetch(ctx, schemaName, acked)
+}
+
+func (s *Store) Ack(ctx context.Context, le *schemalog.LogEntry) (err error) {
+	ctx, span := otel.StartSpan(ctx, s.tracer, "schemalogstore.Ack", trace.WithAttributes(attribute.String("schema", le.SchemaName)))
+	defer otel.CloseSpan(span, err)
+	return s.inner.Ack(ctx, le)
+}
+
+func (s *Store) Close() error {
+	return s.inner.Close()
+}

--- a/pkg/stream/stream_run.go
+++ b/pkg/stream/stream_run.go
@@ -20,6 +20,7 @@ import (
 	processinstrumentation "github.com/xataio/pgstream/pkg/wal/processor/instrumentation"
 	kafkaprocessor "github.com/xataio/pgstream/pkg/wal/processor/kafka"
 	"github.com/xataio/pgstream/pkg/wal/processor/search"
+	searchinstrumentation "github.com/xataio/pgstream/pkg/wal/processor/search/instrumentation"
 	"github.com/xataio/pgstream/pkg/wal/processor/search/store"
 	"github.com/xataio/pgstream/pkg/wal/processor/translator"
 	webhooknotifier "github.com/xataio/pgstream/pkg/wal/processor/webhook/notifier"
@@ -134,6 +135,12 @@ func Run(ctx context.Context, logger loglib.Logger, config *Config, instrumentat
 			return err
 		}
 		searchStore = search.NewStoreRetrier(searchStore, config.Processor.Search.Retrier, search.WithStoreLogger(logger))
+		if instrumentation.IsEnabled() {
+			searchStore, err = searchinstrumentation.NewStore(searchStore, instrumentation)
+			if err != nil {
+				return err
+			}
+		}
 
 		searchIndexer := search.NewBatchIndexer(ctx,
 			config.Processor.Search.Indexer,

--- a/pkg/stream/stream_run.go
+++ b/pkg/stream/stream_run.go
@@ -212,7 +212,13 @@ func Run(ctx context.Context, logger loglib.Logger, config *Config, instrumentat
 
 	if config.Processor.Translator != nil {
 		logger.Info("adding translation to processor...")
-		translator, err := translator.New(config.Processor.Translator, processor, translator.WithLogger(logger))
+		opts := []translator.Option{
+			translator.WithLogger(logger),
+		}
+		if instrumentation.IsEnabled() {
+			opts = append(opts, translator.WithInstrumentation(instrumentation))
+		}
+		translator, err := translator.New(config.Processor.Translator, processor, opts...)
 		if err != nil {
 			return fmt.Errorf("error creating processor translation layer: %w", err)
 		}

--- a/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
+++ b/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
@@ -14,10 +14,10 @@ import (
 	"github.com/xataio/pgstream/pkg/kafka"
 	kafkainstrumentation "github.com/xataio/pgstream/pkg/kafka/instrumentation"
 	loglib "github.com/xataio/pgstream/pkg/log"
+	"github.com/xataio/pgstream/pkg/otel"
 	"github.com/xataio/pgstream/pkg/wal"
 	"github.com/xataio/pgstream/pkg/wal/checkpointer"
 	"github.com/xataio/pgstream/pkg/wal/processor"
-	"go.opentelemetry.io/otel/metric"
 )
 
 // BatchWriter is a kafka writer that uses batches to send the data to the
@@ -104,9 +104,9 @@ func WithCheckpoint(c checkpointer.Checkpoint) Option {
 	}
 }
 
-func WithInstrumentation(m metric.Meter) Option {
+func WithInstrumentation(i *otel.Instrumentation) Option {
 	return func(w *BatchWriter) {
-		instrumentedWriter, err := kafkainstrumentation.NewWriter(w.writer, m)
+		instrumentedWriter, err := kafkainstrumentation.NewWriter(w.writer, i)
 		if err != nil {
 			w.logger.Error(err, "initialising kafka writer instrumentation")
 			return

--- a/pkg/wal/processor/search/instrumentation/instrumented_search_store.go
+++ b/pkg/wal/processor/search/instrumentation/instrumented_search_store.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package instrumentation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/xataio/pgstream/pkg/otel"
+	"github.com/xataio/pgstream/pkg/schemalog"
+	"github.com/xataio/pgstream/pkg/wal/processor/search"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type SearchStore struct {
+	inner   search.Store
+	tracer  trace.Tracer
+	meter   metric.Meter
+	metrics *storeMetrics
+}
+
+type storeMetrics struct {
+	docErrors metric.Int64Counter
+}
+
+func NewStore(inner search.Store, instrumentation *otel.Instrumentation) (search.Store, error) {
+	if instrumentation == nil {
+		return inner, nil
+	}
+
+	s := &SearchStore{
+		inner:   inner,
+		tracer:  instrumentation.Tracer,
+		meter:   instrumentation.Meter,
+		metrics: &storeMetrics{},
+	}
+
+	if err := s.initMetrics(); err != nil {
+		return nil, fmt.Errorf("error initialising search store metrics: %w", err)
+	}
+
+	return s, nil
+}
+
+func (s *SearchStore) ApplySchemaChange(ctx context.Context, logEntry *schemalog.LogEntry) (err error) {
+	ctx, span := otel.StartSpan(ctx, s.tracer, "searchstore.ApplySchemaChange", trace.WithAttributes(
+		attribute.String("schemaName", logEntry.SchemaName),
+	))
+	defer otel.CloseSpan(span, err)
+
+	return s.inner.ApplySchemaChange(ctx, logEntry)
+}
+
+func (s *SearchStore) DeleteSchema(ctx context.Context, schemaName string) (err error) {
+	ctx, span := otel.StartSpan(ctx, s.tracer, "searchstore.DeleteSchema", trace.WithAttributes(
+		attribute.String("schemaName", schemaName),
+	))
+	defer otel.CloseSpan(span, err)
+
+	return s.inner.DeleteSchema(ctx, schemaName)
+}
+
+func (s *SearchStore) DeleteTableDocuments(ctx context.Context, schemaName string, tableIDs []string) (err error) {
+	ctx, span := otel.StartSpan(ctx, s.tracer, "searchstore.DeleteTableDocuments", trace.WithAttributes(
+		attribute.String("schemaName", schemaName),
+		attribute.StringSlice("tables", tableIDs),
+	))
+	defer otel.CloseSpan(span, err)
+
+	return s.inner.DeleteTableDocuments(ctx, schemaName, tableIDs)
+}
+
+func (s *SearchStore) SendDocuments(ctx context.Context, docs []search.Document) (docErrs []search.DocumentError, err error) {
+	ctx, span := otel.StartSpan(ctx, s.tracer, "searchstore.SendDocuments", trace.WithAttributes(
+		attribute.Int("docCount", len(docs)),
+	))
+	defer otel.CloseSpan(span, err)
+
+	docErrs, err = s.inner.SendDocuments(ctx, docs)
+	if s.meter != nil && docErrs != nil {
+		go func() {
+			for _, docErr := range docErrs {
+				s.metrics.docErrors.Add(ctx, 1, metric.WithAttributes(attribute.String("severity", docErr.Severity.String())))
+			}
+		}()
+	}
+
+	return docErrs, err
+}
+
+func (s *SearchStore) GetMapper() search.Mapper {
+	return s.inner.GetMapper()
+}
+
+func (s *SearchStore) initMetrics() error {
+	if s.meter == nil {
+		return nil
+	}
+
+	var err error
+	s.metrics.docErrors, err = s.meter.Int64Counter("pgstream.search.store.doc.errors",
+		metric.WithUnit("errors"),
+		metric.WithDescription("Count of failed sent documents by severity"))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/wal/processor/translator/wal_translator.go
+++ b/pkg/wal/processor/translator/wal_translator.go
@@ -9,7 +9,9 @@ import (
 	"slices"
 
 	loglib "github.com/xataio/pgstream/pkg/log"
+	"github.com/xataio/pgstream/pkg/otel"
 	"github.com/xataio/pgstream/pkg/schemalog"
+	schemaloginstrumentation "github.com/xataio/pgstream/pkg/schemalog/instrumentation"
 	schemalogpg "github.com/xataio/pgstream/pkg/schemalog/postgres"
 	"github.com/xataio/pgstream/pkg/wal"
 	"github.com/xataio/pgstream/pkg/wal/processor"
@@ -107,6 +109,12 @@ func WithLogger(l loglib.Logger) Option {
 		t.logger = loglib.NewLogger(l).WithFields(loglib.Fields{
 			loglib.ServiceField: "wal_translator",
 		})
+	}
+}
+
+func WithInstrumentation(i *otel.Instrumentation) Option {
+	return func(t *Translator) {
+		t.schemaLogStore = schemaloginstrumentation.NewStore(t.schemaLogStore, i)
 	}
 }
 


### PR DESCRIPTION
This PR improves the instrumentation support of pgstream, by adding support for traces and extending the instrumentation coverage. Tracing/metrics are readily available with the library use for now. Out of the box instrumentation for the pgstream CLI tool will be integrated later on.

Commits have been split for ease of reviewing.