### PR TITLE
Reset config file after reading transformation file

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -15,12 +15,14 @@ func Load() error {
 }
 
 func LoadFile(file string) error {
-	if file != "" {
-		viper.SetConfigFile(file)
-		viper.SetConfigType(filepath.Ext(file)[1:])
-		if err := viper.ReadInConfig(); err != nil {
-			return fmt.Errorf("reading config: %w", err)
-		}
+	if file == "" {
+		return nil
+	}
+	fmt.Printf("using config file: %s\n", file) //nolint:forbidigo //logger hasn't been configured yet
+	viper.SetConfigFile(file)
+	viper.SetConfigType(filepath.Ext(file)[1:])
+	if err := viper.ReadInConfig(); err != nil {
+		return fmt.Errorf("reading config: %w", err)
 	}
 
 	transformerRulesFile := viper.GetString("PGSTREAM_TRANSFORMER_RULES_FILE")
@@ -30,7 +32,11 @@ func LoadFile(file string) error {
 		if err := viper.MergeInConfig(); err != nil {
 			return fmt.Errorf("reading transformer rules config: %w", err)
 		}
+		// reset after merge
+		viper.SetConfigFile(file)
+		viper.SetConfigType(filepath.Ext(file)[1:])
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR resets the config file after merging the transformation rules yaml file from the env file. Otherwise, we can't determine if it's the yaml or env config, to parse it into the stream config for the run.