### PR TITLE
Fix deadlock under load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ bin/license-header-checker
 pgstream
 tools/webhook/webhook
 
+coverage
+
 # misc
 .DS_Store


### PR DESCRIPTION
Currently the processor implementations can deadlock under heavy load, if the batch send error channel doesn't get a chance to notify before the send go routine tries to send messages into the batch channel. This causes a situation where the send error channel is not checked because the for select is blocked trying to write, but the send error causes the reader of the unbuffered channel to stop, which makes it block on writes. 

Additionally, when the send go routine ends due to an error, the process will block when trying to enqueue the messages to be sent, since there are no readers for the channel.

In order to solve the first problem, the batch drain is done adding a check for the send errors. The second problem is fixed by adding a done channel to communicate to the processing when the background sending has ended unexpectedly, to prevent deadlock on processing. 

Unit tests are added to cover this code path for all processors.