### PR TITLE
Merge wildcard tables in filter

### DIFF
--- a/pkg/wal/processor/filter/wal_filter.go
+++ b/pkg/wal/processor/filter/wal_filter.go
@@ -159,10 +159,16 @@ func (t schemaTableMap) containsSchemaTable(schema, table string) bool {
 
 func (t schemaTableMap) getSchemaTables(schema string) map[string]struct{} {
 	tables, found := t[schema]
-	if found {
-		return tables
+	if !found {
+		return t[wildcard]
 	}
-	return t[wildcard]
+
+	// make sure it's merged with the wildcard schema tables if any
+	for table := range t[wildcard] {
+		tables[table] = struct{}{}
+	}
+
+	return tables
 }
 
 func (t schemaTableMap) add(schema, table string) {

--- a/pkg/wal/processor/mocks/mock_processor.go
+++ b/pkg/wal/processor/mocks/mock_processor.go
@@ -10,10 +10,16 @@ import (
 
 type Processor struct {
 	ProcessWALEventFn func(ctx context.Context, walEvent *wal.Event) error
+	processCalls      uint
 }
 
 func (m *Processor) ProcessWALEvent(ctx context.Context, walEvent *wal.Event) error {
+	m.processCalls++
 	return m.ProcessWALEventFn(ctx, walEvent)
+}
+
+func (m *Processor) GetProcessCalls() uint {
+	return m.processCalls
 }
 
 func (m *Processor) Name() string {


### PR DESCRIPTION
This PR fixes an edge case with the filtering lists, where if both schema qualified tables and wildcard ones are present, only the schema qualified are matched, skipping events that should otherwise be processed.