### PR TITLE
Return error when applying schema if context is canceled

### DIFF
--- a/pkg/wal/processor/search/search_batch_indexer.go
+++ b/pkg/wal/processor/search/search_batch_indexer.go
@@ -227,6 +227,9 @@ func (i *BatchIndexer) sendBatch(ctx context.Context, batch *msgBatch) error {
 				return err
 			}
 			if err := i.applySchemaChange(ctx, msg.schemaChange); err != nil {
+				if errors.Is(err, context.Canceled) {
+					return err
+				}
 				i.logDataLoss(msg.schemaChange, err)
 				return nil
 			}


### PR DESCRIPTION
Do not treat as data loss when a schema change is applied and the context is canceled. Return the error, and stop the search batch indexer instead to prevent data loss (the event won't be checkpointed and will be retried on the next service start). This is how data write and truncate events are handled currently, it was an oversight for schema changes.