### PR TITLE
Fix instrumentation

### DIFF
--- a/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
+++ b/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
@@ -62,10 +62,6 @@ func NewBatchWriter(config *Config, opts ...Option) (*BatchWriter, error) {
 	}
 	w.queueBytesSema = synclib.NewWeightedSemaphore(int64(maxQueueBytes))
 
-	for _, opt := range opts {
-		opt(w)
-	}
-
 	// Since the batch kafka writer handles the batching, we don't want to have
 	// a timeout configured in the underlying kafka-go writer or the latency for
 	// the send will increase unnecessarily. Instead, we set the kafka-go writer
@@ -85,6 +81,10 @@ func NewBatchWriter(config *Config, opts ...Option) (*BatchWriter, error) {
 	}, w.logger)
 	if err != nil {
 		return nil, err
+	}
+
+	for _, opt := range opts {
+		opt(w)
 	}
 
 	return w, nil


### PR DESCRIPTION
This PR updates the wal kafka batch writer to apply the constructor options after the internal writer is initialised (this allows us to wrap it with instrumentation). 
The search store retrier is updated to return dropped documents as failed documents in the `SendDocuments` method, instead of only returning retriable failed documents. This way the metric to track failed document errors accurately represents the results.