### PR TITLE
Add tx support to postgres lib

### DIFF
--- a/internal/postgres/errors.go
+++ b/internal/postgres/errors.go
@@ -5,14 +5,22 @@ package postgres
 import (
 	"errors"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
-var ErrConnTimeout = errors.New("connection timeout")
+var (
+	ErrConnTimeout = errors.New("connection timeout")
+	ErrNoRows      = errors.New("no rows")
+)
 
 func mapError(err error) error {
 	if pgconn.Timeout(err) {
 		return ErrConnTimeout
+	}
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNoRows
 	}
 
 	return err

--- a/internal/postgres/mocks/mock_pg_querier.go
+++ b/internal/postgres/mocks/mock_pg_querier.go
@@ -12,6 +12,7 @@ type Querier struct {
 	QueryRowFn func(ctx context.Context, query string, args ...any) postgres.Row
 	QueryFn    func(ctx context.Context, query string, args ...any) (postgres.Rows, error)
 	ExecFn     func(context.Context, string, ...any) (postgres.CommandTag, error)
+	ExecInTxFn func(context.Context, func(tx postgres.Tx) error) error
 	CloseFn    func(context.Context) error
 }
 
@@ -25,6 +26,10 @@ func (m *Querier) Query(ctx context.Context, query string, args ...any) (postgre
 
 func (m *Querier) Exec(ctx context.Context, query string, args ...any) (postgres.CommandTag, error) {
 	return m.ExecFn(ctx, query, args...)
+}
+
+func (m *Querier) ExecInTx(ctx context.Context, fn func(tx postgres.Tx) error) error {
+	return m.ExecInTxFn(ctx, fn)
 }
 
 func (m *Querier) Close(ctx context.Context) error {

--- a/internal/postgres/pg_conn.go
+++ b/internal/postgres/pg_conn.go
@@ -48,7 +48,7 @@ func (c *Conn) ExecInTx(ctx context.Context, fn func(Tx) error) error {
 		return mapError(err)
 	}
 
-	if err := fn(tx); err != nil {
+	if err := fn(&Txn{Tx: tx}); err != nil {
 		tx.Rollback(ctx)
 		return mapError(err)
 	}

--- a/internal/postgres/pg_conn.go
+++ b/internal/postgres/pg_conn.go
@@ -7,23 +7,10 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 )
 
 type Conn struct {
 	conn *pgx.Conn
-}
-
-type Row interface {
-	pgx.Row
-}
-
-type Rows interface {
-	pgx.Rows
-}
-
-type CommandTag struct {
-	pgconn.CommandTag
 }
 
 func NewConn(ctx context.Context, url string) (*Conn, error) {
@@ -53,6 +40,20 @@ func (c *Conn) Query(ctx context.Context, query string, args ...any) (Rows, erro
 func (c *Conn) Exec(ctx context.Context, query string, args ...any) (CommandTag, error) {
 	tag, err := c.conn.Exec(ctx, query, args...)
 	return CommandTag{tag}, mapError(err)
+}
+
+func (c *Conn) ExecInTx(ctx context.Context, fn func(Tx) error) error {
+	tx, err := c.conn.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return mapError(err)
+	}
+
+	if err := fn(tx); err != nil {
+		tx.Rollback(ctx)
+		return mapError(err)
+	}
+
+	return tx.Commit(ctx)
 }
 
 func (c *Conn) Close(ctx context.Context) error {

--- a/internal/postgres/pg_conn.go
+++ b/internal/postgres/pg_conn.go
@@ -41,16 +41,18 @@ func NewConn(ctx context.Context, url string) (*Conn, error) {
 }
 
 func (c *Conn) QueryRow(ctx context.Context, query string, args ...any) Row {
-	return c.conn.QueryRow(ctx, query, args...)
+	row := c.conn.QueryRow(ctx, query, args...)
+	return &mappedRow{inner: row}
 }
 
 func (c *Conn) Query(ctx context.Context, query string, args ...any) (Rows, error) {
-	return c.conn.Query(ctx, query, args...)
+	rows, err := c.conn.Query(ctx, query, args...)
+	return rows, mapError(err)
 }
 
 func (c *Conn) Exec(ctx context.Context, query string, args ...any) (CommandTag, error) {
 	tag, err := c.conn.Exec(ctx, query, args...)
-	return CommandTag{tag}, err
+	return CommandTag{tag}, mapError(err)
 }
 
 func (c *Conn) Close(ctx context.Context) error {

--- a/internal/postgres/pg_conn_pool.go
+++ b/internal/postgres/pg_conn_pool.go
@@ -28,16 +28,18 @@ func NewConnPool(ctx context.Context, url string) (*Pool, error) {
 }
 
 func (c *Pool) QueryRow(ctx context.Context, query string, args ...any) Row {
-	return c.Pool.QueryRow(ctx, query, args...)
+	row := c.Pool.QueryRow(ctx, query, args...)
+	return &mappedRow{inner: row}
 }
 
 func (c *Pool) Query(ctx context.Context, query string, args ...any) (Rows, error) {
-	return c.Pool.Query(ctx, query, args...)
+	rows, err := c.Pool.Query(ctx, query, args...)
+	return rows, mapError(err)
 }
 
 func (c *Pool) Exec(ctx context.Context, query string, args ...any) (CommandTag, error) {
 	tag, err := c.Pool.Exec(ctx, query, args...)
-	return CommandTag{tag}, err
+	return CommandTag{tag}, mapError(err)
 }
 
 func (c *Pool) Close(_ context.Context) error {

--- a/internal/postgres/pg_conn_pool.go
+++ b/internal/postgres/pg_conn_pool.go
@@ -49,7 +49,7 @@ func (c *Pool) ExecInTx(ctx context.Context, fn func(Tx) error) error {
 		return mapError(err)
 	}
 
-	if err := fn(tx); err != nil {
+	if err := fn(&Txn{Tx: tx}); err != nil {
 		tx.Rollback(ctx)
 		return mapError(err)
 	}

--- a/internal/postgres/pg_querier.go
+++ b/internal/postgres/pg_querier.go
@@ -2,14 +2,37 @@
 
 package postgres
 
-import "context"
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
 
 type Querier interface {
 	Query(ctx context.Context, query string, args ...any) (Rows, error)
 	QueryRow(ctx context.Context, query string, args ...any) Row
 	Exec(ctx context.Context, query string, args ...any) (CommandTag, error)
+	ExecInTx(ctx context.Context, fn func(tx Tx) error) error
 	Close(ctx context.Context) error
 }
+
+type Row interface {
+	pgx.Row
+}
+
+type Rows interface {
+	pgx.Rows
+}
+
+type Tx interface {
+	pgx.Tx
+}
+
+type CommandTag struct {
+	pgconn.CommandTag
+}
+
 type mappedRow struct {
 	inner Row
 }

--- a/internal/postgres/pg_querier.go
+++ b/internal/postgres/pg_querier.go
@@ -26,7 +26,9 @@ type Rows interface {
 }
 
 type Tx interface {
-	pgx.Tx
+	Query(ctx context.Context, query string, args ...any) (Rows, error)
+	QueryRow(ctx context.Context, query string, args ...any) Row
+	Exec(ctx context.Context, query string, args ...any) (CommandTag, error)
 }
 
 type CommandTag struct {

--- a/internal/postgres/pg_querier.go
+++ b/internal/postgres/pg_querier.go
@@ -10,3 +10,11 @@ type Querier interface {
 	Exec(ctx context.Context, query string, args ...any) (CommandTag, error)
 	Close(ctx context.Context) error
 }
+type mappedRow struct {
+	inner Row
+}
+
+func (mr *mappedRow) Scan(dest ...any) error {
+	err := mr.inner.Scan(dest...)
+	return mapError(err)
+}

--- a/internal/postgres/pg_tx.go
+++ b/internal/postgres/pg_tx.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type Txn struct {
+	pgx.Tx
+}
+
+func (t *Txn) QueryRow(ctx context.Context, query string, args ...any) Row {
+	row := t.Tx.QueryRow(ctx, query, args...)
+	return &mappedRow{inner: row}
+}
+
+func (t *Txn) Query(ctx context.Context, query string, args ...any) (Rows, error) {
+	rows, err := t.Tx.Query(ctx, query, args...)
+	return rows, mapError(err)
+}
+
+func (t *Txn) Exec(ctx context.Context, query string, args ...any) (CommandTag, error) {
+	tag, err := t.Tx.Exec(ctx, query, args...)
+	return CommandTag{tag}, mapError(err)
+}


### PR DESCRIPTION
This PR adds support for executing operations within a transaction using the internal postgres library. It also adds error mapping to the querier implementations.