### PR TITLE
Checkpoint invalid wal events

### DIFF
--- a/pkg/wal/processor/translator/wal_translator_test.go
+++ b/pkg/wal/processor/translator/wal_translator_test.go
@@ -144,10 +144,7 @@ func TestTranslator_ProcessWALEvent(t *testing.T) {
 			processor: &mocks.Processor{
 				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Event) error {
 					wantEvent := newTestDataEvent("I")
-					wantEvent.Data.Metadata = wal.Metadata{
-						SchemaID:        testSchemaID,
-						TablePgstreamID: testTableID,
-					}
+					wantEvent.Data = nil
 					require.Equal(t, wantEvent, walEvent)
 					return nil
 				},


### PR DESCRIPTION
This PR updates the translator logic to treat invalid events as keep alives so that they are checkpointed, instead of ignoring them. This could lead to high replication slot lag if a large amount of invalid wal events are consumed, causing the LSN to not be checkpointed for a long time.
Warning log is downgraded to debug to reduce noise in those cases.