### PR TITLE
[PostgreSQL processor] Handle errors gracefully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 
 .PHONY: integration-test
 integration-test:
-	@PGSTREAM_INTEGRATION_TESTS=true go test -timeout 90s github.com/xataio/pgstream/pkg/stream/integration
+	@PGSTREAM_INTEGRATION_TESTS=true go test -timeout 180s github.com/xataio/pgstream/pkg/stream/integration
 
 .PHONY: license-check
 license-check:

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,6 @@ github.com/elastic/elastic-transport-go/v8 v8.6.0 h1:Y2S/FBjx1LlCv5m6pWAF2kDJAHo
 github.com/elastic/elastic-transport-go/v8 v8.6.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
 github.com/elastic/go-elasticsearch/v8 v8.14.0 h1:1ywU8WFReLLcxE1WJqii3hTtbPUE2hc38ZK/j4mMFow=
 github.com/elastic/go-elasticsearch/v8 v8.14.0/go.mod h1:WRvnlGkSuZyp83M2U8El/LGXpCjYLrvlkSgkAH4O5I4=
-github.com/eminano/greenmask v0.0.0-20250210141616-781d3aca2262 h1:IAhjExmPmCH/UWLv56J/50wrjlwJRTbwI8gBhb5Rl/A=
-github.com/eminano/greenmask v0.0.0-20250210141616-781d3aca2262/go.mod h1:gBBDtACvj/I3nzyEvCGqrWd2ox1XVlh5+Xv5JXKcKDI=
 github.com/eminano/greenmask v0.0.0-20250307113752-035ee2b102e6 h1:m/MuqhOhjJM2oWIjUMkyvrCuCmb/IMC8Ig3/uSM0M+U=
 github.com/eminano/greenmask v0.0.0-20250307113752-035ee2b102e6/go.mod h1:gBBDtACvj/I3nzyEvCGqrWd2ox1XVlh5+Xv5JXKcKDI=
 github.com/expr-lang/expr v1.16.9 h1:WUAzmR0JNI9JCiF0/ewwHB1gmcGw5wW7nWt8gc6PpCI=


### PR DESCRIPTION
This PR updates the query flushing behaviour of the postgres batch writer to ensure that if one of the queries within a batch fails with a non internal error (constraint violation, relation doesn't exist), the error is logged as dataloss, and the rest of the queries are retried and checkpointed, instead of stopping the processor at the first query error.

This aligns with the behaviour of all the other processors.
