### PR TITLE
Update snapshot store

### DIFF
--- a/pkg/snapshot/errors.go
+++ b/pkg/snapshot/errors.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package snapshot
+
+import "errors"
+
+type Errors struct {
+	Snapshot error        `json:"snapshot,omitempty"`
+	Tables   []TableError `json:"tables,omitempty"`
+}
+
+type TableError struct {
+	Table    string `json:"table"`
+	ErrorMsg string `json:"error"`
+}
+
+func (e *Errors) Error() string {
+	var err error
+	if e.Snapshot != nil {
+		err = e.Snapshot
+	}
+
+	for _, table := range e.Tables {
+		if err == nil {
+			err = table
+			continue
+		}
+		err = errors.Join(err, table)
+	}
+	return err.Error()
+}
+
+func (e *Errors) IsTableError(table string) bool {
+	if e == nil {
+		return false
+	}
+
+	if e.Snapshot != nil {
+		return true
+	}
+
+	// treat wildcard table errors as true if there are any table errors.
+	if table == "*" && len(e.Tables) > 0 {
+		return true
+	}
+
+	for _, tableErr := range e.Tables {
+		if tableErr.Table == table {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *Errors) GetFailedTables() []string {
+	if e == nil {
+		return nil
+	}
+	failedTables := make([]string, 0, len(e.Tables))
+	for _, table := range e.Tables {
+		failedTables = append(failedTables, table.Table)
+	}
+	return failedTables
+}
+
+func NewTableError(table string, err error) TableError {
+	errMsg := ""
+	if err != nil {
+		errMsg = err.Error()
+	}
+	return TableError{Table: table, ErrorMsg: errMsg}
+}
+
+func (e TableError) Error() string {
+	return "snapshot error for table " + e.Table + ": " + e.ErrorMsg
+}

--- a/pkg/snapshot/store/mocks/mock_snapshot_store.go
+++ b/pkg/snapshot/store/mocks/mock_snapshot_store.go
@@ -9,19 +9,28 @@ import (
 )
 
 type Store struct {
-	CreateSnapshotRequestFn func(context.Context, *snapshot.Snapshot) error
-	UpdateSnapshotRequestFn func(context.Context, *snapshot.Snapshot) error
-	GetSnapshotRequestsFn   func(ctx context.Context, status snapshot.Status) ([]*snapshot.Snapshot, error)
+	CreateSnapshotRequestFn       func(context.Context, *snapshot.Request) error
+	UpdateSnapshotRequestFn       func(context.Context, *snapshot.Request) error
+	GetSnapshotRequestsByStatusFn func(ctx context.Context, status snapshot.Status) ([]*snapshot.Request, error)
+	GetSnapshotRequestsBySchemaFn func(ctx context.Context, s string) ([]*snapshot.Request, error)
 }
 
-func (m *Store) CreateSnapshotRequest(ctx context.Context, s *snapshot.Snapshot) error {
+func (m *Store) CreateSnapshotRequest(ctx context.Context, s *snapshot.Request) error {
 	return m.CreateSnapshotRequestFn(ctx, s)
 }
 
-func (m *Store) UpdateSnapshotRequest(ctx context.Context, s *snapshot.Snapshot) error {
+func (m *Store) UpdateSnapshotRequest(ctx context.Context, s *snapshot.Request) error {
 	return m.UpdateSnapshotRequestFn(ctx, s)
 }
 
-func (m *Store) GetSnapshotRequests(ctx context.Context, status snapshot.Status) ([]*snapshot.Snapshot, error) {
-	return m.GetSnapshotRequestsFn(ctx, status)
+func (m *Store) GetSnapshotRequestsByStatus(ctx context.Context, status snapshot.Status) ([]*snapshot.Request, error) {
+	return m.GetSnapshotRequestsByStatusFn(ctx, status)
+}
+
+func (m *Store) GetSnapshotRequestsBySchema(ctx context.Context, s string) ([]*snapshot.Request, error) {
+	return m.GetSnapshotRequestsBySchemaFn(ctx, s)
+}
+
+func (m *Store) Close() error {
+	return nil
 }

--- a/pkg/snapshot/store/postgres/pg_snapshot_store.go
+++ b/pkg/snapshot/store/postgres/pg_snapshot_store.go
@@ -18,7 +18,7 @@ type Store struct {
 
 const queryLimit = 1000
 
-func NewStore(ctx context.Context, url string) (*Store, error) {
+func New(ctx context.Context, url string) (*Store, error) {
 	conn, err := postgres.NewConnPool(ctx, url)
 	if err != nil {
 		return nil, err
@@ -40,69 +40,86 @@ func (s *Store) Close() error {
 	return s.conn.Close(context.Background())
 }
 
-func (s *Store) CreateSnapshotRequest(ctx context.Context, req *snapshot.Snapshot) error {
-	query := fmt.Sprintf(`INSERT INTO %s (schema_name, table_name, identity_column_names, created_at, updated_at, status)
-	VALUES($1, $2, $3,'now()','now()','requested')`, snapshotsTable())
-	_, err := s.conn.Exec(ctx, query, req.SchemaName, req.TableName, pq.StringArray(req.IdentityColumnNames))
+func (s *Store) CreateSnapshotRequest(ctx context.Context, req *snapshot.Request) error {
+	query := fmt.Sprintf(`INSERT INTO %s (schema_name, table_names, created_at, updated_at, status)
+	VALUES($1, $2,'now()','now()','requested')`, snapshotsTable())
+	_, err := s.conn.Exec(ctx, query, req.Snapshot.SchemaName, pq.StringArray(req.Snapshot.TableNames))
 	if err != nil {
 		return fmt.Errorf("error creating snapshot request: %w", err)
 	}
 	return nil
 }
 
-func (s *Store) UpdateSnapshotRequest(ctx context.Context, req *snapshot.Snapshot) error {
-	errStr := ""
-	if req.Error != nil {
-		errStr = req.Error.Error()
-	}
-	query := fmt.Sprintf(`UPDATE %s SET status = '%s', error = '%s', updated_at = 'now()'
-	WHERE schema_name = '%s' and table_name = '%s' and status != 'completed'`, snapshotsTable(), req.Status, errStr, req.SchemaName, req.TableName)
-	_, err := s.conn.Exec(ctx, query)
+func (s *Store) UpdateSnapshotRequest(ctx context.Context, req *snapshot.Request) error {
+	query := fmt.Sprintf(`UPDATE %s SET status = $1, errors = $2, updated_at = 'now()'
+	WHERE schema_name = $3 and table_names = $4 and status != 'completed'`, snapshotsTable())
+	_, err := s.conn.Exec(ctx, query, req.Status, req.Errors, req.Snapshot.SchemaName, pq.StringArray(req.Snapshot.TableNames))
 	if err != nil {
 		return fmt.Errorf("error updating snapshot request: %w", err)
 	}
 	return nil
 }
 
-func (s *Store) GetSnapshotRequests(ctx context.Context, status snapshot.Status) ([]*snapshot.Snapshot, error) {
-	query := fmt.Sprintf(`SELECT schema_name,table_name,identity_column_names,status FROM %s
+func (s *Store) GetSnapshotRequestsByStatus(ctx context.Context, status snapshot.Status) ([]*snapshot.Request, error) {
+	query := fmt.Sprintf(`SELECT schema_name,table_names,status,errors FROM %s
 	WHERE status = '%s' ORDER BY req_id ASC LIMIT %d`, snapshotsTable(), status, queryLimit)
 	rows, err := s.conn.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("error getting snapshot requests by status: %w", err)
+	}
+	defer rows.Close()
+
+	snapshotRequests := []*snapshot.Request{}
+	for rows.Next() {
+		req := &snapshot.Request{}
+		if err := rows.Scan(&req.Snapshot.SchemaName, &req.Snapshot.TableNames, &req.Status, &req.Errors); err != nil {
+			return nil, fmt.Errorf("scanning snapshot row: %w", err)
+		}
+
+		snapshotRequests = append(snapshotRequests, req)
+	}
+
+	return snapshotRequests, nil
+}
+
+func (s *Store) GetSnapshotRequestsBySchema(ctx context.Context, schema string) ([]*snapshot.Request, error) {
+	query := fmt.Sprintf(`SELECT schema_name,table_names,status,errors FROM %s
+	WHERE schema_name = $1 ORDER BY req_id ASC LIMIT %d`, snapshotsTable(), queryLimit)
+	rows, err := s.conn.Query(ctx, query, schema)
 	if err != nil {
 		return nil, fmt.Errorf("error getting snapshot requests: %w", err)
 	}
 	defer rows.Close()
 
-	snapshots := []*snapshot.Snapshot{}
+	snapshotRequests := []*snapshot.Request{}
 	for rows.Next() {
-		snapshot := &snapshot.Snapshot{}
-		if err := rows.Scan(&snapshot.SchemaName, &snapshot.TableName, &snapshot.IdentityColumnNames, &snapshot.Status); err != nil {
-			return nil, fmt.Errorf("scanning snapshot row: %w", err)
+		req := &snapshot.Request{}
+		if err := rows.Scan(&req.Snapshot.SchemaName, &req.Snapshot.TableNames, &req.Status, &req.Errors); err != nil {
+			return nil, fmt.Errorf("scanning snapshot request row: %w", err)
 		}
 
-		snapshots = append(snapshots, snapshot)
+		snapshotRequests = append(snapshotRequests, req)
 	}
 
-	return snapshots, nil
+	return snapshotRequests, nil
 }
 
 func (s *Store) createTable(ctx context.Context) error {
 	createQuery := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s(
 	req_id SERIAL PRIMARY KEY,
 	schema_name TEXT,
-	table_name TEXT,
-	identity_column_names TEXT[],
+	table_names TEXT[],
 	created_at TIMESTAMP WITH TIME ZONE,
 	updated_at TIMESTAMP WITH TIME ZONE,
 	status TEXT CHECK (status IN ('requested', 'in progress', 'completed')),
-	error TEXT )`, snapshotsTable())
+	errors JSONB )`, snapshotsTable())
 	_, err := s.conn.Exec(ctx, createQuery)
 	if err != nil {
 		return fmt.Errorf("error creating snapshots postgres table: %w", err)
 	}
 
 	uniqueIndexQuery := fmt.Sprintf(`CREATE UNIQUE INDEX IF NOT EXISTS schema_table_status_unique_index
-	ON %s(schema_name,table_name) WHERE status != 'completed'`, snapshotsTable())
+	ON %s(schema_name,table_names) WHERE status != 'completed'`, snapshotsTable())
 	_, err = s.conn.Exec(ctx, uniqueIndexQuery)
 	if err != nil {
 		return fmt.Errorf("error creating unique index on snapshots postgres table: %w", err)

--- a/pkg/snapshot/store/snapshot_store.go
+++ b/pkg/snapshot/store/snapshot_store.go
@@ -9,9 +9,11 @@ import (
 )
 
 type Store interface {
-	CreateSnapshotRequest(context.Context, *snapshot.Snapshot) error
-	UpdateSnapshotRequest(context.Context, *snapshot.Snapshot) error
-	GetSnapshotRequests(ctx context.Context, status snapshot.Status) ([]*snapshot.Snapshot, error)
+	CreateSnapshotRequest(context.Context, *snapshot.Request) error
+	UpdateSnapshotRequest(context.Context, *snapshot.Request) error
+	GetSnapshotRequestsByStatus(ctx context.Context, status snapshot.Status) ([]*snapshot.Request, error)
+	GetSnapshotRequestsBySchema(ctx context.Context, schema string) ([]*snapshot.Request, error)
+	Close() error
 }
 
 const (


### PR DESCRIPTION
This PR updates the existing snapshot store, since it was initially designed to work with the backfilling approach which required identity columns. Since we will no longer rely on a primary key/unique column to produce the snapshot, it can be removed. Additionally, the snapshot structs have been refined, separating the snapshot request, and including a more thorough recording of snapshot errors at snapshot/table level, which will be helpful to retry failed snapshots for only the affected relations. 
A new method to retrieve snapshot requests by schema is added.
