### PR TITLE
Bug fixes

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -40,12 +40,15 @@ func loadConfig() error {
 	return nil
 }
 
-func pgURL() string {
-	pgurl := viper.GetString("pgurl")
-	if pgurl != "" {
-		return pgurl
+func pgURL() (url string) {
+	switch {
+	case viper.GetString("PGSTREAM_POSTGRES_LISTENER_URL") != "":
+		return viper.GetString("PGSTREAM_POSTGRES_LISTENER_URL")
+	case viper.GetString("PGSTREAM_POSTGRES_SNAPSHOT_LISTENER_URL") != "":
+		return viper.GetString("PGSTREAM_POSTGRES_SNAPSHOT_LISTENER_URL")
+	default:
+		return viper.GetString("pgurl")
 	}
-	return viper.GetString("PGSTREAM_POSTGRES_LISTENER_URL")
 }
 
 func replicationSlotName() string {

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -24,7 +24,7 @@ func init() {
 	rootCmd.PersistentFlags().String("pgurl", "postgres://postgres:postgres@localhost?sslmode=disable", "Postgres URL")
 	rootCmd.PersistentFlags().String("replication-slot", "", "Name of the postgres replication slot to be created")
 	rootCmd.PersistentFlags().StringP("config", "c", "", ".env config file to use if any")
-	rootCmd.PersistentFlags().String("log-level", "debug", "log level for the application")
+	rootCmd.PersistentFlags().String("log-level", "debug", "log level for the application. One of trace, debug, info, warn, error, fatal, panic")
 
 	viper.BindPFlag("pgurl", rootCmd.PersistentFlags().Lookup("pgurl"))
 	viper.BindPFlag("replication-slot", rootCmd.PersistentFlags().Lookup("replication-slot"))

--- a/internal/postgres/pg_utils.go
+++ b/internal/postgres/pg_utils.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import "github.com/lib/pq"
+
+func QuoteIdentifier(s string) string {
+	return pq.QuoteIdentifier(s)
+}

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/lib/pq"
 	pglib "github.com/xataio/pgstream/internal/postgres"
 	loglib "github.com/xataio/pgstream/pkg/log"
 	"github.com/xataio/pgstream/pkg/snapshot"
@@ -187,7 +186,7 @@ func (sg *SnapshotGenerator) snapshotTableRange(ctx context.Context, snapshotID,
 		})
 
 		query := fmt.Sprintf("SELECT * FROM %s.%s WHERE ctid BETWEEN '(%d,0)' AND '(%d,0)'",
-			pq.QuoteIdentifier(schema), pq.QuoteIdentifier(table), pageRange.start, pageRange.end)
+			pglib.QuoteIdentifier(schema), pglib.QuoteIdentifier(table), pageRange.start, pageRange.end)
 		rows, err := tx.Query(ctx, query)
 		if err != nil {
 			return fmt.Errorf("querying table rows: %w", err)

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -148,7 +148,14 @@ func (s *SnapshotGenerator) pgdumpOptions(ss *snapshot.Snapshot) pglib.PGDumpOpt
 		Schemas:          []string{pglib.QuoteIdentifier(ss.SchemaName)},
 	}
 
+	const wildcard = "*"
 	for _, table := range ss.TableNames {
+		if table == wildcard {
+			// wildcard means all tables in the schema, so no table filter
+			// required
+			opts.Tables = nil
+			break
+		}
 		opts.Tables = append(opts.Tables, pglib.QuoteIdentifier(ss.SchemaName)+"."+pglib.QuoteIdentifier(table))
 	}
 

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -145,11 +145,11 @@ func (s *SnapshotGenerator) pgdumpOptions(ss *snapshot.Snapshot) pglib.PGDumpOpt
 		ConnectionString: s.sourceURL,
 		Format:           "c",
 		SchemaOnly:       true,
-		Schemas:          []string{ss.SchemaName},
+		Schemas:          []string{pglib.QuoteIdentifier(ss.SchemaName)},
 	}
 
 	for _, table := range ss.TableNames {
-		opts.Tables = append(opts.Tables, ss.SchemaName+"."+table)
+		opts.Tables = append(opts.Tables, pglib.QuoteIdentifier(ss.SchemaName)+"."+pglib.QuoteIdentifier(table))
 	}
 
 	return opts

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
@@ -53,8 +53,8 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 					ConnectionString: "source-url",
 					Format:           "c",
 					SchemaOnly:       true,
-					Schemas:          []string{testSchema},
-					Tables:           []string{testSchema + "." + testTable},
+					Schemas:          []string{pglib.QuoteIdentifier(testSchema)},
+					Tables:           []string{pglib.QuoteIdentifier(testSchema) + "." + pglib.QuoteIdentifier(testTable)},
 				}, po)
 				return testDump, nil
 			},

--- a/pkg/snapshot/store/postgres/pg_snapshot_store.go
+++ b/pkg/snapshot/store/postgres/pg_snapshot_store.go
@@ -135,5 +135,5 @@ func (s *Store) createTable(ctx context.Context) error {
 }
 
 func snapshotsTable() string {
-	return fmt.Sprintf("%s.%s", pq.QuoteIdentifier(store.SchemaName), pq.QuoteIdentifier(store.TableName))
+	return fmt.Sprintf("%s.%s", postgres.QuoteIdentifier(store.SchemaName), postgres.QuoteIdentifier(store.TableName))
 }

--- a/pkg/stream/stream_init.go
+++ b/pkg/stream/stream_init.go
@@ -42,7 +42,7 @@ func Init(ctx context.Context, pgURL, replicationSlotName string) error {
 		return fmt.Errorf("error creating postgres migrator: %w", err)
 	}
 
-	if err := migrator.Up(); err != nil {
+	if err := migrator.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
 		return fmt.Errorf("failed to run internal pgstream migrations: %w", err)
 	}
 
@@ -85,7 +85,7 @@ func TearDown(ctx context.Context, pgURL, replicationSlotName string) error {
 		return fmt.Errorf("error creating postgres migrator: %w", err)
 	}
 
-	if err := migrator.Down(); err != nil {
+	if err := migrator.Down(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
 		return fmt.Errorf("failed to run internal pgstream migrations: %w", err)
 	}
 

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
@@ -8,7 +8,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/lib/pq"
+	pglib "github.com/xataio/pgstream/internal/postgres"
 	"github.com/xataio/pgstream/pkg/wal"
 )
 
@@ -134,7 +134,7 @@ func (a *dmlAdapter) buildOnConflictQuery(d *wal.Data) string {
 
 		cols := make([]string, 0, len(d.Columns))
 		for _, col := range d.Columns {
-			cols = append(cols, fmt.Sprintf("%[1]s = EXCLUDED.%[1]s", pq.QuoteIdentifier(col.Name)))
+			cols = append(cols, fmt.Sprintf("%[1]s = EXCLUDED.%[1]s", pglib.QuoteIdentifier(col.Name)))
 		}
 		return fmt.Sprintf(" ON CONFLICT (%s) DO UPDATE SET %s", strings.Join(primaryKeyCols, ","), strings.Join(cols, ", "))
 	case onConflictDoNothing:
@@ -169,7 +169,7 @@ func (a *dmlAdapter) extractPrimaryKeyColumnNames(colIDs []string, cols []wal.Co
 }
 
 func quotedTableName(schemaName, tableName string) string {
-	return fmt.Sprintf("%s.%s", pq.QuoteIdentifier(schemaName), pq.QuoteIdentifier(tableName))
+	return fmt.Sprintf("%s.%s", pglib.QuoteIdentifier(schemaName), pglib.QuoteIdentifier(tableName))
 }
 
 func parseOnConflictAction(action string) (onConflictAction, error) {


### PR DESCRIPTION
This PR adds a few small bug fixes:
- Add quote identifiers to snapshot schema/tables
- Do not translate wildcard `*` tables for pgdump schema snapshots, since it prevents all resources in a given schema to be dumped by having a list of tables.
- Update CLI init to account for Postgres URL env variables correctly
- Do not return an error when migrations have no changes
- Add options to CLI `log-level` flag
