### PR TITLE
Fix processing bug

### DIFF
--- a/pkg/wal/processor/search/search_batch_indexer.go
+++ b/pkg/wal/processor/search/search_batch_indexer.go
@@ -264,6 +264,8 @@ func (i *BatchIndexer) sendBatch(ctx context.Context, batch *msgBatch) error {
 
 	for _, msg := range batch.msgs {
 		switch {
+		case msg == nil:
+			// ignore
 		case msg.write != nil:
 			writes = append(writes, *msg.write)
 		case msg.schemaChange != nil:

--- a/pkg/wal/processor/search/search_batch_indexer.go
+++ b/pkg/wal/processor/search/search_batch_indexer.go
@@ -46,6 +46,8 @@ type BatchIndexer struct {
 
 type Option func(*BatchIndexer)
 
+var errSendStopped = errors.New("stop processing, sending has stopped")
+
 // NewBatchIndexer returns a processor of wal events that indexes data into the
 // search store provided on input.
 func NewBatchIndexer(ctx context.Context, config IndexerConfig, store Store, lsnParser replication.LSNParser, opts ...Option) *BatchIndexer {
@@ -138,18 +140,19 @@ func (i *BatchIndexer) ProcessWALEvent(ctx context.Context, event *wal.Event) (e
 				i.sendErr = sendDoneErr
 			}
 			i.logger.Error(i.sendErr, "stop processing, sending has stopped")
-			return fmt.Errorf("stop processing, sending has stopped: %w", i.sendErr)
+			return fmt.Errorf("%w: %w", errSendStopped, i.sendErr)
 		}
 
 		return nil
 	}
 
 	err = enqueueMsg()
-	if err != nil {
+	// close the message channel only if the send thread has stopped, since we
+	// shouldn't keep processing
+	if err != nil && errors.Is(err, errSendStopped) {
 		i.closeMsgChan()
-		return err
 	}
-	return nil
+	return err
 }
 
 func (i *BatchIndexer) Send(ctx context.Context) error {
@@ -230,9 +233,12 @@ func (i *BatchIndexer) Name() string {
 }
 
 func (i *BatchIndexer) Close() error {
+	i.closeMsgChan()
 	return nil
 }
 
+// closeMsgChan closes the internal msg channel. It can be called multiple
+// times.
 func (i *BatchIndexer) closeMsgChan() {
 	i.once.Do(func() {
 		close(i.msgChan)

--- a/pkg/wal/processor/search/search_msg_batch.go
+++ b/pkg/wal/processor/search/search_msg_batch.go
@@ -31,11 +31,11 @@ func (m *msg) size() int {
 }
 
 func (m *msg) isSchemaChange() bool {
-	return m.schemaChange != nil
+	return m != nil && m.schemaChange != nil
 }
 
 func (m *msg) isKeepAlive() bool {
-	return m.write == nil && m.schemaChange == nil && m.truncate == nil &&
+	return m != nil && m.write == nil && m.schemaChange == nil && m.truncate == nil &&
 		m.pos != ""
 }
 


### PR DESCRIPTION
This PR fixes a bug in the WAL processors where the send/notify channels are closed when the enqueuing fails for any reason, but it should only be closed when the send/notify thread stops (this signals the processor has stopped).

This can cause issues if the error returned by the `ProcessWALEvent` method is not treated as fatal, and the processor is called after an error, attempting to send a message on a closed channel with a send/notify thread still running.

Preventative nil checks added for the search indexer message.