### PR TITLE
Add noop transformers support and Strict validation mode

### DIFF
--- a/cmd/config/config_env.go
+++ b/cmd/config/config_env.go
@@ -424,7 +424,7 @@ func parseTransformerConfig() (*transformer.Config, error) {
 		return nil, fmt.Errorf("in file %q: %w", filename, err)
 	}
 
-	return yamlConfig.Transformations.parseTransformationConfig(), nil
+	return yamlConfig.Transformations.parseTransformationConfig()
 }
 
 func parseFilterConfig() *filter.Config {

--- a/cmd/config/test/test_config.yaml
+++ b/cmd/config/test/test_config.yaml
@@ -110,11 +110,13 @@ modifiers:
      - "excluded_schema.test"
      - "another_excluded_schema.*"
   transformations:
-  - schema: public
-    table: test
-    column_transformers:
-      name:
-        name: greenmask_firstname
-        dynamic_parameters:
-          gender:
-            column: sex
+    validation_mode: relaxed
+    table_transformers:
+      - schema: public
+        table: test
+        column_transformers:
+          name:
+            name: greenmask_firstname
+            dynamic_parameters:
+              gender:
+                column: sex

--- a/cmd/config/test/test_transformer_rules.yaml
+++ b/cmd/config/test/test_transformer_rules.yaml
@@ -1,9 +1,11 @@
 transformations:
-  - schema: public
-    table: test
-    column_transformers:
-      name:
-        name: greenmask_firstname
-        dynamic_parameters:
-          gender:
-            column: sex
+  validation_mode: relaxed
+  table_transformers:
+    - schema: public
+      table: test
+      column_transformers:
+        name:
+          name: greenmask_firstname
+          dynamic_parameters:
+            gender:
+              column: sex

--- a/pkg/stream/integration/helper_test.go
+++ b/pkg/stream/integration/helper_test.go
@@ -283,9 +283,11 @@ func testKafkaCfg() kafkalib.ConnConfig {
 func testTransformationRules() []transformer.TableRules {
 	return []transformer.TableRules{
 		{
-			Schema: "public",
-			Table:  "pg2pg_integration_transformer_test",
+			Schema:         "public",
+			Table:          "pg2pg_integration_transformer_test",
+			ValidationMode: "strict",
 			ColumnRules: map[string]transformer.TransformerRules{
+				"id": {},
 				"name": {
 					Name: "neosync_firstname",
 					Parameters: map[string]any{

--- a/pkg/stream/stream_run.go
+++ b/pkg/stream/stream_run.go
@@ -233,12 +233,12 @@ func Run(ctx context.Context, logger loglib.Logger, config *Config, instrumentat
 			pgURL = config.Listener.Snapshot.Generator.URL
 		}
 		if pgURL != "" {
-			pgValidator, err := transformer.NewPostgresTransformerValidator(ctx, pgURL)
+			pgParser, err := transformer.NewPostgresTransformerParser(ctx, pgURL)
 			if err != nil {
 				return fmt.Errorf("error creating postgres transformer validator: %w", err)
 			}
-			defer pgValidator.Close()
-			opts = append(opts, transformer.WithValidator(pgValidator.Validate))
+			defer pgParser.Close()
+			opts = append(opts, transformer.WithParser(pgParser.ParseAndValidate))
 		}
 		transformer, err := transformer.New(ctx, config.Processor.Transformer, processor, opts...)
 		if err != nil {

--- a/pkg/wal/processor/transformer/wal_transformer_rules.go
+++ b/pkg/wal/processor/transformer/wal_transformer_rules.go
@@ -7,9 +7,10 @@ type Rules struct {
 }
 
 type TableRules struct {
-	Schema      string                      `yaml:"schema"`
-	Table       string                      `yaml:"table"`
-	ColumnRules map[string]TransformerRules `yaml:"column_transformers"`
+	Schema         string                      `yaml:"schema"`
+	Table          string                      `yaml:"table"`
+	ColumnRules    map[string]TransformerRules `yaml:"column_transformers"`
+	ValidationMode string                      `yaml:"validation_mode"`
 }
 
 type TransformerRules struct {

--- a/pkg/wal/processor/transformer/wal_transformer_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_test.go
@@ -314,7 +314,7 @@ func Test_transformerMapFromRules(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			transformerMap, err := transformerMapFromRules(tc.rules)
+			transformerMap, err := transformerMapFromRules(tc.rules, nil)
 			require.ErrorIs(t, err, tc.wantErr)
 			require.Equal(t, tc.wantTransformerMap, transformerMap)
 		})

--- a/pkg/wal/processor/transformer/wal_transformer_validator.go
+++ b/pkg/wal/processor/transformer/wal_transformer_validator.go
@@ -29,7 +29,7 @@ func NewPostgresTransformerValidator(ctx context.Context, pgURL string) (*Postgr
 	}, nil
 }
 
-func (v *PostgresTransformerValidator) Validate(ctx context.Context, schemaTable string, transformers ColumnTransformers, columns []string) error {
+func (v *PostgresTransformerValidator) Validate(ctx context.Context, schemaTable string, transformers ColumnTransformers, columns []string, validateStrict bool) error {
 	fieldDescriptions, err := v.getFieldDescriptions(ctx, schemaTable)
 	if err != nil {
 		return err
@@ -39,8 +39,8 @@ func (v *PostgresTransformerValidator) Validate(ctx context.Context, schemaTable
 	mappedColumns := make(map[string]uint32, len(fieldDescriptions))
 	for _, desc := range fieldDescriptions {
 		mappedColumns[string(desc.Name)] = desc.DataTypeOID
-		if !slices.Contains(columns, string(desc.Name)) {
-			// if strict validation is enabled, return error
+		if validateStrict && !slices.Contains(columns, string(desc.Name)) {
+			return fmt.Errorf("column %s of table %s has no transformer configured", desc.Name, schemaTable)
 		}
 	}
 

--- a/pkg/wal/processor/transformer/wal_transformer_validator.go
+++ b/pkg/wal/processor/transformer/wal_transformer_validator.go
@@ -10,60 +10,88 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	pglib "github.com/xataio/pgstream/internal/postgres"
 	"github.com/xataio/pgstream/pkg/transformers"
+	"github.com/xataio/pgstream/pkg/transformers/builder"
 	"golang.org/x/exp/slices"
 )
 
-type PostgresTransformerValidator struct {
+type PostgresTransformerParser struct {
 	conn pglib.Querier
 }
 
 const fieldDescriptionsQuery = "SELECT * FROM %s LIMIT 0"
 
-func NewPostgresTransformerValidator(ctx context.Context, pgURL string) (*PostgresTransformerValidator, error) {
+func NewPostgresTransformerParser(ctx context.Context, pgURL string) (*PostgresTransformerParser, error) {
 	pool, err := pglib.NewConnPool(ctx, pgURL)
 	if err != nil {
 		return nil, err
 	}
-	return &PostgresTransformerValidator{
+	return &PostgresTransformerParser{
 		conn: pool,
 	}, nil
 }
 
-func (v *PostgresTransformerValidator) Validate(ctx context.Context, schemaTable string, transformers ColumnTransformers, columns []string, validateStrict bool) error {
-	fieldDescriptions, err := v.getFieldDescriptions(ctx, schemaTable)
-	if err != nil {
-		return err
-	}
+func (v *PostgresTransformerParser) ParseAndValidate(rules []TableRules) (map[string]ColumnTransformers, error) {
+	transformerMap := map[string]ColumnTransformers{}
+	for _, table := range rules {
+		tableKey := schemaTableKey(table.Schema, table.Table)
+		fieldDescriptions, err := v.getFieldDescriptions(context.Background(), tableKey)
+		if err != nil {
+			return nil, err
+		}
 
-	// map column names to column pg type OIDs
-	mappedColumns := make(map[string]uint32, len(fieldDescriptions))
-	for _, desc := range fieldDescriptions {
-		mappedColumns[string(desc.Name)] = desc.DataTypeOID
-		if validateStrict && !slices.Contains(columns, string(desc.Name)) {
-			return fmt.Errorf("column %s of table %s has no transformer configured", desc.Name, schemaTable)
+		// map column names to column pg type OIDs
+		mappedColumnTypes := make(map[string]uint32, len(fieldDescriptions))
+		for _, desc := range fieldDescriptions {
+			if _, found := table.ColumnRules[string(desc.Name)]; !found {
+				// column is not configured in rules, error out if strict validation mode is enabled
+				if table.ValidationMode == validationModeStrict {
+					return nil, fmt.Errorf("column %s of table %s has no transformer configured", desc.Name, tableKey)
+				}
+				continue
+			}
+			mappedColumnTypes[string(desc.Name)] = desc.DataTypeOID
+		}
+
+		schemaTableTransformers := make(map[string]transformers.Transformer)
+		transformerMap[tableKey] = schemaTableTransformers
+		for colName, transformerRules := range table.ColumnRules {
+			// get the data type so that we can later validate if it's compatible with the configured transformer
+			datatype, found := mappedColumnTypes[colName]
+			if !found {
+				// validate that the column in the rules is present in the table
+				return nil, fmt.Errorf("column %s not found in table %s", colName, tableKey)
+			}
+
+			cfg := transformerRulesToConfig(transformerRules)
+
+			// skip if noop transformer
+			if cfg.Name == "" || cfg.Name == "noop" {
+				continue
+			}
+
+			// build the transformer
+			transformer, err := builder.New(cfg)
+			if err != nil {
+				return nil, err
+			}
+
+			// validate that the transformer is compatible with the column type
+			if !pgTypeCompatibleWithTransformerType(transformer.CompatibleTypes(), datatype) {
+				return nil, fmt.Errorf("transformer specified for column '%s' in table %s does not support pg data type with oid: %d", colName, tableKey, datatype)
+			}
+
+			// add the transformer to the map
+			schemaTableTransformers[colName] = transformer
 		}
 	}
-
-	// check that all column transformers are compatible with corresponding column types
-	for colName, tr := range transformers {
-		datatype, found := mappedColumns[colName]
-		if !found {
-			// validate that all column in the rules are present in the table
-			return fmt.Errorf("column %s not found in table %s", colName, schemaTable)
-		}
-		if !pgTypeCompatibleWithTransformerType(tr.CompatibleTypes(), datatype) {
-			return fmt.Errorf("transformer specified for column '%s' in table %s does not support pg data type with oid: %d", colName, schemaTable, datatype)
-		}
-	}
-
-	return nil
+	return transformerMap, nil
 }
 
-func (v *PostgresTransformerValidator) Close() error {
+func (v *PostgresTransformerParser) Close() error {
 	return v.conn.Close(context.Background())
 }
 
-func (v *PostgresTransformerValidator) getFieldDescriptions(ctx context.Context, schemaTable string) ([]pgconn.FieldDescription, error) {
+func (v *PostgresTransformerParser) getFieldDescriptions(ctx context.Context, schemaTable string) ([]pgconn.FieldDescription, error) {
 	query := fmt.Sprintf(fieldDescriptionsQuery, schemaTable)
 	rows, err := v.conn.Query(ctx, query)
 	if err != nil {

--- a/pkg/wal/processor/transformer/wal_transformer_validator_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_validator_test.go
@@ -219,7 +219,7 @@ func TestPostgresTransformerValidator(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := testPGValidator.Validate(context.Background(), testSchemaTable, tc.transformerMap[testSchemaTable], nil)
+			err := testPGValidator.Validate(context.Background(), testSchemaTable, tc.transformerMap[testSchemaTable], nil, false)
 			if !errors.Is(err, tc.wantErr) {
 				require.Contains(t, err.Error(), tc.wantErr.Error())
 			}

--- a/pkg/wal/processor/transformer/wal_transformer_validator_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_validator_test.go
@@ -219,7 +219,7 @@ func TestPostgresTransformerValidator(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := testPGValidator.Validate(context.Background(), tc.transformerMap)
+			err := testPGValidator.Validate(context.Background(), testSchemaTable, tc.transformerMap[testSchemaTable], nil)
 			if !errors.Is(err, tc.wantErr) {
 				require.Contains(t, err.Error(), tc.wantErr.Error())
 			}

--- a/pkg/wal/processor/transformer/wal_transformer_validator_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_validator_test.go
@@ -73,6 +73,24 @@ func TestPostgresTransformerValidator(t *testing.T) {
 			wantErr:             nil,
 		},
 		{
+			name: "ok - no error for missing column, relaxed mode",
+			transformerRules: []TableRules{
+				{
+					Schema:         "public",
+					Table:          "test",
+					ValidationMode: "relaxed",
+					ColumnRules: map[string]TransformerRules{
+						"name": {
+							Name: "string",
+						},
+					},
+				},
+			},
+
+			wantTransformersFor: []string{"name"},
+			wantErr:             nil,
+		},
+		{
 			name: "error - missing column for strict validation",
 			transformerRules: []TableRules{
 				{


### PR DESCRIPTION
Single PR for both adding noop transformer support and strict validation mode.
Parsing the config, if no validation mode is not provided, the default will be `relaxed` mode. If validation mode is set to `strict` we'll be validating that all columns for that particular table are present in the transformer config, by comparing them to the column list we get from postgres.

fixes: #259 
fixes: #260 