### PR TITLE
Close rows immediately to release connection

### DIFF
--- a/pkg/wal/processor/transformer/wal_transformer_validator_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_validator_test.go
@@ -69,6 +69,7 @@ func TestPostgresTransformerValidator(t *testing.T) {
 					}
 				},
 				CloseFn: func() {},
+				ErrFn:   func() error { return nil },
 			}, nil
 		},
 	}


### PR DESCRIPTION
This PR closes the rows immediately to release the underlying connection and prevent potential `conn busy` errors when the pool is maxed out. The current implementation uses a defer that will only close once the for loop is done, holding as many connections open as tables in the range.

Documentation: https://pkg.go.dev/github.com/jackc/pgx/v5#Rows
>Rows must be closed before the *Conn can be used again.

Relates to #293.