### PR TITLE
[CLI] Bug fixes

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -40,12 +40,15 @@ func loadConfig() error {
 	return nil
 }
 
-func pgURL() string {
-	pgurl := viper.GetString("pgurl")
-	if pgurl != "" {
-		return pgurl
+func pgURL() (url string) {
+	switch {
+	case viper.GetString("PGSTREAM_POSTGRES_LISTENER_URL") != "":
+		return viper.GetString("PGSTREAM_POSTGRES_LISTENER_URL")
+	case viper.GetString("PGSTREAM_POSTGRES_SNAPSHOT_LISTENER_URL") != "":
+		return viper.GetString("PGSTREAM_POSTGRES_SNAPSHOT_LISTENER_URL")
+	default:
+		return viper.GetString("pgurl")
 	}
-	return viper.GetString("PGSTREAM_POSTGRES_LISTENER_URL")
 }
 
 func replicationSlotName() string {

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -24,7 +24,7 @@ func init() {
 	rootCmd.PersistentFlags().String("pgurl", "postgres://postgres:postgres@localhost?sslmode=disable", "Postgres URL")
 	rootCmd.PersistentFlags().String("replication-slot", "", "Name of the postgres replication slot to be created")
 	rootCmd.PersistentFlags().StringP("config", "c", "", ".env config file to use if any")
-	rootCmd.PersistentFlags().String("log-level", "debug", "log level for the application")
+	rootCmd.PersistentFlags().String("log-level", "debug", "log level for the application. One of trace, debug, info, warn, error, fatal, panic")
 
 	viper.BindPFlag("pgurl", rootCmd.PersistentFlags().Lookup("pgurl"))
 	viper.BindPFlag("replication-slot", rootCmd.PersistentFlags().Lookup("replication-slot"))

--- a/pkg/stream/stream_init.go
+++ b/pkg/stream/stream_init.go
@@ -42,7 +42,7 @@ func Init(ctx context.Context, pgURL, replicationSlotName string) error {
 		return fmt.Errorf("error creating postgres migrator: %w", err)
 	}
 
-	if err := migrator.Up(); err != nil {
+	if err := migrator.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
 		return fmt.Errorf("failed to run internal pgstream migrations: %w", err)
 	}
 
@@ -85,7 +85,7 @@ func TearDown(ctx context.Context, pgURL, replicationSlotName string) error {
 		return fmt.Errorf("error creating postgres migrator: %w", err)
 	}
 
-	if err := migrator.Down(); err != nil {
+	if err := migrator.Down(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
 		return fmt.Errorf("failed to run internal pgstream migrations: %w", err)
 	}
 


### PR DESCRIPTION
This PR adds a few small bug fixes:
- Update CLI init to account for Postgres URL env variables correctly
- Do not return an error when migrations have no changes
- Add options to CLI `log-level` flag