### PR TITLE
Add snapshot generator

### DIFF
--- a/internal/postgres/mocks/mock_pg_querier.go
+++ b/internal/postgres/mocks/mock_pg_querier.go
@@ -9,16 +9,18 @@ import (
 )
 
 type Querier struct {
-	QueryRowFn func(ctx context.Context, query string, args ...any) postgres.Row
-	QueryFn    func(ctx context.Context, query string, args ...any) (postgres.Rows, error)
-	ExecFn     func(context.Context, uint, string, ...any) (postgres.CommandTag, error)
-	ExecInTxFn func(context.Context, func(tx postgres.Tx) error) error
-	CloseFn    func(context.Context) error
-	execCalls  uint
+	QueryRowFn    func(ctx context.Context, i uint, query string, args ...any) postgres.Row
+	QueryFn       func(ctx context.Context, query string, args ...any) (postgres.Rows, error)
+	ExecFn        func(context.Context, uint, string, ...any) (postgres.CommandTag, error)
+	ExecInTxFn    func(context.Context, func(tx postgres.Tx) error) error
+	CloseFn       func(context.Context) error
+	execCalls     uint
+	queryRowCalls uint
 }
 
 func (m *Querier) QueryRow(ctx context.Context, query string, args ...any) postgres.Row {
-	return m.QueryRowFn(ctx, query, args...)
+	m.queryRowCalls++
+	return m.QueryRowFn(ctx, m.queryRowCalls, query, args...)
 }
 
 func (m *Querier) Query(ctx context.Context, query string, args ...any) (postgres.Rows, error) {

--- a/internal/postgres/mocks/mock_row.go
+++ b/internal/postgres/mocks/mock_row.go
@@ -3,9 +3,11 @@
 package mocks
 
 type Row struct {
-	ScanFn func(args ...any) error
+	ScanFn    func(i uint, args ...any) error
+	scanCalls uint
 }
 
 func (m *Row) Scan(args ...any) error {
-	return m.ScanFn(args)
+	m.scanCalls++
+	return m.ScanFn(m.scanCalls, args...)
 }

--- a/pkg/schemalog/postgres/pg_schemalog_store_test.go
+++ b/pkg/schemalog/postgres/pg_schemalog_store_test.go
@@ -38,7 +38,7 @@ func TestStore_Fetch(t *testing.T) {
 		{
 			name: "ok - without acked",
 			querier: &pgmocks.Querier{
-				QueryRowFn: func(_ context.Context, query string, args ...any) pglib.Row {
+				QueryRowFn: func(_ context.Context, _ uint, query string, args ...any) pglib.Row {
 					require.Len(t, args, 1)
 					require.Equal(t, args[0], testSchema)
 					require.Equal(t,
@@ -54,7 +54,7 @@ func TestStore_Fetch(t *testing.T) {
 		{
 			name: "ok - with acked",
 			querier: &pgmocks.Querier{
-				QueryRowFn: func(_ context.Context, query string, args ...any) pglib.Row {
+				QueryRowFn: func(_ context.Context, _ uint, query string, args ...any) pglib.Row {
 					require.Len(t, args, 1)
 					require.Equal(t, args[0], testSchema)
 					require.Equal(t,
@@ -71,7 +71,7 @@ func TestStore_Fetch(t *testing.T) {
 		{
 			name: "error - querying rows",
 			querier: &pgmocks.Querier{
-				QueryRowFn: func(_ context.Context, query string, args ...any) pglib.Row {
+				QueryRowFn: func(_ context.Context, _ uint, query string, args ...any) pglib.Row {
 					return &mockRow{scanFn: func(...any) error { return errTest }}
 				},
 			},

--- a/pkg/snapshot/generator/postgres/config.go
+++ b/pkg/snapshot/generator/postgres/config.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+type Config struct {
+	// Size of the incremental batches in which the snapshot will be performed.
+	// It defaults to 1000 rows per batch.
+	BatchSize   uint
+	PostgresURL string
+}
+
+const defaultBatchSize = 1000
+
+func (c *Config) batchSize() uint {
+	if c.BatchSize != 0 {
+		return c.BatchSize
+	}
+	return defaultBatchSize
+}

--- a/pkg/snapshot/generator/postgres/pg_snapshot_generator.go
+++ b/pkg/snapshot/generator/postgres/pg_snapshot_generator.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/lib/pq"
+	"github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/pkg/schemalog"
+	"github.com/xataio/pgstream/pkg/snapshot"
+)
+
+type SnapshotGenerator struct {
+	conn           postgres.Querier
+	schemalogStore schemalogStore
+	batchSize      uint
+}
+
+type schemalogStore interface {
+	Insert(ctx context.Context, schemaName string) (*schemalog.LogEntry, error)
+}
+
+var errInvalidSnapshot = errors.New("invalid snapshot details")
+
+func New(ctx context.Context, cfg *Config, schemalogStore schemalogStore) (*SnapshotGenerator, error) {
+	conn, err := postgres.NewConnPool(ctx, cfg.PostgresURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SnapshotGenerator{
+		batchSize:      cfg.batchSize(),
+		conn:           conn,
+		schemalogStore: schemalogStore,
+	}, nil
+}
+
+func (sg *SnapshotGenerator) CreateSnapshot(ctx context.Context, snapshot *snapshot.Snapshot) error {
+	if !snapshot.IsValid() {
+		return errInvalidSnapshot
+	}
+
+	// make sure there's a schema entry in the schema log store before
+	// triggering the snapshot
+	if _, err := sg.schemalogStore.Insert(ctx, snapshot.TableName); err != nil {
+		return fmt.Errorf("ensuring schemalog: %w", err)
+	}
+
+	return sg.run(ctx, snapshot)
+}
+
+func (sg *SnapshotGenerator) Close(ctx context.Context) error {
+	return sg.conn.Close(ctx)
+}
+
+func (sg *SnapshotGenerator) run(ctx context.Context, snapshot *snapshot.Snapshot) error {
+	var lastValue string
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			var err error
+			lastValue, err = sg.updateBatch(ctx, snapshot, lastValue)
+			if err != nil {
+				if errors.Is(err, postgres.ErrNoRows) {
+					return nil
+				}
+				return fmt.Errorf("error updating batch: %w", err)
+			}
+		}
+	}
+}
+
+func (sg *SnapshotGenerator) updateBatch(ctx context.Context, snapshot *snapshot.Snapshot, lastValue string) (string, error) {
+	query := sg.buildBatchQuery(snapshot, lastValue)
+	err := sg.conn.QueryRow(ctx, query).Scan(&lastValue)
+	return lastValue, err
+}
+
+// buildBatchQuery builds the query used to update the next batch of rows.
+func (sg *SnapshotGenerator) buildBatchQuery(snapshot *snapshot.Snapshot, lastValue string) string {
+	identityName := snapshot.IdentityColumnNames[0]
+	whereClause := ""
+	if lastValue != "" {
+		whereClause = fmt.Sprintf("WHERE %s > %v", pq.QuoteIdentifier(identityName), pq.QuoteLiteral(lastValue))
+	}
+
+	return fmt.Sprintf(`
+    WITH batch AS (
+      SELECT %[1]s FROM %[2]s %[4]s ORDER BY %[1]s LIMIT %[3]d FOR NO KEY UPDATE
+    ), update AS (
+      UPDATE %[2]s SET %[1]s=%[2]s.%[1]s FROM batch WHERE %[2]s.%[1]s = batch.%[1]s RETURNING %[2]s.%[1]s
+    )
+    SELECT LAST_VALUE(%[1]s) OVER() FROM update
+    `,
+		pq.QuoteIdentifier(identityName),
+		sg.table(snapshot),
+		sg.batchSize,
+		whereClause)
+}
+
+func (sg *SnapshotGenerator) table(snapshot *snapshot.Snapshot) string {
+	return fmt.Sprintf("%s.%s", pq.QuoteIdentifier(snapshot.SchemaName), pq.QuoteIdentifier(snapshot.TableName))
+}

--- a/pkg/snapshot/generator/postgres/pg_snapshot_generator_test.go
+++ b/pkg/snapshot/generator/postgres/pg_snapshot_generator_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/internal/postgres"
+	postgresmocks "github.com/xataio/pgstream/internal/postgres/mocks"
+	"github.com/xataio/pgstream/pkg/schemalog"
+	schemalogmocks "github.com/xataio/pgstream/pkg/schemalog/mocks"
+	"github.com/xataio/pgstream/pkg/snapshot"
+)
+
+func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
+	t.Parallel()
+
+	testBatchQuery := func(whereQuery string) string {
+		return fmt.Sprintf(`
+    WITH batch AS (
+      SELECT "id" FROM "test-schema"."test-table" %s ORDER BY "id" LIMIT 10 FOR NO KEY UPDATE
+    ), update AS (
+      UPDATE "test-schema"."test-table" SET "id"="test-schema"."test-table"."id" FROM batch WHERE "test-schema"."test-table"."id" = batch."id" RETURNING "test-schema"."test-table"."id"
+    )
+    SELECT LAST_VALUE("id") OVER() FROM update
+    `, whereQuery)
+	}
+
+	testSnapshot := &snapshot.Snapshot{
+		SchemaName:          "test-schema",
+		TableName:           "test-table",
+		IdentityColumnNames: []string{"id"},
+	}
+
+	errTest := errors.New("oh noes")
+
+	tests := []struct {
+		name           string
+		querier        postgres.Querier
+		schemalogStore schemalogStore
+		snapshot       *snapshot.Snapshot
+
+		wantErr error
+	}{
+		{
+			name: "ok - nothing to snapshot",
+			querier: &postgresmocks.Querier{
+				QueryRowFn: func(ctx context.Context, _ uint, query string, args ...any) postgres.Row {
+					wantQuery := testBatchQuery("")
+					require.Equal(t, wantQuery, query)
+					require.Empty(t, args)
+					return &postgresmocks.Row{
+						ScanFn: func(_ uint, args ...any) error { return postgres.ErrNoRows },
+					}
+				},
+			},
+			schemalogStore: &schemalogmocks.Store{
+				InsertFn: func(ctx context.Context, schemaName string) (*schemalog.LogEntry, error) { return nil, nil },
+			},
+			snapshot: testSnapshot,
+
+			wantErr: nil,
+		},
+		{
+			name: "ok - multiple batches",
+			querier: &postgresmocks.Querier{
+				QueryRowFn: func(ctx context.Context, i uint, query string, args ...any) postgres.Row {
+					var wantQuery string
+					switch i {
+					case 1:
+						wantQuery = testBatchQuery("")
+						require.Equal(t, wantQuery, query)
+						require.Empty(t, args)
+						return &postgresmocks.Row{
+							ScanFn: func(_ uint, args ...any) error {
+								require.Len(t, args, 1)
+								lastValue, ok := args[0].(*string)
+								require.True(t, ok, "type is %T", args[0])
+								*lastValue = "10"
+								return nil
+							},
+						}
+					case 2:
+						wantQuery = testBatchQuery(`WHERE "id" > '10'`)
+						require.Equal(t, wantQuery, query)
+						require.Empty(t, args)
+						return &postgresmocks.Row{
+							ScanFn: func(_ uint, args ...any) error {
+								require.Len(t, args, 1)
+								lastValue, ok := args[0].(*string)
+								require.True(t, ok, "type is %T", args[0])
+								*lastValue = "20"
+								return nil
+							},
+						}
+					case 3:
+						wantQuery = testBatchQuery(`WHERE "id" > '20'`)
+						require.Equal(t, wantQuery, query)
+						require.Empty(t, args)
+						return &postgresmocks.Row{
+							ScanFn: func(_ uint, args ...any) error {
+								return postgres.ErrNoRows
+							},
+						}
+					default:
+						return &postgresmocks.Row{
+							ScanFn: func(_ uint, args ...any) error { return fmt.Errorf("unexpected call to query row: %d", i) },
+						}
+					}
+				},
+			},
+			schemalogStore: &schemalogmocks.Store{
+				InsertFn: func(ctx context.Context, schemaName string) (*schemalog.LogEntry, error) { return nil, nil },
+			},
+			snapshot: testSnapshot,
+
+			wantErr: nil,
+		},
+		{
+			name: "error - invalid snapshot",
+			querier: &postgresmocks.Querier{
+				QueryRowFn: func(ctx context.Context, _ uint, query string, args ...any) postgres.Row {
+					return &postgresmocks.Row{
+						ScanFn: func(_ uint, args ...any) error { return errors.New("QueryRowFn: should not be called") },
+					}
+				},
+			},
+			schemalogStore: &schemalogmocks.Store{
+				InsertFn: func(ctx context.Context, schemaName string) (*schemalog.LogEntry, error) {
+					return nil, errors.New("InsertFn: should not be called")
+				},
+			},
+			snapshot: &snapshot.Snapshot{},
+
+			wantErr: errInvalidSnapshot,
+		},
+		{
+			name: "error - inserting schema log",
+			querier: &postgresmocks.Querier{
+				QueryRowFn: func(ctx context.Context, _ uint, query string, args ...any) postgres.Row {
+					return &postgresmocks.Row{
+						ScanFn: func(_ uint, args ...any) error { return errors.New("QueryRowFn: should not be called") },
+					}
+				},
+			},
+			schemalogStore: &schemalogmocks.Store{
+				InsertFn: func(ctx context.Context, schemaName string) (*schemalog.LogEntry, error) {
+					return nil, errTest
+				},
+			},
+			snapshot: testSnapshot,
+
+			wantErr: errTest,
+		},
+		{
+			name: "error - updating batch",
+			querier: &postgresmocks.Querier{
+				QueryRowFn: func(ctx context.Context, _ uint, query string, args ...any) postgres.Row {
+					wantQuery := testBatchQuery("")
+					require.Equal(t, wantQuery, query)
+					require.Empty(t, args)
+					return &postgresmocks.Row{
+						ScanFn: func(_ uint, args ...any) error { return errTest },
+					}
+				},
+			},
+			schemalogStore: &schemalogmocks.Store{
+				InsertFn: func(ctx context.Context, schemaName string) (*schemalog.LogEntry, error) { return nil, nil },
+			},
+			snapshot: testSnapshot,
+
+			wantErr: errTest,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			generator := SnapshotGenerator{
+				batchSize:      10,
+				conn:           tc.querier,
+				schemalogStore: tc.schemalogStore,
+			}
+			err := generator.CreateSnapshot(context.Background(), tc.snapshot)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}

--- a/pkg/snapshot/generator/snapshot_generator.go
+++ b/pkg/snapshot/generator/snapshot_generator.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package generator
+
+import (
+	"context"
+
+	"github.com/xataio/pgstream/pkg/snapshot"
+)
+
+type Generator interface {
+	CreateSnapshot(ctx context.Context, snapshot *snapshot.Snapshot) error
+	Close(ctx context.Context) error
+}

--- a/pkg/wal/replication/postgres/pg_replication_handler_test.go
+++ b/pkg/wal/replication/postgres/pg_replication_handler_test.go
@@ -50,7 +50,7 @@ func TestHandler_StartReplication(t *testing.T) {
 			},
 			connBuilder: func() (pglib.Querier, error) {
 				return &pgmocks.Querier{
-					QueryRowFn: func(ctx context.Context, query string, args ...any) pglib.Row {
+					QueryRowFn: func(ctx context.Context, _ uint, query string, args ...any) pglib.Row {
 						require.Len(t, args, 1)
 						require.Equal(t, args[0], testSlot)
 						switch query {
@@ -91,7 +91,7 @@ func TestHandler_StartReplication(t *testing.T) {
 			},
 			connBuilder: func() (pglib.Querier, error) {
 				return &pgmocks.Querier{
-					QueryRowFn: func(ctx context.Context, query string, args ...any) pglib.Row {
+					QueryRowFn: func(ctx context.Context, _ uint, query string, args ...any) pglib.Row {
 						require.Len(t, args, 1)
 						require.Equal(t, args[0], testSlot)
 						switch query {
@@ -132,7 +132,7 @@ func TestHandler_StartReplication(t *testing.T) {
 			},
 			connBuilder: func() (pglib.Querier, error) {
 				return &pgmocks.Querier{
-					QueryRowFn: func(ctx context.Context, query string, args ...any) pglib.Row {
+					QueryRowFn: func(ctx context.Context, _ uint, query string, args ...any) pglib.Row {
 						require.Len(t, args, 1)
 						require.Equal(t, args[0], defaultSlot)
 						switch query {
@@ -190,7 +190,7 @@ func TestHandler_StartReplication(t *testing.T) {
 			},
 			connBuilder: func() (pglib.Querier, error) {
 				return &pgmocks.Querier{
-					QueryRowFn: func(ctx context.Context, query string, args ...any) pglib.Row {
+					QueryRowFn: func(ctx context.Context, _ uint, query string, args ...any) pglib.Row {
 						require.Len(t, args, 1)
 						require.Equal(t, args[0], testSlot)
 						switch query {
@@ -219,7 +219,7 @@ func TestHandler_StartReplication(t *testing.T) {
 			},
 			connBuilder: func() (pglib.Querier, error) {
 				return &pgmocks.Querier{
-					QueryRowFn: func(ctx context.Context, query string, args ...any) pglib.Row {
+					QueryRowFn: func(ctx context.Context, _ uint, query string, args ...any) pglib.Row {
 						require.Len(t, args, 1)
 						require.Equal(t, args[0], testSlot)
 						switch query {
@@ -253,7 +253,7 @@ func TestHandler_StartReplication(t *testing.T) {
 			},
 			connBuilder: func() (pglib.Querier, error) {
 				return &pgmocks.Querier{
-					QueryRowFn: func(ctx context.Context, query string, args ...any) pglib.Row {
+					QueryRowFn: func(ctx context.Context, _ uint, query string, args ...any) pglib.Row {
 						require.Len(t, args, 1)
 						require.Equal(t, args[0], testSlot)
 						switch query {
@@ -291,7 +291,7 @@ func TestHandler_StartReplication(t *testing.T) {
 			},
 			connBuilder: func() (pglib.Querier, error) {
 				return &pgmocks.Querier{
-					QueryRowFn: func(ctx context.Context, query string, args ...any) pglib.Row {
+					QueryRowFn: func(ctx context.Context, _ uint, query string, args ...any) pglib.Row {
 						require.Len(t, args, 1)
 						require.Equal(t, args[0], testSlot)
 						switch query {
@@ -419,7 +419,7 @@ func TestHandler_GetReplicationLag(t *testing.T) {
 			name: "ok",
 			connBuilder: func() (pglib.Querier, error) {
 				return &pgmocks.Querier{
-					QueryRowFn: func(ctx context.Context, query string, args ...any) pglib.Row {
+					QueryRowFn: func(ctx context.Context, _ uint, query string, args ...any) pglib.Row {
 						require.Len(t, args, 1)
 						require.Equal(t, args[0], testSlot)
 						switch query {
@@ -449,7 +449,7 @@ func TestHandler_GetReplicationLag(t *testing.T) {
 			name: "error - getting lag",
 			connBuilder: func() (pglib.Querier, error) {
 				return &pgmocks.Querier{
-					QueryRowFn: func(ctx context.Context, query string, args ...any) pglib.Row {
+					QueryRowFn: func(ctx context.Context, _ uint, query string, args ...any) pglib.Row {
 						return &mockRow{scanFn: func(args ...any) error { return errTest }}
 					},
 					CloseFn: func(ctx context.Context) error { return nil },


### PR DESCRIPTION
This PR adds a snapshot generator, which touches all rows of the table to be snapshoted in batches, triggering replication WAL events for all rows that will then sync the data downstream.

The functionality used for snapshoting is naive, similar to what's currently done during the backfilling stage of [pgroll](https://github.com/xataio/pgroll/blob/main/pkg/migrations/backfill.go).

The snapshot generator is an individual component that will be used by follow up PRs.

Relates to https://github.com/xataio/pgstream/issues/80.
