### PR TITLE
Use connection pool in transformer validator

### DIFF
--- a/pkg/stream/stream_run.go
+++ b/pkg/stream/stream_run.go
@@ -233,7 +233,11 @@ func Run(ctx context.Context, logger loglib.Logger, config *Config, instrumentat
 			pgURL = config.Listener.Snapshot.Generator.URL
 		}
 		if pgURL != "" {
-			pgValidator := transformer.NewPostgresTransformerValidator(pgURL)
+			pgValidator, err := transformer.NewPostgresTransformerValidator(ctx, pgURL)
+			if err != nil {
+				return fmt.Errorf("error creating postgres transformer validator: %w", err)
+			}
+			defer pgValidator.Close()
 			opts = append(opts, transformer.WithValidator(pgValidator.Validate))
 		}
 		transformer, err := transformer.New(ctx, config.Processor.Transformer, processor, opts...)

--- a/pkg/wal/processor/transformer/wal_transformer_validator_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_validator_test.go
@@ -74,9 +74,7 @@ func TestPostgresTransformerValidator(t *testing.T) {
 	}
 
 	testPGValidator := PostgresTransformerValidator{
-		connBuilder: func(context.Context) (pglib.Querier, error) {
-			return testQuerier, nil
-		},
+		conn: testQuerier,
 	}
 
 	tests := []struct {


### PR DESCRIPTION
This PR updates the transformer validator to use a connection pool instead of reusing the same connection for the different schema table queries. This should prevent `conn busy` errors during the validation.