### PR TITLE
[Transformers] Make generator type a greenmask parameter

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -464,7 +464,6 @@ transformations:
     column_transformers:
       <column_name>:
         name: <transformer_name>
-        generator: <generator_type>
         parameters:
           <transformer_parameter>: <transformer_parameter_value>
 ```
@@ -485,8 +484,8 @@ transformations:
           max_length: 10
       column_2:
         name: greenmask_firstname
-        generator: deterministic
         parameters:
+          generator: deterministic
           gender: Female
 ```
 

--- a/docs/tutorials/postgres_transformer.md
+++ b/docs/tutorials/postgres_transformer.md
@@ -155,8 +155,8 @@ transformations:
           email_type: fullname
       name:
         name: greenmask_firstname
-        generator: deterministic
         parameters:
+          generator: deterministic
           gender: Female
 ```
 

--- a/pkg/transformers/builder/transformer_builder.go
+++ b/pkg/transformers/builder/transformer_builder.go
@@ -3,42 +3,61 @@
 package builder
 
 import (
+	"strings"
+
 	"github.com/xataio/pgstream/pkg/transformers"
 	"github.com/xataio/pgstream/pkg/transformers/greenmask"
 	"github.com/xataio/pgstream/pkg/transformers/neosync"
 )
 
 func New(cfg *transformers.Config) (transformers.Transformer, error) {
+	if isGreenmaskTransformer(cfg.Name) {
+		var err error
+		generatorType, err := greenmask.GetGeneratorType(cfg.Parameters)
+		if err != nil {
+			return nil, err
+		}
+
+		switch cfg.Name {
+		case transformers.GreenmaskString:
+			return greenmask.NewStringTransformer(generatorType, cfg.Parameters)
+		case transformers.GreenmaskFirstName:
+			return greenmask.NewFirstNameTransformer(generatorType, cfg.Parameters)
+		case transformers.GreenmaskInteger:
+			return greenmask.NewIntegerTransformer(generatorType, cfg.Parameters)
+		case transformers.GreenmaskFloat:
+			return greenmask.NewFloatTransformer(generatorType, cfg.Parameters)
+		case transformers.GreenmaskUUID:
+			return greenmask.NewUUIDTransformer(generatorType)
+		case transformers.GreenmaskBoolean:
+			return greenmask.NewBooleanTransformer(generatorType)
+		case transformers.GreenmaskChoice:
+			return greenmask.NewChoiceTransformer(generatorType, cfg.Parameters)
+		case transformers.GreenmaskUnixTimestamp:
+			return greenmask.NewUnixTimestampTransformer(generatorType, cfg.Parameters)
+		case transformers.GreenmaskDate:
+			return greenmask.NewDateTransformer(generatorType, cfg.Parameters)
+		case transformers.GreenmaskUTCTimestamp:
+			return greenmask.NewUTCTimestampTransformer(generatorType, cfg.Parameters)
+		default:
+			return nil, transformers.ErrUnsupportedTransformer
+		}
+	}
+
 	switch cfg.Name {
 	case transformers.String:
-		return transformers.NewStringTransformer(cfg.Generator, cfg.Parameters)
+		return transformers.NewStringTransformer(cfg.Parameters)
 	case transformers.NeosyncString:
 		return neosync.NewStringTransformer(cfg.Parameters)
-	case transformers.GreenmaskString:
-		return greenmask.NewStringTransformer(cfg.Generator, cfg.Parameters)
 	case transformers.NeosyncFirstName:
 		return neosync.NewFirstNameTransformer(cfg.Parameters)
-	case transformers.GreenmaskFirstName:
-		return greenmask.NewFirstNameTransformer(cfg.Generator, cfg.Parameters)
 	case transformers.NeosyncEmail:
 		return neosync.NewEmailTransformer(cfg.Parameters)
-	case transformers.GreenmaskInteger:
-		return greenmask.NewIntegerTransformer(cfg.Generator, cfg.Parameters)
-	case transformers.GreenmaskFloat:
-		return greenmask.NewFloatTransformer(cfg.Generator, cfg.Parameters)
-	case transformers.GreenmaskUUID:
-		return greenmask.NewUUIDTransformer(cfg.Generator)
-	case transformers.GreenmaskBoolean:
-		return greenmask.NewBooleanTransformer(cfg.Generator)
-	case transformers.GreenmaskChoice:
-		return greenmask.NewChoiceTransformer(cfg.Generator, cfg.Parameters)
-	case transformers.GreenmaskUnixTimestamp:
-		return greenmask.NewUnixTimestampTransformer(cfg.Generator, cfg.Parameters)
-	case transformers.GreenmaskDate:
-		return greenmask.NewDateTransformer(cfg.Generator, cfg.Parameters)
-	case transformers.GreenmaskUTCTimestamp:
-		return greenmask.NewUTCTimestampTransformer(cfg.Generator, cfg.Parameters)
 	default:
 		return nil, transformers.ErrUnsupportedTransformer
 	}
+}
+
+func isGreenmaskTransformer(name transformers.TransformerType) bool {
+	return strings.HasPrefix(string(name), "greenmask_")
 }

--- a/pkg/transformers/builder/transformer_builder.go
+++ b/pkg/transformers/builder/transformer_builder.go
@@ -3,48 +3,33 @@
 package builder
 
 import (
-	"strings"
-
 	"github.com/xataio/pgstream/pkg/transformers"
 	"github.com/xataio/pgstream/pkg/transformers/greenmask"
 	"github.com/xataio/pgstream/pkg/transformers/neosync"
 )
 
 func New(cfg *transformers.Config) (transformers.Transformer, error) {
-	if isGreenmaskTransformer(cfg.Name) {
-		var err error
-		generatorType, err := greenmask.GetGeneratorType(cfg.Parameters)
-		if err != nil {
-			return nil, err
-		}
-
-		switch cfg.Name {
-		case transformers.GreenmaskString:
-			return greenmask.NewStringTransformer(generatorType, cfg.Parameters)
-		case transformers.GreenmaskFirstName:
-			return greenmask.NewFirstNameTransformer(generatorType, cfg.Parameters)
-		case transformers.GreenmaskInteger:
-			return greenmask.NewIntegerTransformer(generatorType, cfg.Parameters)
-		case transformers.GreenmaskFloat:
-			return greenmask.NewFloatTransformer(generatorType, cfg.Parameters)
-		case transformers.GreenmaskUUID:
-			return greenmask.NewUUIDTransformer(generatorType)
-		case transformers.GreenmaskBoolean:
-			return greenmask.NewBooleanTransformer(generatorType)
-		case transformers.GreenmaskChoice:
-			return greenmask.NewChoiceTransformer(generatorType, cfg.Parameters)
-		case transformers.GreenmaskUnixTimestamp:
-			return greenmask.NewUnixTimestampTransformer(generatorType, cfg.Parameters)
-		case transformers.GreenmaskDate:
-			return greenmask.NewDateTransformer(generatorType, cfg.Parameters)
-		case transformers.GreenmaskUTCTimestamp:
-			return greenmask.NewUTCTimestampTransformer(generatorType, cfg.Parameters)
-		default:
-			return nil, transformers.ErrUnsupportedTransformer
-		}
-	}
-
 	switch cfg.Name {
+	case transformers.GreenmaskString:
+		return greenmask.NewStringTransformer(cfg.Parameters)
+	case transformers.GreenmaskFirstName:
+		return greenmask.NewFirstNameTransformer(cfg.Parameters)
+	case transformers.GreenmaskInteger:
+		return greenmask.NewIntegerTransformer(cfg.Parameters)
+	case transformers.GreenmaskFloat:
+		return greenmask.NewFloatTransformer(cfg.Parameters)
+	case transformers.GreenmaskUUID:
+		return greenmask.NewUUIDTransformer(cfg.Parameters)
+	case transformers.GreenmaskBoolean:
+		return greenmask.NewBooleanTransformer(cfg.Parameters)
+	case transformers.GreenmaskChoice:
+		return greenmask.NewChoiceTransformer(cfg.Parameters)
+	case transformers.GreenmaskUnixTimestamp:
+		return greenmask.NewUnixTimestampTransformer(cfg.Parameters)
+	case transformers.GreenmaskDate:
+		return greenmask.NewDateTransformer(cfg.Parameters)
+	case transformers.GreenmaskUTCTimestamp:
+		return greenmask.NewUTCTimestampTransformer(cfg.Parameters)
 	case transformers.String:
 		return transformers.NewStringTransformer(cfg.Parameters)
 	case transformers.NeosyncString:
@@ -56,8 +41,4 @@ func New(cfg *transformers.Config) (transformers.Transformer, error) {
 	default:
 		return nil, transformers.ErrUnsupportedTransformer
 	}
-}
-
-func isGreenmaskTransformer(name transformers.TransformerType) bool {
-	return strings.HasPrefix(string(name), "greenmask_")
 }

--- a/pkg/transformers/greenmask/greenmask_boolean_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_boolean_transformer.go
@@ -11,9 +11,9 @@ type BooleanTransformer struct {
 	transformer *greenmasktransformers.RandomBoolean
 }
 
-func NewBooleanTransformer(generatorType GeneratorType) (*BooleanTransformer, error) {
+func NewBooleanTransformer(params transformers.Parameters) (*BooleanTransformer, error) {
 	t := greenmasktransformers.NewRandomBoolean()
-	if err := setGenerator(t, generatorType); err != nil {
+	if err := setGenerator(t, params); err != nil {
 		return nil, err
 	}
 	return &BooleanTransformer{

--- a/pkg/transformers/greenmask/greenmask_boolean_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_boolean_transformer.go
@@ -11,7 +11,7 @@ type BooleanTransformer struct {
 	transformer *greenmasktransformers.RandomBoolean
 }
 
-func NewBooleanTransformer(generatorType transformers.GeneratorType) (*BooleanTransformer, error) {
+func NewBooleanTransformer(generatorType GeneratorType) (*BooleanTransformer, error) {
 	t := greenmasktransformers.NewRandomBoolean()
 	if err := setGenerator(t, generatorType); err != nil {
 		return nil, err

--- a/pkg/transformers/greenmask/greenmask_boolean_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_boolean_transformer_test.go
@@ -13,17 +13,17 @@ func Test_NewBooleanTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
-		generator transformers.GeneratorType
+		generator GeneratorType
 		wantErr   error
 	}{
 		{
 			name:      "ok - valid random",
-			generator: transformers.Random,
+			generator: Random,
 			wantErr:   nil,
 		},
 		{
 			name:      "ok - valid deterministic",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			wantErr:   nil,
 		},
 		{
@@ -49,25 +49,25 @@ func Test_BooleanTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name          string
-		generatorType transformers.GeneratorType
+		generatorType GeneratorType
 		input         any
 		wantErr       error
 	}{
 		{
 			name:          "ok - bool, random",
-			generatorType: transformers.Random,
+			generatorType: Random,
 			input:         true,
 			wantErr:       nil,
 		},
 		{
 			name:          "ok - bool, deterministic",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         false,
 			wantErr:       nil,
 		},
 		{
 			name:          "ok - []byte, deterministic",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         []byte("123e4567-e89b-12d3-a456-426655440000"),
 			wantErr:       nil,
 		},
@@ -94,7 +94,7 @@ func Test_BooleanTransformer_Transform(t *testing.T) {
 			require.True(t, ok)
 
 			// if deterministic, the same input should always produce the same output
-			if tc.generatorType == transformers.Deterministic {
+			if tc.generatorType == Deterministic {
 				gotAgain, err := transformer.Transform(tc.input)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/greenmask/greenmask_boolean_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_boolean_transformer_test.go
@@ -12,30 +12,36 @@ import (
 func Test_NewBooleanTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		generator GeneratorType
-		wantErr   error
+		name    string
+		params  transformers.Parameters
+		wantErr error
 	}{
 		{
-			name:      "ok - valid random",
-			generator: Random,
-			wantErr:   nil,
+			name: "ok - valid random",
+			params: transformers.Parameters{
+				"generator": random,
+			},
+			wantErr: nil,
 		},
 		{
-			name:      "ok - valid deterministic",
-			generator: Deterministic,
-			wantErr:   nil,
+			name: "ok - valid deterministic",
+			params: transformers.Parameters{
+				"generator": deterministic,
+			},
+			wantErr: nil,
 		},
 		{
-			name:      "error - invalid generator type",
-			generator: "invalid",
-			wantErr:   transformers.ErrUnsupportedGenerator,
+			name: "error - invalid generator type",
+			params: transformers.Parameters{
+				"generator": "invalid",
+			},
+			wantErr: transformers.ErrUnsupportedGenerator,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewBooleanTransformer(tc.generator)
+			transformer, err := NewBooleanTransformer(tc.params)
 			require.ErrorIs(t, err, tc.wantErr)
 			if err != nil {
 				return
@@ -48,28 +54,34 @@ func Test_NewBooleanTransformer(t *testing.T) {
 func Test_BooleanTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name          string
-		generatorType GeneratorType
-		input         any
-		wantErr       error
+		name    string
+		params  transformers.Parameters
+		input   any
+		wantErr error
 	}{
 		{
-			name:          "ok - bool, random",
-			generatorType: Random,
-			input:         true,
-			wantErr:       nil,
+			name: "ok - bool, random",
+			params: transformers.Parameters{
+				"generator": random,
+			},
+			input:   true,
+			wantErr: nil,
 		},
 		{
-			name:          "ok - bool, deterministic",
-			generatorType: Deterministic,
-			input:         false,
-			wantErr:       nil,
+			name: "ok - bool, deterministic",
+			params: transformers.Parameters{
+				"generator": deterministic,
+			},
+			input:   false,
+			wantErr: nil,
 		},
 		{
-			name:          "ok - []byte, deterministic",
-			generatorType: Deterministic,
-			input:         []byte("123e4567-e89b-12d3-a456-426655440000"),
-			wantErr:       nil,
+			name: "ok - []byte, deterministic",
+			params: transformers.Parameters{
+				"generator": deterministic,
+			},
+			input:   []byte("123e4567-e89b-12d3-a456-426655440000"),
+			wantErr: nil,
 		},
 		{
 			name:    "error - invalid input type",
@@ -80,7 +92,7 @@ func Test_BooleanTransformer_Transform(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewBooleanTransformer(tc.generatorType)
+			transformer, err := NewBooleanTransformer(tc.params)
 			require.NoError(t, err)
 			require.NotNil(t, transformer)
 
@@ -94,7 +106,7 @@ func Test_BooleanTransformer_Transform(t *testing.T) {
 			require.True(t, ok)
 
 			// if deterministic, the same input should always produce the same output
-			if tc.generatorType == Deterministic {
+			if mustGetGeneratorType(t, tc.params) == deterministic {
 				gotAgain, err := transformer.Transform(tc.input)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/greenmask/greenmask_choice_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_choice_transformer.go
@@ -17,7 +17,7 @@ type ChoiceTransformer struct {
 
 var errChoicesEmpty = errors.New("greenmask_choice: choices must not be empty")
 
-func NewChoiceTransformer(generatorType GeneratorType, params transformers.Parameters) (*ChoiceTransformer, error) {
+func NewChoiceTransformer(params transformers.Parameters) (*ChoiceTransformer, error) {
 	choices := []string{}
 	choices, err := findParameterArray(params, "choices", choices)
 	if err != nil {
@@ -36,7 +36,7 @@ func NewChoiceTransformer(generatorType GeneratorType, params transformers.Param
 	}
 
 	t := greenmasktransformers.NewRandomChoiceTransformer(choicesRaw)
-	if err := setGenerator(t, generatorType); err != nil {
+	if err := setGenerator(t, params); err != nil {
 		return nil, err
 	}
 	return &ChoiceTransformer{

--- a/pkg/transformers/greenmask/greenmask_choice_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_choice_transformer.go
@@ -17,7 +17,7 @@ type ChoiceTransformer struct {
 
 var errChoicesEmpty = errors.New("greenmask_choice: choices must not be empty")
 
-func NewChoiceTransformer(generatorType transformers.GeneratorType, params transformers.Parameters) (*ChoiceTransformer, error) {
+func NewChoiceTransformer(generatorType GeneratorType, params transformers.Parameters) (*ChoiceTransformer, error) {
 	choices := []string{}
 	choices, err := findParameterArray(params, "choices", choices)
 	if err != nil {

--- a/pkg/transformers/greenmask/greenmask_choice_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_choice_transformer_test.go
@@ -14,13 +14,13 @@ func TestNewChoiceTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
-		generator transformers.GeneratorType
+		generator GeneratorType
 		params    transformers.Parameters
 		wantErr   error
 	}{
 		{
 			name:      "ok - valid random",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"choices": []string{"a", "b", "c", "d"},
 			},
@@ -36,7 +36,7 @@ func TestNewChoiceTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid choices",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			wantErr:   errChoicesEmpty,
 		},
 	}
@@ -58,14 +58,14 @@ func TestChoiceTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name          string
-		generatorType transformers.GeneratorType
+		generatorType GeneratorType
 		input         any
 		params        transformers.Parameters
 		wantErr       error
 	}{
 		{
 			name:          "ok - transform string randomly",
-			generatorType: transformers.Random,
+			generatorType: Random,
 			input:         "test",
 			params: transformers.Parameters{
 				"choices": []string{"a", "b", "c", "d"},
@@ -74,7 +74,7 @@ func TestChoiceTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "ok - transform []byte deterministically",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         []byte("test"),
 			params: transformers.Parameters{
 				"choices": []string{"a", "b", "c", "d"},
@@ -83,7 +83,7 @@ func TestChoiceTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "ok - transform RawValue deterministically",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         toolkit.NewRawValue([]byte("test"), false),
 			params: transformers.Parameters{
 				"choices": []string{"a", "b", "c", "d"},
@@ -92,7 +92,7 @@ func TestChoiceTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "error - invalid input type",
-			generatorType: transformers.Random,
+			generatorType: Random,
 			input:         1,
 			params: transformers.Parameters{
 				"choices": []string{"a", "b", "c", "d"},
@@ -119,7 +119,7 @@ func TestChoiceTransformer_Transform(t *testing.T) {
 			require.Contains(t, tt.params["choices"], string(val))
 
 			// if deterministic, check if we get the same result again
-			if tt.generatorType == transformers.Deterministic {
+			if tt.generatorType == Deterministic {
 				gotAgain, err := transformer.Transform(tt.input)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/greenmask/greenmask_choice_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_choice_transformer_test.go
@@ -13,38 +13,39 @@ import (
 func TestNewChoiceTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		generator GeneratorType
-		params    transformers.Parameters
-		wantErr   error
+		name    string
+		params  transformers.Parameters
+		wantErr error
 	}{
 		{
-			name:      "ok - valid random",
-			generator: Random,
+			name: "ok - valid random",
 			params: transformers.Parameters{
-				"choices": []string{"a", "b", "c", "d"},
+				"generator": random,
+				"choices":   []string{"a", "b", "c", "d"},
 			},
 			wantErr: nil,
 		},
 		{
-			name:      "error - invalid generator type",
-			generator: "invalid",
+			name: "error - invalid generator type",
 			params: transformers.Parameters{
-				"choices": []string{"a", "b", "c", "d"},
+				"generator": "invalid",
+				"choices":   []string{"a", "b", "c", "d"},
 			},
 			wantErr: transformers.ErrUnsupportedGenerator,
 		},
 		{
-			name:      "error - invalid choices",
-			generator: Deterministic,
-			wantErr:   errChoicesEmpty,
+			name: "error - invalid choices",
+			params: transformers.Parameters{
+				"generator": deterministic,
+			},
+			wantErr: errChoicesEmpty,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewChoiceTransformer(tt.generator, tt.params)
+			transformer, err := NewChoiceTransformer(tt.params)
 			require.Equal(t, tt.wantErr, err)
 			if err != nil {
 				return
@@ -57,45 +58,44 @@ func TestNewChoiceTransformer(t *testing.T) {
 func TestChoiceTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name          string
-		generatorType GeneratorType
-		input         any
-		params        transformers.Parameters
-		wantErr       error
+		name    string
+		input   any
+		params  transformers.Parameters
+		wantErr error
 	}{
 		{
-			name:          "ok - transform string randomly",
-			generatorType: Random,
-			input:         "test",
+			name:  "ok - transform string randomly",
+			input: "test",
 			params: transformers.Parameters{
-				"choices": []string{"a", "b", "c", "d"},
+				"generator": random,
+				"choices":   []string{"a", "b", "c", "d"},
 			},
 			wantErr: nil,
 		},
 		{
-			name:          "ok - transform []byte deterministically",
-			generatorType: Deterministic,
-			input:         []byte("test"),
+			name:  "ok - transform []byte deterministically",
+			input: []byte("test"),
 			params: transformers.Parameters{
-				"choices": []string{"a", "b", "c", "d"},
+				"generator": deterministic,
+				"choices":   []string{"a", "b", "c", "d"},
 			},
 			wantErr: nil,
 		},
 		{
-			name:          "ok - transform RawValue deterministically",
-			generatorType: Deterministic,
-			input:         toolkit.NewRawValue([]byte("test"), false),
+			name:  "ok - transform RawValue deterministically",
+			input: toolkit.NewRawValue([]byte("test"), false),
 			params: transformers.Parameters{
-				"choices": []string{"a", "b", "c", "d"},
+				"generator": deterministic,
+				"choices":   []string{"a", "b", "c", "d"},
 			},
 			wantErr: nil,
 		},
 		{
-			name:          "error - invalid input type",
-			generatorType: Random,
-			input:         1,
+			name:  "error - invalid input type",
+			input: 1,
 			params: transformers.Parameters{
-				"choices": []string{"a", "b", "c", "d"},
+				"generator": random,
+				"choices":   []string{"a", "b", "c", "d"},
 			},
 			wantErr: transformers.ErrUnsupportedValueType,
 		},
@@ -103,7 +103,7 @@ func TestChoiceTransformer_Transform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewChoiceTransformer(tt.generatorType, tt.params)
+			transformer, err := NewChoiceTransformer(tt.params)
 			require.NoError(t, err)
 			require.NotNil(t, transformer)
 			got, err := transformer.Transform(tt.input)
@@ -119,7 +119,7 @@ func TestChoiceTransformer_Transform(t *testing.T) {
 			require.Contains(t, tt.params["choices"], string(val))
 
 			// if deterministic, check if we get the same result again
-			if tt.generatorType == Deterministic {
+			if mustGetGeneratorType(t, tt.params) == deterministic {
 				gotAgain, err := transformer.Transform(tt.input)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/greenmask/greenmask_date_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_date_transformer.go
@@ -14,7 +14,7 @@ type DateTransformer struct {
 	transformer *greenmasktransformers.Timestamp
 }
 
-func NewDateTransformer(generatorType transformers.GeneratorType, params transformers.Parameters) (*DateTransformer, error) {
+func NewDateTransformer(generatorType GeneratorType, params transformers.Parameters) (*DateTransformer, error) {
 	minValue, foundMin, err := transformers.FindParameter[string](params, "min_value")
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_date: min_value must be a string: %w", err)

--- a/pkg/transformers/greenmask/greenmask_date_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_date_transformer.go
@@ -14,7 +14,7 @@ type DateTransformer struct {
 	transformer *greenmasktransformers.Timestamp
 }
 
-func NewDateTransformer(generatorType GeneratorType, params transformers.Parameters) (*DateTransformer, error) {
+func NewDateTransformer(params transformers.Parameters) (*DateTransformer, error) {
 	minValue, foundMin, err := transformers.FindParameter[string](params, "min_value")
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_date: min_value must be a string: %w", err)
@@ -52,7 +52,7 @@ func NewDateTransformer(generatorType GeneratorType, params transformers.Paramet
 		return nil, err
 	}
 
-	if err := setGenerator(t, generatorType); err != nil {
+	if err := setGenerator(t, params); err != nil {
 		return nil, err
 	}
 

--- a/pkg/transformers/greenmask/greenmask_date_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_date_transformer_test.go
@@ -14,41 +14,40 @@ import (
 func TestNewDateTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		generator GeneratorType
-		params    transformers.Parameters
-		wantErr   error
+		name    string
+		params  transformers.Parameters
+		wantErr error
 	}{
 		{
-			name:      "ok - valid parameters",
-			generator: Random,
+			name: "ok - valid parameters",
 			params: transformers.Parameters{
+				"generator": random,
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",
 			},
 			wantErr: nil,
 		},
 		{
-			name:      "error - min_value missing",
-			generator: Random,
+			name: "error - min_value missing",
 			params: transformers.Parameters{
+				"generator": random,
 				"max_value": "2022-01-02",
 			},
 			wantErr: errMinMaxValueNotSpecified,
 		},
 		{
-			name:      "error - min_value after max_value",
-			generator: Random,
+			name: "error - min_value after max_value",
 			params: transformers.Parameters{
+				"generator": random,
 				"min_value": "2022-01-03",
 				"max_value": "2022-01-02",
 			},
 			wantErr: greenmasktransformers.ErrWrongLimits,
 		},
 		{
-			name:      "error - invalid generator type",
-			generator: "invalid",
+			name: "error - invalid generator type",
 			params: transformers.Parameters{
+				"generator": "invalid",
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",
 			},
@@ -58,7 +57,7 @@ func TestNewDateTransformer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewDateTransformer(tt.generator, tt.params)
+			transformer, err := NewDateTransformer(tt.params)
 			require.ErrorIs(t, err, tt.wantErr)
 			if err != nil {
 				return
@@ -71,16 +70,15 @@ func TestNewDateTransformer(t *testing.T) {
 func TestDateTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		generator GeneratorType
-		params    transformers.Parameters
-		input     any
-		wantErr   error
+		name    string
+		params  transformers.Parameters
+		input   any
+		wantErr error
 	}{
 		{
-			name:      "ok - valid random",
-			generator: Random,
+			name: "ok - valid random",
 			params: transformers.Parameters{
+				"generator": random,
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",
 			},
@@ -88,9 +86,9 @@ func TestDateTransformer_Transform(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:      "ok - valid deterministic",
-			generator: Deterministic,
+			name: "ok - valid deterministic",
 			params: transformers.Parameters{
+				"generator": deterministic,
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",
 			},
@@ -98,9 +96,9 @@ func TestDateTransformer_Transform(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:      "ok - valid with time input",
-			generator: Deterministic,
+			name: "ok - valid with time input",
 			params: transformers.Parameters{
+				"generator": deterministic,
 				"min_value": "2022-01-02",
 				"max_value": "2022-01-02",
 			},
@@ -108,9 +106,9 @@ func TestDateTransformer_Transform(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:      "error - invalid input",
-			generator: Random,
+			name: "error - invalid input",
 			params: transformers.Parameters{
+				"generator": random,
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",
 			},
@@ -121,7 +119,7 @@ func TestDateTransformer_Transform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewDateTransformer(tt.generator, tt.params)
+			transformer, err := NewDateTransformer(tt.params)
 			require.NoError(t, err)
 			require.NotNil(t, transformer)
 
@@ -144,7 +142,7 @@ func TestDateTransformer_Transform(t *testing.T) {
 			require.True(t, result.After(minDate) || result.Equal(minDate))
 			require.True(t, result.Before(maxDate) || result.Equal(maxDate))
 
-			if tt.generator == Deterministic {
+			if mustGetGeneratorType(t, tt.params) == deterministic {
 				gotAgain, err := transformer.Transform(tt.input)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/greenmask/greenmask_date_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_date_transformer_test.go
@@ -15,13 +15,13 @@ func TestNewDateTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
-		generator transformers.GeneratorType
+		generator GeneratorType
 		params    transformers.Parameters
 		wantErr   error
 	}{
 		{
 			name:      "ok - valid parameters",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",
@@ -30,7 +30,7 @@ func TestNewDateTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - min_value missing",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"max_value": "2022-01-02",
 			},
@@ -38,7 +38,7 @@ func TestNewDateTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - min_value after max_value",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"min_value": "2022-01-03",
 				"max_value": "2022-01-02",
@@ -72,14 +72,14 @@ func TestDateTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
-		generator transformers.GeneratorType
+		generator GeneratorType
 		params    transformers.Parameters
 		input     any
 		wantErr   error
 	}{
 		{
 			name:      "ok - valid random",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",
@@ -89,7 +89,7 @@ func TestDateTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:      "ok - valid deterministic",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",
@@ -99,7 +99,7 @@ func TestDateTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:      "ok - valid with time input",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"min_value": "2022-01-02",
 				"max_value": "2022-01-02",
@@ -109,7 +109,7 @@ func TestDateTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:      "error - invalid input",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",
@@ -144,7 +144,7 @@ func TestDateTransformer_Transform(t *testing.T) {
 			require.True(t, result.After(minDate) || result.Equal(minDate))
 			require.True(t, result.Before(maxDate) || result.Equal(maxDate))
 
-			if tt.generator == transformers.Deterministic {
+			if tt.generator == Deterministic {
 				gotAgain, err := transformer.Transform(tt.input)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/greenmask/greenmask_firstname_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_firstname_transformer.go
@@ -13,7 +13,7 @@ type FirstNameTransformer struct {
 	transformer *greenmasktransformers.RandomPersonTransformer
 }
 
-func NewFirstNameTransformer(generatorType transformers.GeneratorType, params transformers.Parameters) (*FirstNameTransformer, error) {
+func NewFirstNameTransformer(generatorType GeneratorType, params transformers.Parameters) (*FirstNameTransformer, error) {
 	gender, err := findParameter(params, "gender", greenmasktransformers.AnyGenderName)
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_string: symbols must be a string: %w", err)

--- a/pkg/transformers/greenmask/greenmask_firstname_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_firstname_transformer.go
@@ -13,7 +13,7 @@ type FirstNameTransformer struct {
 	transformer *greenmasktransformers.RandomPersonTransformer
 }
 
-func NewFirstNameTransformer(generatorType GeneratorType, params transformers.Parameters) (*FirstNameTransformer, error) {
+func NewFirstNameTransformer(params transformers.Parameters) (*FirstNameTransformer, error) {
 	gender, err := findParameter(params, "gender", greenmasktransformers.AnyGenderName)
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_string: symbols must be a string: %w", err)
@@ -21,7 +21,7 @@ func NewFirstNameTransformer(generatorType GeneratorType, params transformers.Pa
 
 	t := greenmasktransformers.NewRandomPersonTransformer(toGreenmaskGender(gender), nil)
 
-	if err := setGenerator(t, generatorType); err != nil {
+	if err := setGenerator(t, params); err != nil {
 		return nil, err
 	}
 

--- a/pkg/transformers/greenmask/greenmask_firstname_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_firstname_transformer_test.go
@@ -13,52 +13,52 @@ func Test_NewFirstNameTransformer(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		params        transformers.Parameters
-		generatorType GeneratorType
+		name   string
+		params transformers.Parameters
 
 		wantErr error
 	}{
 		{
 			name: "ok - random",
 			params: map[string]any{
-				"gender": "female",
+				"generator": random,
+				"gender":    "female",
 			},
-			generatorType: Random,
 
 			wantErr: nil,
 		},
 		{
 			name: "ok - deterministic",
 			params: map[string]any{
-				"gender": "male",
+				"generator": deterministic,
+				"gender":    "male",
 			},
-			generatorType: Deterministic,
 
 			wantErr: nil,
 		},
 		{
 			name: "ok - unknown gender defaults to any",
 			params: map[string]any{
-				"gender": "other",
+				"generator": deterministic,
+				"gender":    "other",
 			},
-			generatorType: Deterministic,
 
 			wantErr: nil,
 		},
 		{
 			name: "error - invalid gender",
 			params: map[string]any{
-				"gender": 1,
+				"generator": random,
+				"gender":    1,
 			},
-			generatorType: Random,
 
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
-			name:          "error - invalid generator",
-			params:        map[string]any{},
-			generatorType: "invalid",
+			name: "error - invalid generator",
+			params: map[string]any{
+				"generator": "invalid",
+			},
 
 			wantErr: transformers.ErrUnsupportedGenerator,
 		},
@@ -68,7 +68,7 @@ func Test_NewFirstNameTransformer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := NewFirstNameTransformer(tc.generatorType, tc.params)
+			_, err := NewFirstNameTransformer(tc.params)
 			require.ErrorIs(t, err, tc.wantErr)
 		})
 	}
@@ -78,10 +78,9 @@ func TestFirstNameTransformer_Transform(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		value         any
-		params        transformers.Parameters
-		generatorType GeneratorType
+		name   string
+		value  any
+		params transformers.Parameters
 
 		wantName string
 		wantErr  error
@@ -90,9 +89,9 @@ func TestFirstNameTransformer_Transform(t *testing.T) {
 			name:  "ok - random with string",
 			value: "alice",
 			params: map[string]any{
-				"gender": "female",
+				"generator": random,
+				"gender":    "female",
 			},
-			generatorType: Random,
 
 			wantErr: nil,
 		},
@@ -100,9 +99,9 @@ func TestFirstNameTransformer_Transform(t *testing.T) {
 			name:  "ok - random with []byte",
 			value: []byte("alice"),
 			params: map[string]any{
-				"gender": "male",
+				"generator": random,
+				"gender":    "male",
 			},
-			generatorType: Random,
 
 			wantErr: nil,
 		},
@@ -110,9 +109,9 @@ func TestFirstNameTransformer_Transform(t *testing.T) {
 			name:  "ok - deterministic",
 			value: "alice",
 			params: map[string]any{
-				"gender": "female",
+				"generator": deterministic,
+				"gender":    "female",
 			},
-			generatorType: Deterministic,
 
 			wantName: "Pearlie",
 			wantErr:  nil,
@@ -121,9 +120,9 @@ func TestFirstNameTransformer_Transform(t *testing.T) {
 			name:  "error - unsupported value type",
 			value: 1,
 			params: map[string]any{
-				"gender": "female",
+				"generator": random,
+				"gender":    "female",
 			},
-			generatorType: Random,
 
 			wantErr: transformers.ErrUnsupportedValueType,
 		},
@@ -133,7 +132,7 @@ func TestFirstNameTransformer_Transform(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			transformer, err := NewFirstNameTransformer(tc.generatorType, tc.params)
+			transformer, err := NewFirstNameTransformer(tc.params)
 			require.NoError(t, err)
 
 			got, err := transformer.Transform(tc.value)

--- a/pkg/transformers/greenmask/greenmask_firstname_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_firstname_transformer_test.go
@@ -15,7 +15,7 @@ func Test_NewFirstNameTransformer(t *testing.T) {
 	tests := []struct {
 		name          string
 		params        transformers.Parameters
-		generatorType transformers.GeneratorType
+		generatorType GeneratorType
 
 		wantErr error
 	}{
@@ -24,7 +24,7 @@ func Test_NewFirstNameTransformer(t *testing.T) {
 			params: map[string]any{
 				"gender": "female",
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 
 			wantErr: nil,
 		},
@@ -33,7 +33,7 @@ func Test_NewFirstNameTransformer(t *testing.T) {
 			params: map[string]any{
 				"gender": "male",
 			},
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 
 			wantErr: nil,
 		},
@@ -42,7 +42,7 @@ func Test_NewFirstNameTransformer(t *testing.T) {
 			params: map[string]any{
 				"gender": "other",
 			},
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 
 			wantErr: nil,
 		},
@@ -51,7 +51,7 @@ func Test_NewFirstNameTransformer(t *testing.T) {
 			params: map[string]any{
 				"gender": 1,
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 
 			wantErr: transformers.ErrInvalidParameters,
 		},
@@ -81,7 +81,7 @@ func TestFirstNameTransformer_Transform(t *testing.T) {
 		name          string
 		value         any
 		params        transformers.Parameters
-		generatorType transformers.GeneratorType
+		generatorType GeneratorType
 
 		wantName string
 		wantErr  error
@@ -92,7 +92,7 @@ func TestFirstNameTransformer_Transform(t *testing.T) {
 			params: map[string]any{
 				"gender": "female",
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 
 			wantErr: nil,
 		},
@@ -102,7 +102,7 @@ func TestFirstNameTransformer_Transform(t *testing.T) {
 			params: map[string]any{
 				"gender": "male",
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 
 			wantErr: nil,
 		},
@@ -112,7 +112,7 @@ func TestFirstNameTransformer_Transform(t *testing.T) {
 			params: map[string]any{
 				"gender": "female",
 			},
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 
 			wantName: "Pearlie",
 			wantErr:  nil,
@@ -123,7 +123,7 @@ func TestFirstNameTransformer_Transform(t *testing.T) {
 			params: map[string]any{
 				"gender": "female",
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 
 			wantErr: transformers.ErrUnsupportedValueType,
 		},

--- a/pkg/transformers/greenmask/greenmask_float_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_float_transformer.go
@@ -21,7 +21,7 @@ type FloatTransformer struct {
 	transformer *greenmasktransformers.RandomFloat64Transformer
 }
 
-func NewFloatTransformer(generatorType transformers.GeneratorType, params transformers.Parameters) (*FloatTransformer, error) {
+func NewFloatTransformer(generatorType GeneratorType, params transformers.Parameters) (*FloatTransformer, error) {
 	minValue, err := findParameter(params, "min_value", defaultMinFloat)
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_float: min_value must be a float: %w", err)

--- a/pkg/transformers/greenmask/greenmask_float_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_float_transformer.go
@@ -21,7 +21,7 @@ type FloatTransformer struct {
 	transformer *greenmasktransformers.RandomFloat64Transformer
 }
 
-func NewFloatTransformer(generatorType GeneratorType, params transformers.Parameters) (*FloatTransformer, error) {
+func NewFloatTransformer(params transformers.Parameters) (*FloatTransformer, error) {
 	minValue, err := findParameter(params, "min_value", defaultMinFloat)
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_float: min_value must be a float: %w", err)
@@ -40,7 +40,7 @@ func NewFloatTransformer(generatorType GeneratorType, params transformers.Parame
 	}
 	t := greenmasktransformers.NewRandomFloat64Transformer(limiter)
 
-	if err := setGenerator(t, generatorType); err != nil {
+	if err := setGenerator(t, params); err != nil {
 		return nil, err
 	}
 

--- a/pkg/transformers/greenmask/greenmask_float_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_float_transformer_test.go
@@ -15,44 +15,47 @@ func Test_NewFloatTransformer(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		params        transformers.Parameters
-		generatorType GeneratorType
-		wantErr       error
+		name    string
+		params  transformers.Parameters
+		wantErr error
 	}{
 		{
 			name: "ok - random with parameters",
 			params: map[string]any{
+				"generator": random,
 				"min_value": 1.01,
 				"max_value": 10.5,
 			},
-			generatorType: Random,
-			wantErr:       nil,
+			wantErr: nil,
 		},
 		{
 			name: "ok - deterministic with parameters",
 			params: map[string]any{
+				"generator": deterministic,
 				"min_value": 0.0000000000000000000000000000001,
 				"max_value": 100.0,
 				"precision": 44,
 			},
-			generatorType: Deterministic,
-			wantErr:       nil,
-		},
-		{
-			name:    "ok - random with default",
-			params:  map[string]any{},
 			wantErr: nil,
 		},
 		{
-			name:          "ok - deterministic with default",
-			params:        map[string]any{},
-			generatorType: Deterministic,
-			wantErr:       nil,
+			name: "ok - random with default",
+			params: map[string]any{
+				"generator": random,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ok - deterministic with default",
+			params: map[string]any{
+				"generator": deterministic,
+			},
+			wantErr: nil,
 		},
 		{
 			name: "error - min_value greater than max_value",
 			params: map[string]any{
+				"generator": random,
 				"min_value": 10.5,
 				"max_value": 1.5,
 				"precision": 2,
@@ -62,48 +65,48 @@ func Test_NewFloatTransformer(t *testing.T) {
 		{
 			name: "error - invalid min_value type",
 			params: map[string]any{
+				"generator": random,
 				"min_value": "invalid",
 				"max_value": 10.5,
 				"precision": 2,
 			},
-			generatorType: Random,
-			wantErr:       transformers.ErrInvalidParameters,
+			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
 			name: "error - invalid max_value type",
 			params: map[string]any{
+				"generator": deterministic,
 				"min_value": 1.5,
 				"max_value": "invalid",
 				"precision": 2,
 			},
-			generatorType: Deterministic,
-			wantErr:       transformers.ErrInvalidParameters,
+			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
 			name: "error - invalid precision type",
 			params: map[string]any{
+				"generator": random,
 				"min_value": 1.5,
 				"precision": "invalid",
 			},
-			generatorType: Random,
-			wantErr:       transformers.ErrInvalidParameters,
+			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
 			name: "error - invalid generator type",
 			params: map[string]any{
+				"generator": "invalid",
 				"min_value": 1.5,
 				"max_value": 10.5,
 				"precision": 2,
 			},
-			generatorType: "invalid",
-			wantErr:       transformers.ErrUnsupportedGenerator,
+			wantErr: transformers.ErrUnsupportedGenerator,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewFloatTransformer(tc.generatorType, tc.params)
+			transformer, err := NewFloatTransformer(tc.params)
 			require.ErrorIs(t, err, tc.wantErr)
 			if err != nil {
 				return
@@ -117,67 +120,68 @@ func TestFloatTransformer_Transform(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		value         any
-		params        transformers.Parameters
-		generatorType GeneratorType
-		wantErr       error
+		name    string
+		value   any
+		params  transformers.Parameters
+		wantErr error
 	}{
 		{
 			name:  "ok - random with float64",
 			value: float64(5.5),
 			params: map[string]any{
+				"generator": random,
 				"min_value": 9.999999999999,
 				"max_value": 10.0,
 				"precision": 12,
 			},
-			generatorType: Random,
-			wantErr:       nil,
+			wantErr: nil,
 		},
 		{
-			name:          "ok - deterministic with float32, with default params",
-			value:         float32(5555.5),
-			generatorType: Deterministic,
-			wantErr:       nil,
+			name:  "ok - deterministic with float32, with default params",
+			value: float32(5555.5),
+			params: transformers.Parameters{
+				"generator": deterministic,
+			},
+			wantErr: nil,
 		},
 		{
 			name:  "ok - deterministic with byte slice",
 			value: []byte{0, 0, 0, 50},
 			params: map[string]any{
+				"generator": deterministic,
 				"min_value": 1.0,
 				"max_value": 100000.0000000001,
 			},
-			generatorType: Deterministic,
-			wantErr:       nil,
+			wantErr: nil,
 		},
 		{
 			name:  "error - invalid value type",
 			value: "invalid",
 			params: map[string]any{
+				"generator": random,
 				"min_value": 1.0,
 				"max_value": 10.0,
 				"precision": 2,
 			},
-			generatorType: Random,
-			wantErr:       transformers.ErrUnsupportedValueType,
+			wantErr: transformers.ErrUnsupportedValueType,
 		},
 		{
 			name:  "error - nil value",
 			value: nil,
 			params: map[string]any{
+				"generator": random,
 				"min_value": 1.0,
 				"max_value": 10.0,
 				"precision": 2,
 			},
-			generatorType: Random,
-			wantErr:       transformers.ErrUnsupportedValueType,
+			wantErr: transformers.ErrUnsupportedValueType,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewFloatTransformer(tc.generatorType, tc.params)
+			transformer, err := NewFloatTransformer(tc.params)
 			require.NoError(t, err)
 
 			got, err := transformer.Transform(tc.value)
@@ -202,7 +206,7 @@ func TestFloatTransformer_Transform(t *testing.T) {
 			}
 
 			// if deterministic, check if we get the same result again
-			if tc.generatorType == Deterministic {
+			if mustGetGeneratorType(t, tc.params) == deterministic {
 				gotAgain, err := transformer.Transform(tc.value)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/greenmask/greenmask_float_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_float_transformer_test.go
@@ -17,7 +17,7 @@ func Test_NewFloatTransformer(t *testing.T) {
 	tests := []struct {
 		name          string
 		params        transformers.Parameters
-		generatorType transformers.GeneratorType
+		generatorType GeneratorType
 		wantErr       error
 	}{
 		{
@@ -26,7 +26,7 @@ func Test_NewFloatTransformer(t *testing.T) {
 				"min_value": 1.01,
 				"max_value": 10.5,
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 			wantErr:       nil,
 		},
 		{
@@ -36,7 +36,7 @@ func Test_NewFloatTransformer(t *testing.T) {
 				"max_value": 100.0,
 				"precision": 44,
 			},
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			wantErr:       nil,
 		},
 		{
@@ -47,7 +47,7 @@ func Test_NewFloatTransformer(t *testing.T) {
 		{
 			name:          "ok - deterministic with default",
 			params:        map[string]any{},
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			wantErr:       nil,
 		},
 		{
@@ -66,7 +66,7 @@ func Test_NewFloatTransformer(t *testing.T) {
 				"max_value": 10.5,
 				"precision": 2,
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 			wantErr:       transformers.ErrInvalidParameters,
 		},
 		{
@@ -76,7 +76,7 @@ func Test_NewFloatTransformer(t *testing.T) {
 				"max_value": "invalid",
 				"precision": 2,
 			},
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			wantErr:       transformers.ErrInvalidParameters,
 		},
 		{
@@ -85,7 +85,7 @@ func Test_NewFloatTransformer(t *testing.T) {
 				"min_value": 1.5,
 				"precision": "invalid",
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 			wantErr:       transformers.ErrInvalidParameters,
 		},
 		{
@@ -120,7 +120,7 @@ func TestFloatTransformer_Transform(t *testing.T) {
 		name          string
 		value         any
 		params        transformers.Parameters
-		generatorType transformers.GeneratorType
+		generatorType GeneratorType
 		wantErr       error
 	}{
 		{
@@ -131,13 +131,13 @@ func TestFloatTransformer_Transform(t *testing.T) {
 				"max_value": 10.0,
 				"precision": 12,
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 			wantErr:       nil,
 		},
 		{
 			name:          "ok - deterministic with float32, with default params",
 			value:         float32(5555.5),
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			wantErr:       nil,
 		},
 		{
@@ -147,7 +147,7 @@ func TestFloatTransformer_Transform(t *testing.T) {
 				"min_value": 1.0,
 				"max_value": 100000.0000000001,
 			},
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			wantErr:       nil,
 		},
 		{
@@ -158,7 +158,7 @@ func TestFloatTransformer_Transform(t *testing.T) {
 				"max_value": 10.0,
 				"precision": 2,
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 			wantErr:       transformers.ErrUnsupportedValueType,
 		},
 		{
@@ -169,7 +169,7 @@ func TestFloatTransformer_Transform(t *testing.T) {
 				"max_value": 10.0,
 				"precision": 2,
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 			wantErr:       transformers.ErrUnsupportedValueType,
 		},
 	}
@@ -202,7 +202,7 @@ func TestFloatTransformer_Transform(t *testing.T) {
 			}
 
 			// if deterministic, check if we get the same result again
-			if tc.generatorType == transformers.Deterministic {
+			if tc.generatorType == Deterministic {
 				gotAgain, err := transformer.Transform(tc.value)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/greenmask/greenmask_integer_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_integer_transformer.go
@@ -22,10 +22,11 @@ type IntegerTransformer struct {
 
 var errUnsupportedSizeError = errors.New("greenmask_integer: size must be 2 or 4")
 
-// NewIntegerTransformer creates a new IntegerTransformer with the specified generator and parameters.
-// The size parameter must be 2, 4 or 8, and the min_value and max_value parameters
-// must be valid integers within the range of the specified size.
-func NewIntegerTransformer(generatorType GeneratorType, params transformers.Parameters) (*IntegerTransformer, error) {
+// NewIntegerTransformer creates a new IntegerTransformer with the specified
+// generator and parameters. The size parameter must be 2 or 4, and the
+// min_value and max_value parameters must be valid integers within the range of
+// the specified size.
+func NewIntegerTransformer(params transformers.Parameters) (*IntegerTransformer, error) {
 	size, err := findParameter(params, "size", int(defaultSize))
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_integer: size must be an integer: %w", err)
@@ -54,7 +55,7 @@ func NewIntegerTransformer(generatorType GeneratorType, params transformers.Para
 		return nil, err
 	}
 
-	if err := setGenerator(t, generatorType); err != nil {
+	if err := setGenerator(t, params); err != nil {
 		return nil, err
 	}
 

--- a/pkg/transformers/greenmask/greenmask_integer_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_integer_transformer.go
@@ -25,7 +25,7 @@ var errUnsupportedSizeError = errors.New("greenmask_integer: size must be 2 or 4
 // NewIntegerTransformer creates a new IntegerTransformer with the specified generator and parameters.
 // The size parameter must be 2, 4 or 8, and the min_value and max_value parameters
 // must be valid integers within the range of the specified size.
-func NewIntegerTransformer(generatorType transformers.GeneratorType, params transformers.Parameters) (*IntegerTransformer, error) {
+func NewIntegerTransformer(generatorType GeneratorType, params transformers.Parameters) (*IntegerTransformer, error) {
 	size, err := findParameter(params, "size", int(defaultSize))
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_integer: size must be an integer: %w", err)

--- a/pkg/transformers/greenmask/greenmask_integer_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_integer_transformer_test.go
@@ -15,19 +15,19 @@ func TestNewIntegerTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
-		generator transformers.GeneratorType
+		generator GeneratorType
 		params    transformers.Parameters
 		wantErr   error
 	}{
 		{
 			name:      "ok - valid default parameters",
-			generator: transformers.Random,
+			generator: Random,
 			params:    transformers.Parameters{},
 			wantErr:   nil,
 		},
 		{
 			name:      "ok - valid custom parameters",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"size":      4,
 				"min_value": -100,
@@ -42,7 +42,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid size, too small",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"size": 0,
 			},
@@ -50,7 +50,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid size, too large",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"size": 9,
 			},
@@ -58,7 +58,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - wrong limits",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"min_value": 100,
 				"max_value": 99,
@@ -67,7 +67,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - wrong limits not fitting size",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"min_value": math.MaxInt,
 				"size":      2,
@@ -76,7 +76,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid size type",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"size": "invalid",
 			},
@@ -84,7 +84,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid min_value type",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"min_value": "invalid",
 			},
@@ -92,7 +92,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid max_value type",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"max_value": "invalid",
 			},
@@ -118,7 +118,7 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name          string
-		generatorType transformers.GeneratorType
+		generatorType GeneratorType
 		input         any
 		params        transformers.Parameters
 
@@ -126,7 +126,7 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 	}{
 		{
 			name:          "ok - transform int8 randomly",
-			generatorType: transformers.Random,
+			generatorType: Random,
 			input:         int8(120),
 			params: map[string]any{
 				"size":      4,
@@ -136,7 +136,7 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "ok - transform uint8 randomly",
-			generatorType: transformers.Random,
+			generatorType: Random,
 			input:         uint8(120),
 			params: map[string]any{
 				"size":      2,
@@ -146,7 +146,7 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "ok - transform []byte randomly",
-			generatorType: transformers.Random,
+			generatorType: Random,
 			input:         []byte{0, 0, 0, 50},
 			params: map[string]any{
 				"size":      4,
@@ -156,7 +156,7 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "ok - transform int16 randomly",
-			generatorType: transformers.Random,
+			generatorType: Random,
 			input:         int16(500),
 			params: map[string]any{
 				"min_value": -400,
@@ -165,28 +165,28 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "ok - transform int64 randomly with default params",
-			generatorType: transformers.Random,
+			generatorType: Random,
 			input:         int64(500),
 		},
 		{
 			name:          "ok - transform int deterministically with default params",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         int(500),
 		},
 		{
 			name:          "ok - transform uint deterministically with default params",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         uint(4646),
 		},
 		{
 			name:          "ok - transform uint32 deterministically with default params",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         uint32(500000000),
 			params:        map[string]any{},
 		},
 		{
 			name:          "ok - transform int32 deterministically",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         int32(45000),
 			params: map[string]any{
 				"size":      2,
@@ -195,7 +195,7 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "ok - transform uint16 deterministically",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         uint16(0),
 			params: map[string]any{
 				"size":      2,
@@ -204,7 +204,7 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "ok - transform uint64 deterministically",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         uint64(1000000000000000000),
 			params: map[string]any{
 				"size":      4,
@@ -213,7 +213,7 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "ok - transform []byte deterministically, oversize",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         []byte{0, 1, 2, 3, 0, 0, 50, 0, 0, 0},
 			params: map[string]any{
 				"size":      2,
@@ -222,14 +222,14 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "invalid type with default params",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         "invalid",
 			params:        map[string]any{},
 			wantErr:       transformers.ErrUnsupportedValueType,
 		},
 		{
 			name:          "invalid type",
-			generatorType: transformers.Random,
+			generatorType: Random,
 			input:         "invalid",
 			params: map[string]any{
 				"size":      4,
@@ -270,7 +270,7 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 			}
 
 			// if deterministic, check if we get the same result again
-			if tt.generatorType == transformers.Deterministic {
+			if tt.generatorType == Deterministic {
 				gotAgain, err := transformer.Transform(tt.input)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/greenmask/greenmask_integer_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_integer_transformer_test.go
@@ -14,21 +14,21 @@ import (
 func TestNewIntegerTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		generator GeneratorType
-		params    transformers.Parameters
-		wantErr   error
+		name    string
+		params  transformers.Parameters
+		wantErr error
 	}{
 		{
-			name:      "ok - valid default parameters",
-			generator: Random,
-			params:    transformers.Parameters{},
-			wantErr:   nil,
+			name: "ok - valid default parameters",
+			params: transformers.Parameters{
+				"generator": random,
+			},
+			wantErr: nil,
 		},
 		{
-			name:      "ok - valid custom parameters",
-			generator: Deterministic,
+			name: "ok - valid custom parameters",
 			params: transformers.Parameters{
+				"generator": deterministic,
 				"size":      4,
 				"min_value": -100,
 				"max_value": 100,
@@ -36,64 +36,66 @@ func TestNewIntegerTransformer(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:      "error - invalid generator type",
-			generator: "invalid",
-			wantErr:   transformers.ErrUnsupportedGenerator,
+			name: "error - invalid generator type",
+			params: transformers.Parameters{
+				"generator": "invalid",
+			},
+			wantErr: transformers.ErrUnsupportedGenerator,
 		},
 		{
-			name:      "error - invalid size, too small",
-			generator: Random,
+			name: "error - invalid size, too small",
 			params: transformers.Parameters{
-				"size": 0,
+				"generator": random,
+				"size":      0,
 			},
 			wantErr: errUnsupportedSizeError,
 		},
 		{
-			name:      "error - invalid size, too large",
-			generator: Deterministic,
+			name: "error - invalid size, too large",
 			params: transformers.Parameters{
-				"size": 9,
+				"generator": deterministic,
+				"size":      9,
 			},
 			wantErr: errUnsupportedSizeError,
 		},
 		{
-			name:      "error - wrong limits",
-			generator: Random,
+			name: "error - wrong limits",
 			params: transformers.Parameters{
+				"generator": random,
 				"min_value": 100,
 				"max_value": 99,
 			},
 			wantErr: greenmasktransformers.ErrWrongLimits,
 		},
 		{
-			name:      "error - wrong limits not fitting size",
-			generator: Random,
+			name: "error - wrong limits not fitting size",
 			params: transformers.Parameters{
+				"generator": random,
 				"min_value": math.MaxInt,
 				"size":      2,
 			},
 			wantErr: greenmasktransformers.ErrWrongLimits,
 		},
 		{
-			name:      "error - invalid size type",
-			generator: Deterministic,
+			name: "error - invalid size type",
 			params: transformers.Parameters{
-				"size": "invalid",
+				"generator": deterministic,
+				"size":      "invalid",
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
-			name:      "error - invalid min_value type",
-			generator: Random,
+			name: "error - invalid min_value type",
 			params: transformers.Parameters{
+				"generator": random,
 				"min_value": "invalid",
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
-			name:      "error - invalid max_value type",
-			generator: Deterministic,
+			name: "error - invalid max_value type",
 			params: transformers.Parameters{
+				"generator": deterministic,
 				"max_value": "invalid",
 			},
 			wantErr: transformers.ErrInvalidParameters,
@@ -103,7 +105,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewIntegerTransformer(tt.generator, tt.params)
+			transformer, err := NewIntegerTransformer(tt.params)
 			require.ErrorIs(t, err, tt.wantErr)
 			if err != nil {
 				return
@@ -117,121 +119,128 @@ func TestNewIntegerTransformer(t *testing.T) {
 func TestIntegerTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name          string
-		generatorType GeneratorType
-		input         any
-		params        transformers.Parameters
+		name   string
+		input  any
+		params transformers.Parameters
 
 		wantErr error
 	}{
 		{
-			name:          "ok - transform int8 randomly",
-			generatorType: Random,
-			input:         int8(120),
+			name:  "ok - transform int8 randomly",
+			input: int8(120),
 			params: map[string]any{
+				"generator": random,
 				"size":      4,
 				"min_value": -100,
 				"max_value": 100,
 			},
 		},
 		{
-			name:          "ok - transform uint8 randomly",
-			generatorType: Random,
-			input:         uint8(120),
+			name:  "ok - transform uint8 randomly",
+			input: uint8(120),
 			params: map[string]any{
+				"generator": random,
 				"size":      2,
 				"min_value": -100,
 				"max_value": 100,
 			},
 		},
 		{
-			name:          "ok - transform []byte randomly",
-			generatorType: Random,
-			input:         []byte{0, 0, 0, 50},
+			name:  "ok - transform []byte randomly",
+			input: []byte{0, 0, 0, 50},
 			params: map[string]any{
+				"generator": random,
 				"size":      4,
 				"min_value": -100,
 				"max_value": 500,
 			},
 		},
 		{
-			name:          "ok - transform int16 randomly",
-			generatorType: Random,
-			input:         int16(500),
+			name:  "ok - transform int16 randomly",
+			input: int16(500),
 			params: map[string]any{
+				"generator": random,
 				"min_value": -400,
 				"max_value": 100,
 			},
 		},
 		{
-			name:          "ok - transform int64 randomly with default params",
-			generatorType: Random,
-			input:         int64(500),
+			name: "ok - transform int64 randomly with default params",
+			params: transformers.Parameters{
+				"generator": random,
+			},
+			input: int64(500),
 		},
 		{
-			name:          "ok - transform int deterministically with default params",
-			generatorType: Deterministic,
-			input:         int(500),
+			name: "ok - transform int deterministically with default params",
+			params: transformers.Parameters{
+				"generator": deterministic,
+			},
+			input: int(500),
 		},
 		{
-			name:          "ok - transform uint deterministically with default params",
-			generatorType: Deterministic,
-			input:         uint(4646),
+			name: "ok - transform uint deterministically with default params",
+			params: transformers.Parameters{
+				"generator": deterministic,
+			},
+			input: uint(4646),
 		},
 		{
-			name:          "ok - transform uint32 deterministically with default params",
-			generatorType: Deterministic,
-			input:         uint32(500000000),
-			params:        map[string]any{},
+			name: "ok - transform uint32 deterministically with default params",
+			params: transformers.Parameters{
+				"generator": deterministic,
+			},
+			input: uint32(500000000),
 		},
 		{
-			name:          "ok - transform int32 deterministically",
-			generatorType: Deterministic,
-			input:         int32(45000),
+			name:  "ok - transform int32 deterministically",
+			input: int32(45000),
 			params: map[string]any{
+				"generator": deterministic,
 				"size":      2,
 				"min_value": -100,
 			},
 		},
 		{
-			name:          "ok - transform uint16 deterministically",
-			generatorType: Deterministic,
-			input:         uint16(0),
+			name:  "ok - transform uint16 deterministically",
+			input: uint16(0),
 			params: map[string]any{
+				"generator": deterministic,
 				"size":      2,
 				"min_value": -100,
 			},
 		},
 		{
-			name:          "ok - transform uint64 deterministically",
-			generatorType: Deterministic,
-			input:         uint64(1000000000000000000),
+			name:  "ok - transform uint64 deterministically",
+			input: uint64(1000000000000000000),
 			params: map[string]any{
+				"generator": deterministic,
 				"size":      4,
 				"min_value": math.MaxInt32 - 2,
 			},
 		},
 		{
-			name:          "ok - transform []byte deterministically, oversize",
-			generatorType: Deterministic,
-			input:         []byte{0, 1, 2, 3, 0, 0, 50, 0, 0, 0},
+			name:  "ok - transform []byte deterministically, oversize",
+			input: []byte{0, 1, 2, 3, 0, 0, 50, 0, 0, 0},
 			params: map[string]any{
+				"generator": deterministic,
 				"size":      2,
 				"min_value": -100,
 			},
 		},
 		{
-			name:          "invalid type with default params",
-			generatorType: Deterministic,
-			input:         "invalid",
-			params:        map[string]any{},
-			wantErr:       transformers.ErrUnsupportedValueType,
+			name:  "invalid type with default params",
+			input: "invalid",
+			params: map[string]any{
+				"generator": deterministic,
+			},
+			wantErr: transformers.ErrUnsupportedValueType,
 		},
 		{
-			name:          "invalid type",
-			generatorType: Random,
-			input:         "invalid",
+			name:  "invalid type",
+			input: "invalid",
 			params: map[string]any{
+				"generator": random,
 				"size":      4,
 				"min_value": -100,
 				"max_value": 100,
@@ -243,7 +252,7 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewIntegerTransformer(tt.generatorType, tt.params)
+			transformer, err := NewIntegerTransformer(tt.params)
 			require.NoError(t, err)
 
 			got, err := transformer.Transform(tt.input)
@@ -270,7 +279,7 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 			}
 
 			// if deterministic, check if we get the same result again
-			if tt.generatorType == Deterministic {
+			if mustGetGeneratorType(t, tt.params) == deterministic {
 				gotAgain, err := transformer.Transform(tt.input)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/greenmask/greenmask_string_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_string_transformer.go
@@ -15,7 +15,7 @@ type StringTransformer struct {
 
 const defaultSymbols = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 
-func NewStringTransformer(generatorType transformers.GeneratorType, params transformers.Parameters) (*StringTransformer, error) {
+func NewStringTransformer(generatorType GeneratorType, params transformers.Parameters) (*StringTransformer, error) {
 	symbols, err := findParameter(params, "symbols", defaultSymbols)
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_string: symbols must be a string: %w", err)

--- a/pkg/transformers/greenmask/greenmask_string_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_string_transformer.go
@@ -15,7 +15,7 @@ type StringTransformer struct {
 
 const defaultSymbols = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 
-func NewStringTransformer(generatorType GeneratorType, params transformers.Parameters) (*StringTransformer, error) {
+func NewStringTransformer(params transformers.Parameters) (*StringTransformer, error) {
 	symbols, err := findParameter(params, "symbols", defaultSymbols)
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_string: symbols must be a string: %w", err)
@@ -36,7 +36,7 @@ func NewStringTransformer(generatorType GeneratorType, params transformers.Param
 		return nil, err
 	}
 
-	if err := setGenerator(t, generatorType); err != nil {
+	if err := setGenerator(t, params); err != nil {
 		return nil, err
 	}
 

--- a/pkg/transformers/greenmask/greenmask_string_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_string_transformer_test.go
@@ -13,65 +13,65 @@ func Test_NewStringTransformer(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		params        transformers.Parameters
-		generatorType GeneratorType
+		name   string
+		params transformers.Parameters
 
 		wantErr error
 	}{
 		{
 			name: "ok - random",
 			params: map[string]any{
+				"generator":  random,
 				"symbols":    "abcdef",
 				"min_length": int(2),
 				"max_length": int(2),
 			},
-			generatorType: Random,
 
 			wantErr: nil,
 		},
 		{
 			name: "ok - deterministic",
 			params: map[string]any{
+				"generator":  deterministic,
 				"symbols":    "abcdef",
 				"min_length": int(2),
 				"max_length": int(2),
 			},
-			generatorType: Deterministic,
 
 			wantErr: nil,
 		},
 		{
 			name: "error - invalid symbols",
 			params: map[string]any{
-				"symbols": 123,
+				"generator": random,
+				"symbols":   123,
 			},
-			generatorType: Random,
 
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
 			name: "error - invalid min length",
 			params: map[string]any{
+				"generator":  random,
 				"min_length": "2",
 			},
-			generatorType: Random,
 
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
 			name: "error - invalid max length",
 			params: map[string]any{
+				"generator":  random,
 				"max_length": "2",
 			},
-			generatorType: Random,
 
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
-			name:          "error - invalid generator",
-			params:        map[string]any{},
-			generatorType: "invalid",
+			name: "error - invalid generator",
+			params: map[string]any{
+				"generator": "invalid",
+			},
 
 			wantErr: transformers.ErrUnsupportedGenerator,
 		},
@@ -81,7 +81,7 @@ func Test_NewStringTransformer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := NewStringTransformer(tc.generatorType, tc.params)
+			_, err := NewStringTransformer(tc.params)
 			require.ErrorIs(t, err, tc.wantErr)
 		})
 	}
@@ -91,10 +91,9 @@ func TestStringTransformer_Transform(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		value         any
-		params        transformers.Parameters
-		generatorType GeneratorType
+		name   string
+		value  any
+		params transformers.Parameters
 
 		wantLen int
 		wantStr string
@@ -104,11 +103,11 @@ func TestStringTransformer_Transform(t *testing.T) {
 			name:  "ok - random with string",
 			value: "hello",
 			params: map[string]any{
+				"generator":  random,
 				"symbols":    "abcdef",
 				"min_length": int(2),
 				"max_length": int(2),
 			},
-			generatorType: Random,
 
 			wantLen: 2,
 			wantErr: nil,
@@ -117,11 +116,11 @@ func TestStringTransformer_Transform(t *testing.T) {
 			name:  "ok - random with []byte",
 			value: []byte("hello"),
 			params: map[string]any{
+				"generator":  random,
 				"symbols":    "abcdef",
 				"min_length": int(2),
 				"max_length": int(2),
 			},
-			generatorType: Random,
 
 			wantLen: 2,
 			wantErr: nil,
@@ -130,11 +129,11 @@ func TestStringTransformer_Transform(t *testing.T) {
 			name:  "ok - deterministic",
 			value: "hello",
 			params: map[string]any{
+				"generator":  deterministic,
 				"symbols":    "abcdef",
 				"min_length": int(2),
 				"max_length": int(2),
 			},
-			generatorType: Deterministic,
 
 			wantLen: 2,
 			wantStr: "dc",
@@ -144,11 +143,11 @@ func TestStringTransformer_Transform(t *testing.T) {
 			name:  "error - unsupported value type",
 			value: 1,
 			params: map[string]any{
+				"generator":  random,
 				"symbols":    "abcdef",
 				"min_length": int(2),
 				"max_length": int(2),
 			},
-			generatorType: Random,
 
 			wantLen: 0,
 			wantErr: transformers.ErrUnsupportedValueType,
@@ -159,7 +158,7 @@ func TestStringTransformer_Transform(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			transformer, err := NewStringTransformer(tc.generatorType, tc.params)
+			transformer, err := NewStringTransformer(tc.params)
 			require.NoError(t, err)
 
 			got, err := transformer.Transform(tc.value)

--- a/pkg/transformers/greenmask/greenmask_string_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_string_transformer_test.go
@@ -15,7 +15,7 @@ func Test_NewStringTransformer(t *testing.T) {
 	tests := []struct {
 		name          string
 		params        transformers.Parameters
-		generatorType transformers.GeneratorType
+		generatorType GeneratorType
 
 		wantErr error
 	}{
@@ -26,7 +26,7 @@ func Test_NewStringTransformer(t *testing.T) {
 				"min_length": int(2),
 				"max_length": int(2),
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 
 			wantErr: nil,
 		},
@@ -37,7 +37,7 @@ func Test_NewStringTransformer(t *testing.T) {
 				"min_length": int(2),
 				"max_length": int(2),
 			},
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 
 			wantErr: nil,
 		},
@@ -46,7 +46,7 @@ func Test_NewStringTransformer(t *testing.T) {
 			params: map[string]any{
 				"symbols": 123,
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 
 			wantErr: transformers.ErrInvalidParameters,
 		},
@@ -55,7 +55,7 @@ func Test_NewStringTransformer(t *testing.T) {
 			params: map[string]any{
 				"min_length": "2",
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 
 			wantErr: transformers.ErrInvalidParameters,
 		},
@@ -64,7 +64,7 @@ func Test_NewStringTransformer(t *testing.T) {
 			params: map[string]any{
 				"max_length": "2",
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 
 			wantErr: transformers.ErrInvalidParameters,
 		},
@@ -94,7 +94,7 @@ func TestStringTransformer_Transform(t *testing.T) {
 		name          string
 		value         any
 		params        transformers.Parameters
-		generatorType transformers.GeneratorType
+		generatorType GeneratorType
 
 		wantLen int
 		wantStr string
@@ -108,7 +108,7 @@ func TestStringTransformer_Transform(t *testing.T) {
 				"min_length": int(2),
 				"max_length": int(2),
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 
 			wantLen: 2,
 			wantErr: nil,
@@ -121,7 +121,7 @@ func TestStringTransformer_Transform(t *testing.T) {
 				"min_length": int(2),
 				"max_length": int(2),
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 
 			wantLen: 2,
 			wantErr: nil,
@@ -134,7 +134,7 @@ func TestStringTransformer_Transform(t *testing.T) {
 				"min_length": int(2),
 				"max_length": int(2),
 			},
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 
 			wantLen: 2,
 			wantStr: "dc",
@@ -148,7 +148,7 @@ func TestStringTransformer_Transform(t *testing.T) {
 				"min_length": int(2),
 				"max_length": int(2),
 			},
-			generatorType: transformers.Random,
+			generatorType: Random,
 
 			wantLen: 0,
 			wantErr: transformers.ErrUnsupportedValueType,

--- a/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
@@ -20,7 +20,7 @@ var (
 	errInvalidTimestamp            = errors.New("greenmask_timestamp: min_timestamp and max_timestamp must be valid RFC3339 timestamps")
 )
 
-func NewUTCTimestampTransformer(generatorType GeneratorType, params transformers.Parameters) (*UTCTimestampTransformer, error) {
+func NewUTCTimestampTransformer(params transformers.Parameters) (*UTCTimestampTransformer, error) {
 	truncatePart, err := findParameter(params, "truncate_part", "")
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_integer: truncate_part must be a string: %w", err)
@@ -58,7 +58,7 @@ func NewUTCTimestampTransformer(generatorType GeneratorType, params transformers
 		return nil, err
 	}
 
-	if err := setGenerator(t, generatorType); err != nil {
+	if err := setGenerator(t, params); err != nil {
 		return nil, err
 	}
 

--- a/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
@@ -20,7 +20,7 @@ var (
 	errInvalidTimestamp            = errors.New("greenmask_timestamp: min_timestamp and max_timestamp must be valid RFC3339 timestamps")
 )
 
-func NewUTCTimestampTransformer(generatorType transformers.GeneratorType, params transformers.Parameters) (*UTCTimestampTransformer, error) {
+func NewUTCTimestampTransformer(generatorType GeneratorType, params transformers.Parameters) (*UTCTimestampTransformer, error) {
 	truncatePart, err := findParameter(params, "truncate_part", "")
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_integer: truncate_part must be a string: %w", err)

--- a/pkg/transformers/greenmask/greenmask_timestamp_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_timestamp_transformer_test.go
@@ -14,84 +14,83 @@ import (
 func TestNewUTCTimestampTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		generator GeneratorType
-		params    transformers.Parameters
-		wantErr   error
+		name    string
+		params  transformers.Parameters
+		wantErr error
 	}{
 		{
-			name:      "ok - valid random",
-			generator: Random,
+			name: "ok - valid random",
 			params: transformers.Parameters{
+				"generator":     random,
 				"min_timestamp": "2021-01-01T00:00:00Z",
 				"max_timestamp": "2022-01-02T00:00:00Z",
 			},
 			wantErr: nil,
 		},
 		{
-			name:      "error - invalid truncate_part",
-			generator: Deterministic,
+			name: "error - invalid truncate_part",
 			params: transformers.Parameters{
+				"generator":     deterministic,
 				"truncate_part": 1.2,
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
-			name:      "error - invalid min_timestamp",
-			generator: Deterministic,
+			name: "error - invalid min_timestamp",
 			params: transformers.Parameters{
+				"generator":     deterministic,
 				"min_timestamp": 1.2,
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
-			name:      "error - invalid min_timestamp format",
-			generator: Deterministic,
+			name: "error - invalid min_timestamp format",
 			params: transformers.Parameters{
+				"generator":     deterministic,
 				"min_timestamp": "2021 Jan 01",
 				"max_timestamp": "2022-01-02T00:00:00Z",
 			},
 			wantErr: errInvalidTimestamp,
 		},
 		{
-			name:      "error - invalid max_timestamp",
-			generator: Random,
+			name: "error - invalid max_timestamp",
 			params: transformers.Parameters{
+				"generator":     random,
 				"min_timestamp": "2021-01-01T00:00:00Z",
 				"max_timestamp": 1.2,
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
-			name:      "error - invalid max_timestamp format",
-			generator: Deterministic,
+			name: "error - invalid max_timestamp format",
 			params: transformers.Parameters{
+				"generator":     deterministic,
 				"min_timestamp": "2021-01-01T00:00:00Z",
 				"max_timestamp": "2021 Jan 01",
 			},
 			wantErr: errInvalidTimestamp,
 		},
 		{
-			name:      "error - min_timestamp not specified",
-			generator: Random,
+			name: "error - min_timestamp not specified",
 			params: transformers.Parameters{
+				"generator":     random,
 				"max_timestamp": "2022-01-02T00:00:00Z",
 			},
 			wantErr: errMinMaxTimestampNotSpecified,
 		},
 		{
-			name:      "error - min_timestamp equal to max_timestamp",
-			generator: Deterministic,
+			name: "error - min_timestamp equal to max_timestamp",
 			params: transformers.Parameters{
+				"generator":     deterministic,
 				"min_timestamp": "2023-01-02T00:00:00Z",
 				"max_timestamp": "2023-01-02T00:01:00+01:00",
 			},
 			wantErr: greenmasktransformers.ErrWrongLimits,
 		},
 		{
-			name:      "error - invalid generator type",
-			generator: "invalid",
+			name: "error - invalid generator type",
 			params: transformers.Parameters{
+				"generator":     "invalid",
 				"min_timestamp": "2021-01-01T00:00:00Z",
 				"max_timestamp": "2022-01-02T00:00:00Z",
 			},
@@ -101,7 +100,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewUTCTimestampTransformer(tt.generator, tt.params)
+			transformer, err := NewUTCTimestampTransformer(tt.params)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
 				return
@@ -115,17 +114,16 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 func TestUTCTimestampTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name          string
-		generatorType GeneratorType
-		input         any
-		params        transformers.Parameters
-		wantErr       error
+		name    string
+		input   any
+		params  transformers.Parameters
+		wantErr error
 	}{
 		{
-			name:          "ok - transform string randomly",
-			generatorType: Random,
-			input:         "test",
+			name:  "ok - transform string randomly",
+			input: "test",
 			params: transformers.Parameters{
+				"generator":     random,
 				"min_timestamp": "2022-01-01T00:00:00Z",
 				"max_timestamp": "2023-01-02T00:00:00Z",
 				"truncate_part": "month",
@@ -133,10 +131,10 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:          "ok - transform []byte deterministically",
-			generatorType: Deterministic,
-			input:         []byte("test"),
+			name:  "ok - transform []byte deterministically",
+			input: []byte("test"),
 			params: transformers.Parameters{
+				"generator":     deterministic,
 				"min_timestamp": "2021-01-01T00:00:00Z",
 				"max_timestamp": "2023-01-02T00:00:00Z",
 				"truncate_part": "day",
@@ -144,10 +142,10 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:          "ok - transform time.Time deterministically",
-			generatorType: Deterministic,
-			input:         time.Now(),
+			name:  "ok - transform time.Time deterministically",
+			input: time.Now(),
 			params: transformers.Parameters{
+				"generator":     deterministic,
 				"min_timestamp": "2020-01-01T00:00:00Z",
 				"max_timestamp": "2023-01-02T00:00:00Z",
 				"truncate_part": "hour",
@@ -155,10 +153,10 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:          "ok - truncate after millisecond part",
-			generatorType: Deterministic,
-			input:         "2021-01-01T00:00:00Z",
+			name:  "ok - truncate after millisecond part",
+			input: "2021-01-01T00:00:00Z",
 			params: transformers.Parameters{
+				"generator":     deterministic,
 				"min_timestamp": "2023-01-01T00:00:00Z",
 				"max_timestamp": "2023-01-01T01:10:00+01:00",
 				"truncate_part": "millisecond",
@@ -166,10 +164,10 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:          "error - invalid input type",
-			generatorType: Deterministic,
-			input:         1,
+			name:  "error - invalid input type",
+			input: 1,
 			params: transformers.Parameters{
+				"generator":     deterministic,
 				"min_timestamp": "2020-01-01T00:00:00Z",
 				"max_timestamp": "2023-01-02T00:00:00Z",
 			},
@@ -179,7 +177,7 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewUTCTimestampTransformer(tt.generatorType, tt.params)
+			transformer, err := NewUTCTimestampTransformer(tt.params)
 			require.NoError(t, err)
 			require.NotNil(t, transformer)
 
@@ -235,7 +233,7 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 			require.LessOrEqual(t, result, maxTimestamp)
 
 			// if deterministic, check that the same input always produces the same output
-			if tt.generatorType == Deterministic {
+			if mustGetGeneratorType(t, tt.params) == deterministic {
 				gotAgain, err := transformer.Transform(tt.input)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/greenmask/greenmask_timestamp_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_timestamp_transformer_test.go
@@ -15,13 +15,13 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
-		generator transformers.GeneratorType
+		generator GeneratorType
 		params    transformers.Parameters
 		wantErr   error
 	}{
 		{
 			name:      "ok - valid random",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"min_timestamp": "2021-01-01T00:00:00Z",
 				"max_timestamp": "2022-01-02T00:00:00Z",
@@ -30,7 +30,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid truncate_part",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"truncate_part": 1.2,
 			},
@@ -38,7 +38,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid min_timestamp",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"min_timestamp": 1.2,
 			},
@@ -46,7 +46,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid min_timestamp format",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"min_timestamp": "2021 Jan 01",
 				"max_timestamp": "2022-01-02T00:00:00Z",
@@ -55,7 +55,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid max_timestamp",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"min_timestamp": "2021-01-01T00:00:00Z",
 				"max_timestamp": 1.2,
@@ -64,7 +64,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid max_timestamp format",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"min_timestamp": "2021-01-01T00:00:00Z",
 				"max_timestamp": "2021 Jan 01",
@@ -73,7 +73,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - min_timestamp not specified",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"max_timestamp": "2022-01-02T00:00:00Z",
 			},
@@ -81,7 +81,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - min_timestamp equal to max_timestamp",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"min_timestamp": "2023-01-02T00:00:00Z",
 				"max_timestamp": "2023-01-02T00:01:00+01:00",
@@ -116,14 +116,14 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name          string
-		generatorType transformers.GeneratorType
+		generatorType GeneratorType
 		input         any
 		params        transformers.Parameters
 		wantErr       error
 	}{
 		{
 			name:          "ok - transform string randomly",
-			generatorType: transformers.Random,
+			generatorType: Random,
 			input:         "test",
 			params: transformers.Parameters{
 				"min_timestamp": "2022-01-01T00:00:00Z",
@@ -134,7 +134,7 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "ok - transform []byte deterministically",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         []byte("test"),
 			params: transformers.Parameters{
 				"min_timestamp": "2021-01-01T00:00:00Z",
@@ -145,7 +145,7 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "ok - transform time.Time deterministically",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         time.Now(),
 			params: transformers.Parameters{
 				"min_timestamp": "2020-01-01T00:00:00Z",
@@ -156,7 +156,7 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "ok - truncate after millisecond part",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         "2021-01-01T00:00:00Z",
 			params: transformers.Parameters{
 				"min_timestamp": "2023-01-01T00:00:00Z",
@@ -167,7 +167,7 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:          "error - invalid input type",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         1,
 			params: transformers.Parameters{
 				"min_timestamp": "2020-01-01T00:00:00Z",
@@ -235,7 +235,7 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 			require.LessOrEqual(t, result, maxTimestamp)
 
 			// if deterministic, check that the same input always produces the same output
-			if tt.generatorType == transformers.Deterministic {
+			if tt.generatorType == Deterministic {
 				gotAgain, err := transformer.Transform(tt.input)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/greenmask/greenmask_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_transformer.go
@@ -10,17 +10,28 @@ import (
 	"github.com/xataio/pgstream/pkg/transformers"
 )
 
-func setGenerator(t greenmasktransformers.Transformer, generatorType transformers.GeneratorType) error {
+type GeneratorType string
+
+const (
+	Random        GeneratorType = "random"
+	Deterministic GeneratorType = "deterministic"
+)
+
+func GetGeneratorType(params transformers.Parameters) (GeneratorType, error) {
+	return findParameter(params, "generator", Random)
+}
+
+func setGenerator(t greenmasktransformers.Transformer, generatorType GeneratorType) error {
 	// default to using random generator
 	if generatorType == "" {
-		generatorType = transformers.Random
+		generatorType = Random
 	}
 
 	var greenmaskGenerator greenmaskgenerators.Generator
 	switch generatorType {
-	case transformers.Random:
+	case Random:
 		greenmaskGenerator = greenmaskgenerators.NewRandomBytes(time.Now().UnixNano(), t.GetRequiredGeneratorByteLength())
-	case transformers.Deterministic:
+	case Deterministic:
 		var err error
 		greenmaskGenerator, err = greenmaskgenerators.GetHashBytesGen([]byte{}, t.GetRequiredGeneratorByteLength())
 		if err != nil {

--- a/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
@@ -13,7 +13,7 @@ import (
 
 var errMinMaxValueNotSpecified = errors.New("min_value and max_value must be specified")
 
-func NewUnixTimestampTransformer(generatorType transformers.GeneratorType, params transformers.Parameters) (*IntegerTransformer, error) {
+func NewUnixTimestampTransformer(generatorType GeneratorType, params transformers.Parameters) (*IntegerTransformer, error) {
 	minValueStr, foundMin, err := transformers.FindParameter[string](params, "min_value")
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_unix_timestamp: min_value must be a string: %w", err)

--- a/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
@@ -13,7 +13,7 @@ import (
 
 var errMinMaxValueNotSpecified = errors.New("min_value and max_value must be specified")
 
-func NewUnixTimestampTransformer(generatorType GeneratorType, params transformers.Parameters) (*IntegerTransformer, error) {
+func NewUnixTimestampTransformer(params transformers.Parameters) (*IntegerTransformer, error) {
 	minValueStr, foundMin, err := transformers.FindParameter[string](params, "min_value")
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_unix_timestamp: min_value must be a string: %w", err)
@@ -48,7 +48,7 @@ func NewUnixTimestampTransformer(generatorType GeneratorType, params transformer
 		return nil, err
 	}
 
-	if err := setGenerator(t, generatorType); err != nil {
+	if err := setGenerator(t, params); err != nil {
 		return nil, err
 	}
 

--- a/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer_test.go
@@ -15,13 +15,13 @@ func TestNewUnixTimestampTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
-		generator transformers.GeneratorType
+		generator GeneratorType
 		params    transformers.Parameters
 		wantErr   error
 	}{
 		{
 			name:      "ok - valid random",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"min_value": "-1741957250",
 				"max_value": "1741957250",
@@ -39,7 +39,7 @@ func TestNewUnixTimestampTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid min_value",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"min_value": 3.0,
 			},
@@ -47,7 +47,7 @@ func TestNewUnixTimestampTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid max_value",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"min_value": "1741957250",
 				"max_value": 3,
@@ -56,7 +56,7 @@ func TestNewUnixTimestampTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - min_value missing",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"max_value": "1741957250",
 			},
@@ -64,7 +64,7 @@ func TestNewUnixTimestampTransformer(t *testing.T) {
 		},
 		{
 			name:      "error - invalid limits",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"min_value": "1741957250",
 				"max_value": "1741957250",
@@ -90,13 +90,13 @@ func TestUnixTimestampTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
-		generator transformers.GeneratorType
+		generator GeneratorType
 		input     any
 		params    transformers.Parameters
 	}{
 		{
 			name:      "ok - random",
-			generator: transformers.Random,
+			generator: Random,
 			params: transformers.Parameters{
 				"min_value": "1625097600",
 				"max_value": "1625184000",
@@ -105,7 +105,7 @@ func TestUnixTimestampTransformer_Transform(t *testing.T) {
 		},
 		{
 			name:      "ok - deterministic",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			params: transformers.Parameters{
 				"min_value": "1625097600",
 				"max_value": "1625184000",
@@ -136,7 +136,7 @@ func TestUnixTimestampTransformer_Transform(t *testing.T) {
 			require.LessOrEqual(t, v, maxVal)
 
 			// if deterministic, check if we get the same result again
-			if tt.generator == transformers.Deterministic {
+			if tt.generator == Deterministic {
 				gotAgain, err := transformer.Transform(tt.input)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer_test.go
@@ -14,58 +14,57 @@ import (
 func TestNewUnixTimestampTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		generator GeneratorType
-		params    transformers.Parameters
-		wantErr   error
+		name    string
+		params  transformers.Parameters
+		wantErr error
 	}{
 		{
-			name:      "ok - valid random",
-			generator: Random,
+			name: "ok - valid random",
 			params: transformers.Parameters{
+				"generator": random,
 				"min_value": "-1741957250",
 				"max_value": "1741957250",
 			},
 			wantErr: nil,
 		},
 		{
-			name:      "error - invalid generator",
-			generator: "invalid",
+			name: "error - invalid generator",
 			params: transformers.Parameters{
+				"generator": "invalid",
 				"min_value": "-1741957250",
 				"max_value": "1741957250",
 			},
 			wantErr: transformers.ErrUnsupportedGenerator,
 		},
 		{
-			name:      "error - invalid min_value",
-			generator: Deterministic,
+			name: "error - invalid min_value",
 			params: transformers.Parameters{
+				"generator": deterministic,
 				"min_value": 3.0,
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
-			name:      "error - invalid max_value",
-			generator: Deterministic,
+			name: "error - invalid max_value",
 			params: transformers.Parameters{
+				"generator": deterministic,
 				"min_value": "1741957250",
 				"max_value": 3,
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
-			name:      "error - min_value missing",
-			generator: Deterministic,
+			name: "error - min_value missing",
 			params: transformers.Parameters{
+				"generator": deterministic,
 				"max_value": "1741957250",
 			},
 			wantErr: errMinMaxValueNotSpecified,
 		},
 		{
-			name:      "error - invalid limits",
-			generator: Random,
+			name: "error - invalid limits",
 			params: transformers.Parameters{
+				"generator": random,
 				"min_value": "1741957250",
 				"max_value": "1741957250",
 			},
@@ -75,7 +74,7 @@ func TestNewUnixTimestampTransformer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewUnixTimestampTransformer(tt.generator, tt.params)
+			transformer, err := NewUnixTimestampTransformer(tt.params)
 			require.ErrorIs(t, err, tt.wantErr)
 			if err != nil {
 				return
@@ -89,24 +88,23 @@ func TestNewUnixTimestampTransformer(t *testing.T) {
 func TestUnixTimestampTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		generator GeneratorType
-		input     any
-		params    transformers.Parameters
+		name   string
+		input  any
+		params transformers.Parameters
 	}{
 		{
-			name:      "ok - random",
-			generator: Random,
+			name: "ok - random",
 			params: transformers.Parameters{
+				"generator": random,
 				"min_value": "1625097600",
 				"max_value": "1625184000",
 			},
 			input: int64(0),
 		},
 		{
-			name:      "ok - deterministic",
-			generator: Deterministic,
+			name: "ok - deterministic",
 			params: transformers.Parameters{
+				"generator": deterministic,
 				"min_value": "1625097600",
 				"max_value": "1625184000",
 			},
@@ -116,7 +114,7 @@ func TestUnixTimestampTransformer_Transform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			transformer, err := NewUnixTimestampTransformer(tt.generator, tt.params)
+			transformer, err := NewUnixTimestampTransformer(tt.params)
 			require.NoError(t, err)
 			got, err := transformer.Transform(tt.input)
 			require.NoError(t, err)
@@ -136,11 +134,17 @@ func TestUnixTimestampTransformer_Transform(t *testing.T) {
 			require.LessOrEqual(t, v, maxVal)
 
 			// if deterministic, check if we get the same result again
-			if tt.generator == Deterministic {
+			if mustGetGeneratorType(t, tt.params) == deterministic {
 				gotAgain, err := transformer.Transform(tt.input)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)
 			}
 		})
 	}
+}
+
+func mustGetGeneratorType(t *testing.T, params transformers.Parameters) string {
+	gt, err := getGeneratorType(params)
+	require.NoError(t, err)
+	return gt
 }

--- a/pkg/transformers/greenmask/greenmask_uuid_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_uuid_transformer.go
@@ -12,9 +12,9 @@ type UUIDTransformer struct {
 	transformer *greenmasktransformers.RandomUuidTransformer
 }
 
-func NewUUIDTransformer(generatorType GeneratorType) (*UUIDTransformer, error) {
+func NewUUIDTransformer(params transformers.Parameters) (*UUIDTransformer, error) {
 	t := greenmasktransformers.NewRandomUuidTransformer()
-	if err := setGenerator(t, generatorType); err != nil {
+	if err := setGenerator(t, params); err != nil {
 		return nil, err
 	}
 	return &UUIDTransformer{

--- a/pkg/transformers/greenmask/greenmask_uuid_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_uuid_transformer.go
@@ -12,7 +12,7 @@ type UUIDTransformer struct {
 	transformer *greenmasktransformers.RandomUuidTransformer
 }
 
-func NewUUIDTransformer(generatorType transformers.GeneratorType) (*UUIDTransformer, error) {
+func NewUUIDTransformer(generatorType GeneratorType) (*UUIDTransformer, error) {
 	t := greenmasktransformers.NewRandomUuidTransformer()
 	if err := setGenerator(t, generatorType); err != nil {
 		return nil, err

--- a/pkg/transformers/greenmask/greenmask_uuid_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_uuid_transformer_test.go
@@ -15,17 +15,17 @@ func Test_NewUUIDTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name      string
-		generator transformers.GeneratorType
+		generator GeneratorType
 		wantErr   error
 	}{
 		{
 			name:      "ok - valid random",
-			generator: transformers.Random,
+			generator: Random,
 			wantErr:   nil,
 		},
 		{
 			name:      "ok - valid deterministic",
-			generator: transformers.Deterministic,
+			generator: Deterministic,
 			wantErr:   nil,
 		},
 		{
@@ -51,37 +51,37 @@ func Test_UUIDTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name          string
-		generatorType transformers.GeneratorType
+		generatorType GeneratorType
 		input         any
 		wantErr       error
 	}{
 		{
 			name:          "ok - string, random",
-			generatorType: transformers.Random,
+			generatorType: Random,
 			input:         "123e4567-e89b-12d3-a456-426655440000",
 			wantErr:       nil,
 		},
 		{
 			name:          "ok - []byte, deterministic",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         []byte("123e4567-e89b-12d3-a456-426655440000"),
 			wantErr:       nil,
 		},
 		{
 			name:          "ok - uuid.UUID, deterministic",
-			generatorType: transformers.Deterministic,
+			generatorType: Deterministic,
 			input:         uuid.MustParse("123e4567-e89b-12d3-a456-426655440000"),
 			wantErr:       nil,
 		},
 		{
 			name:          "error - invalid input type",
-			generatorType: transformers.Random,
+			generatorType: Random,
 			input:         123,
 			wantErr:       transformers.ErrUnsupportedValueType,
 		},
 		{
 			name:          "error - cannot parse string",
-			generatorType: transformers.Random,
+			generatorType: Random,
 			input:         "123e45671e89b112d31a4561426655440000",
 			wantErr:       errors.New("invalid UUID format"),
 		},
@@ -103,7 +103,7 @@ func Test_UUIDTransformer_Transform(t *testing.T) {
 			require.NotNil(t, got)
 
 			// if deterministic, the same input should always produce the same output
-			if tc.generatorType == transformers.Deterministic {
+			if tc.generatorType == Deterministic {
 				gotAgain, err := transformer.Transform(tc.input)
 				require.NoError(t, err)
 				require.Equal(t, got, gotAgain)

--- a/pkg/transformers/string_transformer.go
+++ b/pkg/transformers/string_transformer.go
@@ -14,7 +14,7 @@ type StringTransformer struct {
 	// minLength int
 }
 
-func NewStringTransformer(generator GeneratorType, params Parameters) (*StringTransformer, error) {
+func NewStringTransformer(params Parameters) (*StringTransformer, error) {
 	return &StringTransformer{}, nil
 }
 

--- a/pkg/transformers/string_transformer_test.go
+++ b/pkg/transformers/string_transformer_test.go
@@ -45,7 +45,7 @@ func TestStringTransformer_Transform(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			st, err := NewStringTransformer(Random, nil)
+			st, err := NewStringTransformer(nil)
 			require.NoError(t, err)
 			got, err := st.Transform(tc.value)
 			require.ErrorIs(t, err, tc.wantErr)

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -13,7 +13,6 @@ type Transformer interface {
 
 type Config struct {
 	Name       TransformerType
-	Generator  GeneratorType
 	Parameters Parameters
 }
 
@@ -34,13 +33,6 @@ const (
 	GreenmaskUnixTimestamp TransformerType = "greenmask_unix_timestamp"
 	GreenmaskDate          TransformerType = "greenmask_date"
 	GreenmaskUTCTimestamp  TransformerType = "greenmask_utc_timestamp"
-)
-
-type GeneratorType string
-
-const (
-	Random        GeneratorType = "random"
-	Deterministic GeneratorType = "deterministic"
 )
 
 type Parameters map[string]any

--- a/pkg/wal/processor/transformer/wal_transformer.go
+++ b/pkg/wal/processor/transformer/wal_transformer.go
@@ -141,7 +141,6 @@ func transformerMapFromRules(rules *Rules) (map[string]columnTransformers, error
 func transformerRulesToConfig(rules TransformerRules) *transformers.Config {
 	return &transformers.Config{
 		Name:       transformers.TransformerType(rules.Name),
-		Generator:  transformers.GeneratorType(rules.Generator),
 		Parameters: rules.Parameters,
 	}
 }

--- a/pkg/wal/processor/transformer/wal_transformer_rules.go
+++ b/pkg/wal/processor/transformer/wal_transformer_rules.go
@@ -23,7 +23,6 @@ type TableRules struct {
 
 type TransformerRules struct {
 	Name       string         `yaml:"name"`
-	Generator  string         `yaml:"generator"`
 	Parameters map[string]any `yaml:"parameters"`
 }
 

--- a/pkg/wal/processor/transformer/wal_transformer_rules_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_rules_test.go
@@ -28,8 +28,7 @@ func Test_readRulesFromFile(t *testing.T) {
 						Table:  "test1",
 						ColumnRules: map[string]TransformerRules{
 							"column_1": {
-								Name:      "string",
-								Generator: "random",
+								Name: "string",
 								Parameters: map[string]any{
 									"min_length": 1,
 									"max_length": 2,
@@ -42,8 +41,7 @@ func Test_readRulesFromFile(t *testing.T) {
 						Table:  "test2",
 						ColumnRules: map[string]TransformerRules{
 							"column_2": {
-								Name:      "string",
-								Generator: "deterministic",
+								Name: "string",
 								Parameters: map[string]any{
 									"symbols": "abcdef",
 								},

--- a/pkg/wal/processor/transformer/wal_transformer_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_test.go
@@ -20,7 +20,7 @@ func TestTransformer_New(t *testing.T) {
 	t.Parallel()
 
 	mockProcessor := &mocks.Processor{}
-	testTransformer, err := transformers.NewStringTransformer(transformers.Random, nil)
+	testTransformer, err := transformers.NewStringTransformer(nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -229,7 +229,7 @@ func Test_transformerMapFromRules(t *testing.T) {
 
 	testSchema := "test_schema"
 	testTable := "test_table"
-	testTransformer, err := transformers.NewStringTransformer(transformers.Random, nil)
+	testTransformer, err := transformers.NewStringTransformer(nil)
 	require.NoError(t, err)
 	testKey := testSchema + "/" + testTable
 
@@ -249,12 +249,10 @@ func Test_transformerMapFromRules(t *testing.T) {
 						Table:  testTable,
 						ColumnRules: map[string]TransformerRules{
 							"column_1": {
-								Name:      "string",
-								Generator: "random",
+								Name: "string",
 							},
 							"column_2": {
-								Name:      "string",
-								Generator: "random",
+								Name: "string",
 							},
 						},
 					},
@@ -285,8 +283,7 @@ func Test_transformerMapFromRules(t *testing.T) {
 						Table:  testTable,
 						ColumnRules: map[string]TransformerRules{
 							"column_1": {
-								Name:      "invalid",
-								Generator: "random",
+								Name: "invalid",
 							},
 						},
 					},


### PR DESCRIPTION
Move the generator type a parameter of the greenmask transformers, since it's specific to greenmask (similar to how neosync has a `seed` parameter). 