### PR TITLE
Make processors concurrency safe

### DIFF
--- a/pkg/wal/processor/kafka/wal_kafka_batch_writer_test.go
+++ b/pkg/wal/processor/kafka/wal_kafka_batch_writer_test.go
@@ -190,6 +190,7 @@ func TestBatchKafkaWriter_ProcessWALEvent(t *testing.T) {
 				queueBytesSema: semaphore.NewWeighted(defaultMaxQueueBytes),
 				serialiser:     mockMarshaler,
 				sendDone:       make(chan error, 1),
+				once:           &sync.Once{},
 			}
 
 			if tc.semaphore != nil {
@@ -201,7 +202,7 @@ func TestBatchKafkaWriter_ProcessWALEvent(t *testing.T) {
 			}
 
 			go func() {
-				defer close(writer.msgChan)
+				defer writer.closeMsgChan()
 				err := writer.ProcessWALEvent(context.Background(), tc.walEvent)
 				if !errors.Is(err, tc.wantErr) {
 					require.Equal(t, err.Error(), tc.wantErr.Error())
@@ -535,6 +536,7 @@ func TestBatchKafkaWriter(t *testing.T) {
 		sendFrequency:  time.Second,
 		sendDone:       make(chan error, 1),
 		serialiser:     json.Marshal,
+		once:           &sync.Once{},
 	}
 
 	doneChan := make(chan struct{}, 1)

--- a/pkg/wal/processor/search/search_batch_indexer_test.go
+++ b/pkg/wal/processor/search/search_batch_indexer_test.go
@@ -205,13 +205,14 @@ func TestBatchIndexer_ProcessWALEvent(t *testing.T) {
 				msgChan:        make(chan *msg, 100),
 				adapter:        tc.adapter,
 				sendDone:       make(chan error, 1),
+				once:           &sync.Once{},
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
 			go func() {
-				defer close(indexer.msgChan)
+				defer indexer.closeMsgChan()
 				err := indexer.ProcessWALEvent(ctx, tc.event)
 				require.ErrorIs(t, err, tc.wantErr)
 			}()
@@ -349,6 +350,7 @@ func TestBatchIndexer_Send(t *testing.T) {
 					ReleaseFn: func(_ uint64, _ int64) {},
 				},
 				sendDone: make(chan error, 1),
+				once:     &sync.Once{},
 			}
 
 			if tc.semaphore != nil {
@@ -710,6 +712,7 @@ func TestBatchIndexer(t *testing.T) {
 		skipSchema:        func(schemaName string) bool { return false },
 		queueBytesSema:    semaphore.NewWeighted(defaultMaxQueueBytes),
 		sendDone:          make(chan error, 1),
+		once:              &sync.Once{},
 	}
 
 	doneChan := make(chan struct{}, 1)

--- a/pkg/wal/processor/webhook/notifier/webhook_notifier_test.go
+++ b/pkg/wal/processor/webhook/notifier/webhook_notifier_test.go
@@ -169,7 +169,7 @@ func TestNotifier_ProcessWALEvent(t *testing.T) {
 			go func() {
 				err := n.ProcessWALEvent(context.Background(), tc.event)
 				require.ErrorIs(t, err, tc.wantErr)
-				close(n.notifyChan)
+				n.closeNotifyChan()
 			}()
 
 			msgs := []*notifyMsg{}


### PR DESCRIPTION
This PR updates the existing processors to ensure they are safe to be called concurrently. The initial snapshot generator will call the process from multiple parallel workers, so this makes sure there are no race conditions or unexpected errors.

The main change is to ensure once the send thread is done, that any running go routines don't block waiting to write to a channel that would have no readers. Once the send thread terminates, it communicates the error if any to the send done channel, and closes it, allowing any parallel workers to flag the processing needs to stop.