### PR TITLE
UUID Transformer: Do not parse string into uuid

### DIFF
--- a/pkg/transformers/greenmask/greenmask_uuid_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_uuid_transformer.go
@@ -31,11 +31,7 @@ func (ut *UUIDTransformer) Transform(value transformers.Value) (any, error) {
 	var toTransform []byte
 	switch val := value.TransformValue.(type) {
 	case string:
-		parsed, err := uuid.Parse(val)
-		if err != nil {
-			return nil, err
-		}
-		toTransform = parsed[:]
+		toTransform = []byte(val)
 	case uuid.UUID:
 		toTransform = val[:]
 	case []byte:

--- a/pkg/transformers/greenmask/greenmask_uuid_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_uuid_transformer_test.go
@@ -86,20 +86,20 @@ func Test_UUIDTransformer_Transform(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "ok - can be any string",
+			params: transformers.Parameters{
+				"generator": deterministic,
+			},
+			input:   "this is not a uuid",
+			wantErr: nil,
+		},
+		{
 			name: "error - invalid input type",
 			params: transformers.Parameters{
 				"generator": random,
 			},
 			input:   123,
 			wantErr: transformers.ErrUnsupportedValueType,
-		},
-		{
-			name: "error - cannot parse string",
-			params: transformers.Parameters{
-				"generator": random,
-			},
-			input:   "123e45671e89b112d31a4561426655440000",
-			wantErr: errors.New("invalid UUID format"),
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Do not parse string into uuid, for uuid transformer, but directly use the bytes instead.