### PR TITLE
Add support to provide LSN

### DIFF
--- a/pkg/wal/replication/instrumentation/instrumented_replication_handler.go
+++ b/pkg/wal/replication/instrumentation/instrumented_replication_handler.go
@@ -47,6 +47,10 @@ func (h *Handler) StartReplication(ctx context.Context) error {
 	return h.inner.StartReplication(ctx)
 }
 
+func (h *Handler) StartReplicationFromLSN(ctx context.Context, lsn replication.LSN) error {
+	return h.inner.StartReplicationFromLSN(ctx, lsn)
+}
+
 func (h *Handler) ReceiveMessage(ctx context.Context) (msg *replication.Message, err error) {
 	ctx, span := otel.StartSpan(ctx, h.tracer, "replicationhandler.ReceiveMessage")
 	defer otel.CloseSpan(span, err)
@@ -61,6 +65,10 @@ func (h *Handler) SyncLSN(ctx context.Context, lsn replication.LSN) (err error) 
 
 func (h *Handler) GetReplicationLag(ctx context.Context) (int64, error) {
 	return h.inner.GetReplicationLag(ctx)
+}
+
+func (h *Handler) GetCurrentLSN(ctx context.Context) (replication.LSN, error) {
+	return h.inner.GetCurrentLSN(ctx)
 }
 
 func (h *Handler) GetLSNParser() replication.LSNParser {

--- a/pkg/wal/replication/mocks/mock_replication_handler.go
+++ b/pkg/wal/replication/mocks/mock_replication_handler.go
@@ -10,18 +10,24 @@ import (
 )
 
 type Handler struct {
-	StartReplicationFn    func(context.Context) error
-	ReceiveMessageFn      func(context.Context, uint64) (*replication.Message, error)
-	SyncLSNFn             func(context.Context, replication.LSN) error
-	DropReplicationSlotFn func(ctx context.Context) error
-	GetLSNParserFn        func() replication.LSNParser
-	CloseFn               func() error
-	SyncLSNCalls          uint64
-	ReceiveMessageCalls   uint64
+	StartReplicationFn        func(context.Context) error
+	StartReplicationFromLSNFn func(context.Context, replication.LSN) error
+	ReceiveMessageFn          func(context.Context, uint64) (*replication.Message, error)
+	SyncLSNFn                 func(context.Context, replication.LSN) error
+	DropReplicationSlotFn     func(ctx context.Context) error
+	GetLSNParserFn            func() replication.LSNParser
+	GetCurrentLSNFn           func(context.Context) (replication.LSN, error)
+	CloseFn                   func() error
+	SyncLSNCalls              uint64
+	ReceiveMessageCalls       uint64
 }
 
 func (m *Handler) StartReplication(ctx context.Context) error {
 	return m.StartReplicationFn(ctx)
+}
+
+func (m *Handler) StartReplicationFromLSN(ctx context.Context, lsn replication.LSN) error {
+	return m.StartReplicationFromLSNFn(ctx, lsn)
 }
 
 func (m *Handler) ReceiveMessage(ctx context.Context) (*replication.Message, error) {
@@ -36,6 +42,10 @@ func (m *Handler) SyncLSN(ctx context.Context, lsn replication.LSN) error {
 
 func (m *Handler) DropReplicationSlot(ctx context.Context) error {
 	return m.DropReplicationSlotFn(ctx)
+}
+
+func (m *Handler) GetCurrentLSN(ctx context.Context) (replication.LSN, error) {
+	return m.GetCurrentLSNFn(ctx)
 }
 
 func (m *Handler) GetLSNParser() replication.LSNParser {

--- a/pkg/wal/replication/postgres/pg_replication_handler_test.go
+++ b/pkg/wal/replication/postgres/pg_replication_handler_test.go
@@ -18,8 +18,6 @@ import (
 func TestHandler_StartReplication(t *testing.T) {
 	t.Parallel()
 
-	defaultSlot := fmt.Sprintf("pgstream_%s_slot", testDBName)
-
 	tests := []struct {
 		name            string
 		replicationConn pgReplicationConn
@@ -109,57 +107,6 @@ func TestHandler_StartReplication(t *testing.T) {
 			slotName: testSlot,
 
 			wantErr: nil,
-		},
-		{
-			name: "ok - with default slot name",
-			replicationConn: &pgmocks.ReplicationConn{
-				IdentifySystemFn: func(ctx context.Context) (pglib.IdentifySystemResult, error) {
-					return pglib.IdentifySystemResult{
-						DBName:   testDBName,
-						SystemID: "tes-sys-id",
-					}, nil
-				},
-				StartReplicationFn: func(ctx context.Context, cfg pglib.ReplicationConfig) error {
-					require.Equal(t, testLSN, cfg.StartPos)
-					require.Equal(t, defaultSlot, cfg.SlotName)
-					require.Equal(t, pluginArguments, cfg.PluginArguments)
-					return nil
-				},
-				SendStandbyStatusUpdateFn: func(ctx context.Context, lsn uint64) error {
-					require.Equal(t, testLSN, lsn)
-					return nil
-				},
-			},
-			connBuilder: func() (pglib.Querier, error) {
-				return &pgmocks.Querier{
-					QueryRowFn: func(ctx context.Context, query string, args ...any) pglib.Row {
-						require.Len(t, args, 1)
-						require.Equal(t, args[0], defaultSlot)
-						switch query {
-						case "select restart_lsn from pg_replication_slots where slot_name=$1":
-							return &mockRow{scanFn: func(args ...any) error { return errors.New("restart lsn should not be called") }}
-						case "select confirmed_flush_lsn from pg_replication_slots where slot_name=$1":
-							return &mockRow{lsn: testLSNStr}
-						default:
-							return &mockRow{scanFn: func(args ...any) error { return fmt.Errorf("unexpected query: %s", query) }}
-						}
-					},
-					CloseFn: func(ctx context.Context) error { return nil },
-				}, nil
-			},
-
-			wantErr: nil,
-		},
-		{
-			name: "error - identifying system",
-			replicationConn: &pgmocks.ReplicationConn{
-				IdentifySystemFn: func(ctx context.Context) (pglib.IdentifySystemResult, error) {
-					return pglib.IdentifySystemResult{}, errTest
-				},
-			},
-			slotName: testSlot,
-
-			wantErr: errTest,
 		},
 		{
 			name: "error - creating connection",
@@ -476,6 +423,81 @@ func TestHandler_GetReplicationLag(t *testing.T) {
 			lag, err := h.GetReplicationLag(context.Background())
 			require.ErrorIs(t, err, tc.wantErr)
 			require.Equal(t, tc.wantLag, lag)
+		})
+	}
+}
+
+func TestHandler_GetCurrentLSN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		connBuilder func() (pglib.Querier, error)
+
+		wantLSN replication.LSN
+		wantErr error
+	}{
+		{
+			name: "ok",
+			connBuilder: func() (pglib.Querier, error) {
+				return &pgmocks.Querier{
+					QueryRowFn: func(ctx context.Context, query string, args ...any) pglib.Row {
+						require.Len(t, args, 1)
+						require.Equal(t, args[0], testSlot)
+						switch query {
+						case "SELECT confirmed_flush_lsn FROM pg_replication_slots WHERE slot_name=$1":
+							return &mockRow{lsn: testLSNStr}
+						default:
+							return &mockRow{scanFn: func(args ...any) error { return fmt.Errorf("unexpected query: %s", query) }}
+						}
+					},
+					CloseFn: func(ctx context.Context) error { return nil },
+				}, nil
+			},
+
+			wantLSN: replication.LSN(testLSN),
+			wantErr: nil,
+		},
+		{
+			name: "error - building connection",
+			connBuilder: func() (pglib.Querier, error) {
+				return nil, errTest
+			},
+
+			wantLSN: replication.LSN(0),
+			wantErr: errTest,
+		},
+		{
+			name: "error - getting current lsn",
+			connBuilder: func() (pglib.Querier, error) {
+				return &pgmocks.Querier{
+					QueryRowFn: func(ctx context.Context, query string, args ...any) pglib.Row {
+						return &mockRow{scanFn: func(args ...any) error { return errTest }}
+					},
+					CloseFn: func(ctx context.Context) error { return nil },
+				}, nil
+			},
+
+			wantLSN: replication.LSN(0),
+			wantErr: errTest,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := Handler{
+				logger:                log.NewNoopLogger(),
+				pgConnBuilder:         tc.connBuilder,
+				pgReplicationSlotName: testSlot,
+				lsnParser:             NewLSNParser(),
+			}
+
+			lsn, err := h.GetCurrentLSN(context.Background())
+			require.ErrorIs(t, err, tc.wantErr)
+			require.Equal(t, tc.wantLSN, lsn)
 		})
 	}
 }

--- a/pkg/wal/replication/replication_handler.go
+++ b/pkg/wal/replication/replication_handler.go
@@ -11,9 +11,11 @@ import (
 // Handler manages the replication operations
 type Handler interface {
 	StartReplication(ctx context.Context) error
+	StartReplicationFromLSN(ctx context.Context, lsn LSN) error
 	ReceiveMessage(ctx context.Context) (*Message, error)
 	SyncLSN(ctx context.Context, lsn LSN) error
 	GetReplicationLag(ctx context.Context) (int64, error)
+	GetCurrentLSN(ctx context.Context) (LSN, error)
 	GetLSNParser() LSNParser
 	Close() error
 }


### PR DESCRIPTION
This PR updates the replication handler to support retrieving the current LSN as well as starting replication from a provided LSN. This will be used by the snapshoting behaviour, to ensure we can retrieve the LSN before getting the transaction snapshot, so that when we finish the snapshot we can resume/start replication from the last processed event.