### PR TITLE
Use current commit in version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ generate:
 	# Generate the cli-definition.json file
 	go run tools/build-cli-definition.go
 
-GIT_COMMIT := $(shell git describe --tags HEAD)
+GIT_COMMIT := $(shell git rev-parse --short HEAD)
 .PHONY: build
 build:
-	@go build -ldflags "-X github.com/xataio/pgstream/cmd.Version=$(GIT_COMMIT)" .
+	@go build -ldflags "-X github.com/xataio/pgstream/cmd.Env=development -X github.com/xataio/pgstream/cmd.Version=$(GIT_COMMIT)" .

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -17,13 +17,14 @@ import (
 // Version is the pgstream version
 var (
 	Version = "development"
+	Env     string
 )
 
 func Prepare() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:          "pgstream",
 		SilenceUsage: true,
-		Version:      Version,
+		Version:      version(),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return config.Load()
 		},
@@ -103,4 +104,11 @@ func withSignalWatcher(fn func(ctx context.Context) error) func(cmd *cobra.Comma
 func rootFlagBinding(cmd *cobra.Command) {
 	viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config"))
 	viper.BindPFlag("PGSTREAM_LOG_LEVEL", cmd.PersistentFlags().Lookup("log-level"))
+}
+
+func version() string {
+	if Env != "" {
+		return Env + " (" + Version + ")"
+	}
+	return Version
 }


### PR DESCRIPTION
This PR updates the make build target to use the latest commit instead of the tag version, so that it's easier to track. Adds `development` environment to differentiate between the go releases and local builds.

Example output:
```sh
➜  pgstream git:(update-version-commit-hash) ✗ make build
➜  pgstream git:(update-version-commit-hash) ✗ ./pgstream -v
pgstream version development (aa9a8c6)
```