### PR TITLE
[Snapshots] Fix data snapshot concurrency

### DIFF
--- a/pkg/wal/listener/snapshot/adapter/wal_snapshot_generator_adapter.go
+++ b/pkg/wal/listener/snapshot/adapter/wal_snapshot_generator_adapter.go
@@ -4,6 +4,7 @@ package adapter
 
 import (
 	"context"
+	"time"
 
 	loglib "github.com/xataio/pgstream/pkg/log"
 	"github.com/xataio/pgstream/pkg/snapshot"
@@ -44,7 +45,12 @@ func WithLogger(logger loglib.Logger) Option {
 	}
 }
 
-func (s *SnapshotGeneratorAdapter) CreateSnapshot(ctx context.Context) error {
+func (s *SnapshotGeneratorAdapter) CreateSnapshot(ctx context.Context) (err error) {
+	startTime := time.Now()
+	defer func() {
+		s.logger.Info("snapshot generation completed", loglib.Fields{"err": err, "duration": time.Since(startTime).String()})
+	}()
+
 	errGroup, ctx := errgroup.WithContext(ctx)
 	snapshotChan := make(chan *snapshot.Snapshot)
 	for i := uint(0); i < s.snapshotWorkers; i++ {

--- a/pkg/wal/processor/postgres/postgres_batch_writer.go
+++ b/pkg/wal/processor/postgres/postgres_batch_writer.go
@@ -125,7 +125,7 @@ func (w *BatchWriter) ProcessWALEvent(ctx context.Context, walEvent *wal.Event) 
 	}
 
 	for _, q := range queries {
-		w.logger.Debug("batching query", loglib.Fields{"sql": q.getSQL(), "args": q.getArgs()})
+		w.logger.Debug("batching query", loglib.Fields{"sql": q.getSQL(), "args": q.getArgs(), "commit_position": walEvent.CommitPosition})
 		msg := batch.NewWALMessage(q, walEvent.CommitPosition)
 		if err := w.batchSender.AddToBatch(ctx, msg); err != nil {
 			return err


### PR DESCRIPTION
This PR updates the postgres data snapshot generator to remove the nested transactions during the table range processing, which makes the process slower and sometimes even stuck. This was not necessary, but an oversight during implementation.