### PR TITLE
Add NoopTransformer

### DIFF
--- a/pkg/transformers/builder/transformer_builder.go
+++ b/pkg/transformers/builder/transformer_builder.go
@@ -44,6 +44,8 @@ func New(cfg *transformers.Config) (transformers.Transformer, error) {
 		return transformers.NewPhoneNumberTransformer(cfg.Parameters)
 	case transformers.Masking:
 		return transformers.NewMaskingTransformer(cfg.Parameters)
+	case transformers.Noop:
+		return transformers.NewNoopTransformer()
 	default:
 		return nil, fmt.Errorf("%w: unexpected transformer name '%s'", transformers.ErrUnsupportedTransformer, cfg.Name)
 	}

--- a/pkg/transformers/noop_transformer.go
+++ b/pkg/transformers/noop_transformer.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformers
+
+type NoopTransformer struct{}
+
+// NoopTransformer is intended to be used as a placeholder for a transformer that does nothing.
+// It is used when a transformer is required for the validation phase for security reasons.
+func NewNoopTransformer() (*NoopTransformer, error) {
+	return &NoopTransformer{}, nil
+}
+
+// Transform method should ideally never be called.
+func (nt *NoopTransformer) Transform(value Value) (any, error) {
+	return value, nil
+}
+
+func (nt *NoopTransformer) CompatibleTypes() []SupportedDataType {
+	return []SupportedDataType{AllDataType}
+}

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -46,6 +46,7 @@ const (
 	GreenmaskDate          TransformerType = "greenmask_date"
 	GreenmaskUTCTimestamp  TransformerType = "greenmask_utc_timestamp"
 	Masking                TransformerType = "masking"
+	Noop                   TransformerType = "noop"
 )
 
 type SupportedDataType string
@@ -68,6 +69,7 @@ const (
 	UInt8ArrayOf16DataType SupportedDataType = "uint8_array_of_16"
 	DateDataType           SupportedDataType = "date"
 	DatetimeDataType       SupportedDataType = "datetime"
+	AllDataType            SupportedDataType = "all"
 )
 
 const (
@@ -196,4 +198,10 @@ func ValidateParameters(provided map[string]any, expected []string) error {
 	}
 
 	return nil
+}
+
+// IsNoopTransformer checks if a transformer is a NoopTransformer.
+func IsNoopTransformer(t Transformer) bool {
+	_, isNoop := t.(*NoopTransformer)
+	return isNoop
 }

--- a/pkg/wal/processor/transformer/wal_transformer_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_test.go
@@ -50,6 +50,9 @@ func TestTransformer_New(t *testing.T) {
 							"column_2": {
 								Name: "string",
 							},
+							"column_3": {
+								Name: "noop",
+							},
 						},
 					},
 				},

--- a/pkg/wal/processor/transformer/wal_transformer_validator_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_validator_test.go
@@ -66,6 +66,10 @@ func TestPostgresTransformerValidator(t *testing.T) {
 							Name:        "created_at",
 							DataTypeOID: pgtype.TimestamptzOID,
 						},
+						{
+							Name:        "column_with_noop_transformer",
+							DataTypeOID: pgtype.Float8OID,
+						},
 					}
 				},
 				CloseFn: func() {},
@@ -178,6 +182,13 @@ func TestPostgresTransformerValidator(t *testing.T) {
 						CompatibleTypesFn: func() []transformers.SupportedDataType {
 							return []transformers.SupportedDataType{
 								transformers.DatetimeDataType,
+							}
+						},
+					},
+					"column_with_noop_transformer": &mocks.Transformer{
+						CompatibleTypesFn: func() []transformers.SupportedDataType {
+							return []transformers.SupportedDataType{
+								transformers.AllDataType,
 							}
 						},
 					},


### PR DESCRIPTION
Noop transformers are expected to be used for security purposes only. We will be validating that all columns have assigned a transformer if the strict validation mode is enabled. In that case noop transformers can be used for columns that does not need to be actually transformed.

Noop transformers will be added to the map initially, for the transformer processor. But they will be deleted after the validation phase, as we don't want to be calling their `Transform` method every single time.

fixes: #259 