### PR TITLE
Allow providing replication slot on the CLI

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -41,6 +41,14 @@ func pgURL() string {
 	return viper.GetString("PGSTREAM_POSTGRES_LISTENER_URL")
 }
 
+func replicationSlotName() string {
+	replicationslot := viper.GetString("replication-slot")
+	if replicationslot != "" {
+		return replicationslot
+	}
+	return viper.GetString("PGSTREAM_POSTGRES_REPLICATION_SLOT_NAME")
+}
+
 func parseStreamConfig() *stream.Config {
 	return &stream.Config{
 		Listener:  parseListenerConfig(),
@@ -65,7 +73,8 @@ func parsePostgresListenerConfig() *stream.PostgresListenerConfig {
 
 	return &stream.PostgresListenerConfig{
 		Replication: pgreplication.Config{
-			PostgresURL: pgURL,
+			PostgresURL:         pgURL,
+			ReplicationSlotName: replicationSlotName(),
 		},
 	}
 }

--- a/cmd/init_cmd.go
+++ b/cmd/init_cmd.go
@@ -18,7 +18,7 @@ var initCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sp, _ := pterm.DefaultSpinner.WithText("initialising pgstream...").Start()
 
-		if err := stream.Init(context.Background(), pgURL()); err != nil {
+		if err := stream.Init(context.Background(), pgURL(), replicationSlotName()); err != nil {
 			sp.Fail(err.Error())
 			return err
 		}
@@ -34,7 +34,7 @@ var tearDownCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sp, _ := pterm.DefaultSpinner.WithText("tearing down pgstream...").Start()
 
-		if err := stream.TearDown(context.Background(), pgURL()); err != nil {
+		if err := stream.TearDown(context.Background(), pgURL(), replicationSlotName()); err != nil {
 			sp.Fail(err.Error())
 			return err
 		}

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -22,10 +22,12 @@ func init() {
 	viper.AutomaticEnv()
 
 	rootCmd.PersistentFlags().String("pgurl", "postgres://postgres:postgres@localhost?sslmode=disable", "Postgres URL")
+	rootCmd.PersistentFlags().String("replication-slot", "", "Name of the postgres replication slot to be created")
 	rootCmd.PersistentFlags().StringP("config", "c", "", ".env config file to use if any")
 	rootCmd.PersistentFlags().String("log-level", "debug", "log level for the application")
 
 	viper.BindPFlag("pgurl", rootCmd.PersistentFlags().Lookup("pgurl"))
+	viper.BindPFlag("replication-slot", rootCmd.PersistentFlags().Lookup("replication-slot"))
 	viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
 	viper.BindPFlag("PGSTREAM_LOG_LEVEL", rootCmd.PersistentFlags().Lookup("log-level"))
 }

--- a/pkg/stream/integration/setup_test.go
+++ b/pkg/stream/integration/setup_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 		}
 		defer pgcleanup()
 
-		if err := stream.Init(ctx, pgurl); err != nil {
+		if err := stream.Init(ctx, pgurl, ""); err != nil {
 			log.Fatal(err)
 		}
 


### PR DESCRIPTION
The pgstream library already provides the ability to override the replication slot name. This PR adds the plumbing to allow setting it from the CLI.