### PR TITLE
Update logger field

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.58.1
+    rev: v1.60.1
     hooks:
       - id: golangci-lint-full
         args: ["--timeout=10m", "--config=.golangci.yml"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: lint
 lint: ## Lint source code
 	@echo "Linting source code..."
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.1
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
 	@golangci-lint run
 
 .PHONY: test

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -26,7 +26,7 @@ func (l *NoopLogger) WithFields(fields Fields) Logger {
 	return l
 }
 
-const ServiceField = "service"
+const ModuleField = "module"
 
 func NewNoopLogger() *NoopLogger {
 	return &NoopLogger{}

--- a/pkg/wal/checkpointer/kafka/wal_kafka_checkpointer.go
+++ b/pkg/wal/checkpointer/kafka/wal_kafka_checkpointer.go
@@ -53,7 +53,7 @@ func New(ctx context.Context, cfg Config, committer kafkaCommitter, opts ...Opti
 func WithLogger(l loglib.Logger) Option {
 	return func(c *Checkpointer) {
 		c.logger = loglib.NewLogger(l).WithFields(loglib.Fields{
-			loglib.ServiceField: "wal_kafka_checkpointer",
+			loglib.ModuleField: "wal_kafka_checkpointer",
 		})
 	}
 }

--- a/pkg/wal/listener/kafka/wal_kafka_reader.go
+++ b/pkg/wal/listener/kafka/wal_kafka_reader.go
@@ -53,7 +53,7 @@ func NewWALReader(kafkaReader kafkaReader, processRecord payloadProcessor, opts 
 func WithLogger(logger loglib.Logger) Option {
 	return func(r *Reader) {
 		r.logger = loglib.NewLogger(logger).WithFields(loglib.Fields{
-			loglib.ServiceField: "wal_kafka_reader",
+			loglib.ModuleField: "wal_kafka_reader",
 		})
 	}
 }

--- a/pkg/wal/listener/postgres/wal_pg_listener.go
+++ b/pkg/wal/listener/postgres/wal_pg_listener.go
@@ -62,7 +62,7 @@ func New(handler replicationHandler, processEvent listenerProcessWalEvent, opts 
 func WithLogger(logger loglib.Logger) Option {
 	return func(l *Listener) {
 		l.logger = loglib.NewLogger(logger).WithFields(loglib.Fields{
-			loglib.ServiceField: "wal_postgres_listener",
+			loglib.ModuleField: "wal_postgres_listener",
 		})
 	}
 }

--- a/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
+++ b/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
@@ -93,7 +93,7 @@ func NewBatchWriter(config *Config, opts ...Option) (*BatchWriter, error) {
 func WithLogger(l loglib.Logger) Option {
 	return func(w *BatchWriter) {
 		w.logger = loglib.NewLogger(l).WithFields(loglib.Fields{
-			loglib.ServiceField: "kafka_batch_writer",
+			loglib.ModuleField: "kafka_batch_writer",
 		})
 	}
 }

--- a/pkg/wal/processor/search/search_batch_indexer.go
+++ b/pkg/wal/processor/search/search_batch_indexer.go
@@ -76,7 +76,7 @@ func NewBatchIndexer(ctx context.Context, config IndexerConfig, store Store, lsn
 func WithLogger(l loglib.Logger) Option {
 	return func(i *BatchIndexer) {
 		i.logger = loglib.NewLogger(l).WithFields(loglib.Fields{
-			loglib.ServiceField: "search_batch_indexer",
+			loglib.ModuleField: "search_batch_indexer",
 		})
 	}
 }

--- a/pkg/wal/processor/translator/wal_translator.go
+++ b/pkg/wal/processor/translator/wal_translator.go
@@ -107,7 +107,7 @@ func WithSkipDataEvent(skip dataEventFilter) Option {
 func WithLogger(l loglib.Logger) Option {
 	return func(t *Translator) {
 		t.logger = loglib.NewLogger(l).WithFields(loglib.Fields{
-			loglib.ServiceField: "wal_translator",
+			loglib.ModuleField: "wal_translator",
 		})
 	}
 }

--- a/pkg/wal/processor/webhook/notifier/webhook_notifier.go
+++ b/pkg/wal/processor/webhook/notifier/webhook_notifier.go
@@ -69,7 +69,7 @@ func New(cfg *Config, store subscriptionRetriever, opts ...Option) *Notifier {
 func WithLogger(l loglib.Logger) Option {
 	return func(n *Notifier) {
 		n.logger = loglib.NewLogger(l).WithFields(loglib.Fields{
-			loglib.ServiceField: "webhook_notifier",
+			loglib.ModuleField: "webhook_notifier",
 		})
 	}
 }

--- a/pkg/wal/processor/webhook/subscription/server/subscription_server.go
+++ b/pkg/wal/processor/webhook/subscription/server/subscription_server.go
@@ -54,7 +54,7 @@ func New(cfg *Config, store store.Store, opts ...Option) *Server {
 func WithLogger(l loglib.Logger) Option {
 	return func(s *Server) {
 		s.logger = loglib.NewLogger(l).WithFields(loglib.Fields{
-			loglib.ServiceField: "webhook_subscription_server",
+			loglib.ModuleField: "webhook_subscription_server",
 		})
 	}
 }

--- a/pkg/wal/processor/webhook/subscription/store/cache/subscription_store_cache.go
+++ b/pkg/wal/processor/webhook/subscription/store/cache/subscription_store_cache.go
@@ -61,7 +61,7 @@ func New(ctx context.Context, store store.Store, cfg *Config, opts ...Option) (*
 func WithLogger(l loglib.Logger) Option {
 	return func(sc *Store) {
 		sc.logger = loglib.NewLogger(l).WithFields(loglib.Fields{
-			loglib.ServiceField: "subscription_store_cache",
+			loglib.ModuleField: "subscription_store_cache",
 		})
 	}
 }

--- a/pkg/wal/processor/webhook/subscription/store/postgres/pg_subscription_store.go
+++ b/pkg/wal/processor/webhook/subscription/store/postgres/pg_subscription_store.go
@@ -47,7 +47,7 @@ func NewSubscriptionStore(ctx context.Context, url string, opts ...Option) (*Sto
 func WithLogger(l loglib.Logger) Option {
 	return func(ss *Store) {
 		ss.logger = loglib.NewLogger(l).WithFields(loglib.Fields{
-			loglib.ServiceField: "webhook_subscription_store",
+			loglib.ModuleField: "webhook_subscription_store",
 		})
 	}
 }

--- a/pkg/wal/replication/postgres/pg_replication_handler.go
+++ b/pkg/wal/replication/postgres/pg_replication_handler.go
@@ -85,7 +85,7 @@ func NewHandler(ctx context.Context, cfg Config, opts ...Option) (*Handler, erro
 func WithLogger(l loglib.Logger) Option {
 	return func(h *Handler) {
 		h.logger = loglib.NewLogger(l).WithFields(loglib.Fields{
-			loglib.ServiceField: "postgres_replication_handler",
+			loglib.ModuleField: "postgres_replication_handler",
 		})
 	}
 }


### PR DESCRIPTION
This PR updates the logger library to use the field `module` instead of `service`, since `service` is commonly used by many logging platforms and it will overwrite the values. `module` aligns more with the concept for which it's currently used, since it's set per block of work.

The golangci-lint version is updated.