### PR TITLE
Update internal pg lib

### DIFF
--- a/internal/postgres/mocks/mock_pg_querier.go
+++ b/internal/postgres/mocks/mock_pg_querier.go
@@ -4,17 +4,20 @@ package mocks
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/xataio/pgstream/internal/postgres"
 )
 
 type Querier struct {
-	QueryRowFn func(ctx context.Context, query string, args ...any) postgres.Row
-	QueryFn    func(ctx context.Context, query string, args ...any) (postgres.Rows, error)
-	ExecFn     func(context.Context, uint, string, ...any) (postgres.CommandTag, error)
-	ExecInTxFn func(context.Context, func(tx postgres.Tx) error) error
-	CloseFn    func(context.Context) error
-	execCalls  uint
+	QueryRowFn               func(ctx context.Context, query string, args ...any) postgres.Row
+	QueryFn                  func(ctx context.Context, query string, args ...any) (postgres.Rows, error)
+	ExecFn                   func(context.Context, uint, string, ...any) (postgres.CommandTag, error)
+	ExecInTxFn               func(context.Context, func(tx postgres.Tx) error) error
+	ExecInTxWithOptionsFn    func(context.Context, uint, func(tx postgres.Tx) error, postgres.TxOptions) error
+	CloseFn                  func(context.Context) error
+	execCalls                uint32
+	execInTxWithOptionsCalls uint32
 }
 
 func (m *Querier) QueryRow(ctx context.Context, query string, args ...any) postgres.Row {
@@ -26,12 +29,17 @@ func (m *Querier) Query(ctx context.Context, query string, args ...any) (postgre
 }
 
 func (m *Querier) Exec(ctx context.Context, query string, args ...any) (postgres.CommandTag, error) {
-	m.execCalls++
-	return m.ExecFn(ctx, m.execCalls, query, args...)
+	atomic.AddUint32(&m.execCalls, 1)
+	return m.ExecFn(ctx, uint(atomic.LoadUint32(&m.execCalls)), query, args...)
 }
 
 func (m *Querier) ExecInTx(ctx context.Context, fn func(tx postgres.Tx) error) error {
 	return m.ExecInTxFn(ctx, fn)
+}
+
+func (m *Querier) ExecInTxWithOptions(ctx context.Context, fn func(tx postgres.Tx) error, opts postgres.TxOptions) error {
+	atomic.AddUint32(&m.execInTxWithOptionsCalls, 1)
+	return m.ExecInTxWithOptionsFn(ctx, uint(atomic.LoadUint32(&m.execInTxWithOptionsCalls)), fn, opts)
 }
 
 func (m *Querier) Close(ctx context.Context) error {

--- a/internal/postgres/mocks/mock_row.go
+++ b/internal/postgres/mocks/mock_row.go
@@ -7,5 +7,5 @@ type Row struct {
 }
 
 func (m *Row) Scan(args ...any) error {
-	return m.ScanFn(args)
+	return m.ScanFn(args...)
 }

--- a/internal/postgres/mocks/mock_tx.go
+++ b/internal/postgres/mocks/mock_tx.go
@@ -15,13 +15,13 @@ type Tx struct {
 }
 
 func (m *Tx) QueryRow(ctx context.Context, query string, args ...any) postgres.Row {
-	return m.QueryRowFn(ctx, query, args)
+	return m.QueryRowFn(ctx, query, args...)
 }
 
 func (m *Tx) Query(ctx context.Context, query string, args ...any) (postgres.Rows, error) {
-	return m.QueryFn(ctx, query, args)
+	return m.QueryFn(ctx, query, args...)
 }
 
 func (m *Tx) Exec(ctx context.Context, query string, args ...any) (postgres.CommandTag, error) {
-	return m.ExecFn(ctx, query, args)
+	return m.ExecFn(ctx, query, args...)
 }

--- a/internal/postgres/pg_conn.go
+++ b/internal/postgres/pg_conn.go
@@ -43,7 +43,11 @@ func (c *Conn) Exec(ctx context.Context, query string, args ...any) (CommandTag,
 }
 
 func (c *Conn) ExecInTx(ctx context.Context, fn func(Tx) error) error {
-	tx, err := c.conn.BeginTx(ctx, pgx.TxOptions{})
+	return c.ExecInTxWithOptions(ctx, fn, TxOptions{})
+}
+
+func (c *Conn) ExecInTxWithOptions(ctx context.Context, fn func(Tx) error, opts TxOptions) error {
+	tx, err := c.conn.BeginTx(ctx, toTxOptions(opts))
 	if err != nil {
 		return mapError(err)
 	}

--- a/internal/postgres/pg_conn_pool.go
+++ b/internal/postgres/pg_conn_pool.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -44,7 +43,11 @@ func (c *Pool) Exec(ctx context.Context, query string, args ...any) (CommandTag,
 }
 
 func (c *Pool) ExecInTx(ctx context.Context, fn func(Tx) error) error {
-	tx, err := c.Pool.BeginTx(ctx, pgx.TxOptions{})
+	return c.ExecInTxWithOptions(ctx, fn, TxOptions{})
+}
+
+func (c *Pool) ExecInTxWithOptions(ctx context.Context, fn func(Tx) error, opts TxOptions) error {
+	tx, err := c.Pool.BeginTx(ctx, toTxOptions(opts))
 	if err != nil {
 		return mapError(err)
 	}

--- a/internal/postgres/pg_mapper.go
+++ b/internal/postgres/pg_mapper.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import "github.com/jackc/pgx/v5/pgtype"
+
+type Mapper struct {
+	pgMap *pgtype.Map
+}
+
+func NewMapper() *Mapper {
+	return &Mapper{
+		pgMap: pgtype.NewMap(),
+	}
+}
+
+func (m *Mapper) TypeForOID(oid uint32) string {
+	dataType, found := m.pgMap.TypeForOID(oid)
+	if !found {
+		return ""
+	}
+	return dataType.Name
+}

--- a/internal/postgres/pg_querier.go
+++ b/internal/postgres/pg_querier.go
@@ -14,6 +14,7 @@ type Querier interface {
 	QueryRow(ctx context.Context, query string, args ...any) Row
 	Exec(ctx context.Context, query string, args ...any) (CommandTag, error)
 	ExecInTx(ctx context.Context, fn func(tx Tx) error) error
+	ExecInTxWithOptions(ctx context.Context, fn func(tx Tx) error, txOpts TxOptions) error
 	Close(ctx context.Context) error
 }
 

--- a/internal/postgres/pg_tx.go
+++ b/internal/postgres/pg_tx.go
@@ -8,6 +8,27 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
+type TxIsolationLevel string
+
+const (
+	Serializable    TxIsolationLevel = "serializable"
+	RepeatableRead  TxIsolationLevel = "repeatable read"
+	ReadCommitted   TxIsolationLevel = "read committed"
+	ReadUncommitted TxIsolationLevel = "read uncommitted"
+)
+
+type TxAccessMode string
+
+const (
+	ReadWrite TxAccessMode = "read write"
+	ReadOnly  TxAccessMode = "read only"
+)
+
+type TxOptions struct {
+	IsolationLevel TxIsolationLevel
+	AccessMode     TxAccessMode
+}
+
 type Txn struct {
 	pgx.Tx
 }
@@ -25,4 +46,11 @@ func (t *Txn) Query(ctx context.Context, query string, args ...any) (Rows, error
 func (t *Txn) Exec(ctx context.Context, query string, args ...any) (CommandTag, error) {
 	tag, err := t.Tx.Exec(ctx, query, args...)
 	return CommandTag{tag}, mapError(err)
+}
+
+func toTxOptions(opts TxOptions) pgx.TxOptions {
+	return pgx.TxOptions{
+		IsoLevel:   pgx.TxIsoLevel(opts.IsolationLevel),
+		AccessMode: pgx.TxAccessMode(opts.AccessMode),
+	}
 }


### PR DESCRIPTION
This PR updates the internal postgres library to support executing within a transaction providing transaction options. This will be required by the snapshoting implementation, since we'll need to set the options to repeatable read/read only. 