### PR TITLE
Read config case sensitive, using yaml unmarshal

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -4,10 +4,12 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/viper"
 	"github.com/xataio/pgstream/pkg/stream"
+	"gopkg.in/yaml.v3"
 )
 
 func Load() error {
@@ -77,9 +79,14 @@ func ParseStreamConfig() (*stream.Config, error) {
 	cfgFile := viper.GetViper().ConfigFileUsed()
 	switch ext := filepath.Ext(cfgFile); ext {
 	case ".yml", ".yaml":
-		yamlCfg := YAMLConfig{}
-		if err := viper.Unmarshal(&yamlCfg); err != nil {
+		buf, err := os.ReadFile(cfgFile)
+		if err != nil {
 			return nil, err
+		}
+		yamlCfg := YAMLConfig{}
+		err = yaml.Unmarshal(buf, &yamlCfg)
+		if err != nil {
+			return nil, fmt.Errorf("in file %q: %w", cfgFile, err)
 		}
 		return yamlCfg.toStreamConfig()
 	default:

--- a/cmd/config/config_env.go
+++ b/cmd/config/config_env.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/viper"
 	"github.com/xataio/pgstream/pkg/backoff"
@@ -26,6 +27,7 @@ import (
 	"github.com/xataio/pgstream/pkg/wal/processor/webhook/notifier"
 	"github.com/xataio/pgstream/pkg/wal/processor/webhook/subscription/server"
 	pgreplication "github.com/xataio/pgstream/pkg/wal/replication/postgres"
+	"gopkg.in/yaml.v3"
 )
 
 func envConfigToStreamConfig() (*stream.Config, error) {
@@ -328,15 +330,24 @@ func parseInjectorConfig() *injector.Config {
 }
 
 func parseTransformerConfig() (*transformer.Config, error) {
-	if viper.GetString("PGSTREAM_TRANSFORMER_RULES_FILE") == "" {
+	filename := viper.GetString("PGSTREAM_TRANSFORMER_RULES_FILE")
+	if filename == "" {
 		return nil, nil
 	}
+
+	buf, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
 	yamlConfig := struct {
 		Transformations TransformationsConfig `mapstructure:"transformations"`
 	}{}
-	if err := viper.Unmarshal(&yamlConfig); err != nil {
-		return nil, err
+	err = yaml.Unmarshal(buf, &yamlConfig)
+	if err != nil {
+		return nil, fmt.Errorf("in file %q: %w", filename, err)
 	}
+
 	return yamlConfig.Transformations.parseTransformationConfig(), nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.35.0
 	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c
 	golang.org/x/sync v0.13.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -168,5 +169,4 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/grpc v1.71.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
This PR changes the library used to unmarshal yaml files, from viper to yaml, to allow reading case sensitive keys correctly.

fixes: #277 