### PR TITLE
Wrap external json lib 

### DIFF
--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package json
+
+import (
+	json "github.com/bytedance/sonic"
+)
+
+func Unmarshal(b []byte, v any) error {
+	return json.Unmarshal(b, v)
+}
+
+func Marshal(v any) ([]byte, error) {
+	return json.Marshal(v)
+}

--- a/internal/searchstore/search_client.go
+++ b/internal/searchstore/search_client.go
@@ -5,9 +5,10 @@ package searchstore
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/xataio/pgstream/internal/json"
 )
 
 type Client interface {

--- a/pkg/schemalog/log_entry.go
+++ b/pkg/schemalog/log_entry.go
@@ -96,7 +96,7 @@ func (m *LogEntry) Diff(previous *LogEntry) *SchemaDiff {
 	return m.Schema.Diff(&previous.Schema)
 }
 
-func (m *LogEntry) GetTableByName(tableName string) *Table {
+func (m *LogEntry) GetTableByName(tableName string) (Table, bool) {
 	return m.Schema.getTableByName(tableName)
 }
 

--- a/pkg/schemalog/schema.go
+++ b/pkg/schemalog/schema.go
@@ -3,8 +3,9 @@
 package schemalog
 
 import (
-	"encoding/json"
 	"slices"
+
+	"github.com/xataio/pgstream/internal/json"
 )
 
 type Schema struct {

--- a/pkg/schemalog/schema.go
+++ b/pkg/schemalog/schema.go
@@ -96,13 +96,13 @@ func (s *Schema) Diff(previous *Schema) *SchemaDiff {
 	return &d
 }
 
-func (s *Schema) getTableByName(tableName string) *Table {
+func (s *Schema) getTableByName(tableName string) (Table, bool) {
 	for _, t := range s.Tables {
 		if t.Name == tableName {
-			return &t
+			return t, true
 		}
 	}
-	return nil
+	return Table{}, false
 }
 
 func (s *Schema) getTableByID(pgstreamID string) *Table {

--- a/pkg/wal/listener/kafka/wal_kafka_reader.go
+++ b/pkg/wal/listener/kafka/wal_kafka_reader.go
@@ -4,10 +4,10 @@ package kafka
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
+	"github.com/xataio/pgstream/internal/json"
 	"github.com/xataio/pgstream/pkg/kafka"
 	loglib "github.com/xataio/pgstream/pkg/log"
 	"github.com/xataio/pgstream/pkg/wal"

--- a/pkg/wal/listener/postgres/wal_pg_listener.go
+++ b/pkg/wal/listener/postgres/wal_pg_listener.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	json "github.com/bytedance/sonic"
+	"github.com/xataio/pgstream/internal/json"
 	loglib "github.com/xataio/pgstream/pkg/log"
 	"github.com/xataio/pgstream/pkg/wal"
 	"github.com/xataio/pgstream/pkg/wal/replication"

--- a/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
+++ b/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
@@ -9,7 +9,7 @@ import (
 	"runtime/debug"
 	"time"
 
-	json "github.com/bytedance/sonic"
+	"github.com/xataio/pgstream/internal/json"
 	synclib "github.com/xataio/pgstream/internal/sync"
 	"github.com/xataio/pgstream/pkg/kafka"
 	kafkainstrumentation "github.com/xataio/pgstream/pkg/kafka/instrumentation"

--- a/pkg/wal/processor/search/search_adapter.go
+++ b/pkg/wal/processor/search/search_adapter.go
@@ -3,11 +3,11 @@
 package search
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
 
+	"github.com/xataio/pgstream/internal/json"
 	"github.com/xataio/pgstream/pkg/schemalog"
 	"github.com/xataio/pgstream/pkg/wal"
 	"github.com/xataio/pgstream/pkg/wal/processor"

--- a/pkg/wal/processor/search/search_store_retrier_test.go
+++ b/pkg/wal/processor/search/search_store_retrier_test.go
@@ -4,6 +4,7 @@ package search
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -229,6 +230,7 @@ func TestStoreRetrier_SendDocuments(t *testing.T) {
 				inner:           tc.store,
 				logger:          loglib.NewNoopLogger(),
 				backoffProvider: newMockBackoffProvider(),
+				marshaler:       json.Marshal,
 			}
 
 			failedDocs, err := retrier.SendDocuments(context.Background(), testDocs)

--- a/pkg/wal/processor/search/store/search_adapter.go
+++ b/pkg/wal/processor/search/store/search_adapter.go
@@ -3,9 +3,9 @@
 package store
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/xataio/pgstream/internal/json"
 	"github.com/xataio/pgstream/internal/searchstore"
 	"github.com/xataio/pgstream/pkg/schemalog"
 	"github.com/xataio/pgstream/pkg/wal/processor/search"

--- a/pkg/wal/processor/search/store/search_store.go
+++ b/pkg/wal/processor/search/store/search_store.go
@@ -5,14 +5,13 @@ package store
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
+	"github.com/xataio/pgstream/internal/json"
 	"github.com/xataio/pgstream/internal/searchstore"
 	elasticsearchstore "github.com/xataio/pgstream/internal/searchstore/elasticsearch"
 	opensearchstore "github.com/xataio/pgstream/internal/searchstore/opensearch"
-
 	loglib "github.com/xataio/pgstream/pkg/log"
 	"github.com/xataio/pgstream/pkg/schemalog"
 	"github.com/xataio/pgstream/pkg/wal/processor/search"
@@ -423,7 +422,7 @@ func (s *Store) updateMappingAddNewColumns(ctx context.Context, indexName IndexN
 }
 
 func (s *Store) insertNewSchemaLog(ctx context.Context, m *schemalog.LogEntry) error {
-	logBytes, err := json.Marshal(m)
+	logBytes, err := s.marshaler(m)
 	if err != nil {
 		return fmt.Errorf("insert schema log, failed to marshal search doc: %w", err)
 	}

--- a/pkg/wal/processor/translator/wal_translator.go
+++ b/pkg/wal/processor/translator/wal_translator.go
@@ -203,16 +203,16 @@ func (t *Translator) translate(ctx context.Context, data *wal.Data) error {
 		return fmt.Errorf("failed to retrieve schema for translate %w", err)
 	}
 
-	table := logEntry.GetTableByName(data.Table)
-	if table == nil {
+	table, found := logEntry.GetTableByName(data.Table)
+	if !found {
 		return processor.ErrTableNotFound
 	}
 
-	if err = t.fillEventMetadata(data, logEntry, table); err != nil {
+	if err = t.fillEventMetadata(data, logEntry, &table); err != nil {
 		return fmt.Errorf("failed to fill event metadata: %w", err)
 	}
 
-	if err = t.translateColumnNames(data, table); err != nil {
+	if err = t.translateColumnNames(data, &table); err != nil {
 		return fmt.Errorf("failed to translate column names: %w", err)
 	}
 

--- a/pkg/wal/processor/webhook/notifier/webhook_notifier.go
+++ b/pkg/wal/processor/webhook/notifier/webhook_notifier.go
@@ -5,7 +5,6 @@ package notifier
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +12,7 @@ import (
 	"sync"
 
 	httplib "github.com/xataio/pgstream/internal/http"
+	"github.com/xataio/pgstream/internal/json"
 	synclib "github.com/xataio/pgstream/internal/sync"
 	loglib "github.com/xataio/pgstream/pkg/log"
 	"github.com/xataio/pgstream/pkg/wal"


### PR DESCRIPTION
This PR wraps the external json lib implementation under an internal package so that it can be easily replaced in all places where it's used. It updates processor side modules to benefit from the performance improvements of the library change.

It also updates the `GetTableByName` method to reduce unnecessary memory allocations.

Follow up on https://github.com/xataio/pgstream/pull/84.