### PR TITLE
Add literal string transformer

### DIFF
--- a/pkg/transformers/builder/transformer_builder.go
+++ b/pkg/transformers/builder/transformer_builder.go
@@ -34,6 +34,8 @@ func New(cfg *transformers.Config) (transformers.Transformer, error) {
 		return greenmask.NewUTCTimestampTransformer(cfg.Parameters)
 	case transformers.String:
 		return transformers.NewStringTransformer(cfg.Parameters)
+	case transformers.LiteralString:
+		return transformers.NewLiteralStringTransformer(cfg.Parameters)
 	case transformers.NeosyncString:
 		return neosync.NewStringTransformer(cfg.Parameters)
 	case transformers.NeosyncFirstName:

--- a/pkg/transformers/literal_string_transformer.go
+++ b/pkg/transformers/literal_string_transformer.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformers
+
+import (
+	"errors"
+	"fmt"
+)
+
+type LiteralStringTransformer struct {
+	literal string
+}
+
+var (
+	literalStringTransformerParams = []string{"literal"}
+	errLiteralStringCannotBeEmpty  = errors.New("literal_string_transformer: literal parameter cannot be empty")
+)
+
+func NewLiteralStringTransformer(params Parameters) (*LiteralStringTransformer, error) {
+	if err := ValidateParameters(params, literalStringTransformerParams); err != nil {
+		return nil, err
+	}
+
+	literal, _, err := FindParameter[string](params, "literal")
+	if err != nil {
+		return nil, fmt.Errorf("literal_string_transformer: literal must be a string: %w", err)
+	}
+	if literal == "" {
+		return nil, errLiteralStringCannotBeEmpty
+	}
+
+	return &LiteralStringTransformer{
+		literal: literal,
+	}, nil
+}
+
+func (lst *LiteralStringTransformer) Transform(value Value) (any, error) {
+	return lst.literal, nil
+}
+
+func (lst *LiteralStringTransformer) CompatibleTypes() []SupportedDataType {
+	return []SupportedDataType{
+		StringDataType,
+		ByteArrayDataType,
+		JSONDataType,
+	}
+}

--- a/pkg/transformers/literal_string_transformer.go
+++ b/pkg/transformers/literal_string_transformer.go
@@ -40,8 +40,6 @@ func (lst *LiteralStringTransformer) Transform(value Value) (any, error) {
 
 func (lst *LiteralStringTransformer) CompatibleTypes() []SupportedDataType {
 	return []SupportedDataType{
-		StringDataType,
-		ByteArrayDataType,
-		JSONDataType,
+		AllDataTypes,
 	}
 }

--- a/pkg/transformers/literal_string_transformer.go
+++ b/pkg/transformers/literal_string_transformer.go
@@ -13,7 +13,7 @@ type LiteralStringTransformer struct {
 
 var (
 	literalStringTransformerParams = []string{"literal"}
-	errLiteralStringCannotBeEmpty  = errors.New("literal_string_transformer: literal parameter cannot be empty")
+	errLiteralStringNotFound       = errors.New("literal_string_transformer: literal parameter not found")
 )
 
 func NewLiteralStringTransformer(params Parameters) (*LiteralStringTransformer, error) {
@@ -21,12 +21,12 @@ func NewLiteralStringTransformer(params Parameters) (*LiteralStringTransformer, 
 		return nil, err
 	}
 
-	literal, _, err := FindParameter[string](params, "literal")
+	literal, found, err := FindParameter[string](params, "literal")
 	if err != nil {
 		return nil, fmt.Errorf("literal_string_transformer: literal must be a string: %w", err)
 	}
-	if literal == "" {
-		return nil, errLiteralStringCannotBeEmpty
+	if !found {
+		return nil, errLiteralStringNotFound
 	}
 
 	return &LiteralStringTransformer{

--- a/pkg/transformers/literal_string_transformer_test.go
+++ b/pkg/transformers/literal_string_transformer_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLiteralStringTransformer(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		params  Parameters
+		wantErr error
+	}{
+		{
+			name: "ok - valid",
+			params: Parameters{
+				"literal": "test",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "error - invalid literal",
+			params: Parameters{
+				"literal": 123,
+			},
+			wantErr: ErrInvalidParameters,
+		},
+		{
+			name:    "error - empty literal",
+			params:  Parameters{},
+			wantErr: errLiteralStringCannotBeEmpty,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			lst, err := NewLiteralStringTransformer(tc.params)
+			require.ErrorIs(t, err, tc.wantErr)
+			if tc.wantErr != nil {
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, lst)
+		})
+	}
+}
+
+func TestLiteralStringTransformer_Transform(t *testing.T) {
+	t.Parallel()
+	wantOutput := "{'output': 'testoutput'"
+	lst, err := NewLiteralStringTransformer(Parameters{"literal": wantOutput})
+	require.NoError(t, err)
+	tests := []struct {
+		name    string
+		params  Parameters
+		input   any
+		want    any
+		wantErr error
+	}{
+		{
+			name:    "ok - string",
+			input:   "testinput",
+			wantErr: nil,
+		},
+		{
+			name:    "ok - JSON",
+			input:   "{'json': 'jsoninput'}",
+			wantErr: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := lst.Transform(Value{TransformValue: tc.input})
+			require.ErrorIs(t, err, tc.wantErr)
+			if tc.wantErr != nil {
+				return
+			}
+			require.Equal(t, wantOutput, got)
+		})
+	}
+}

--- a/pkg/transformers/literal_string_transformer_test.go
+++ b/pkg/transformers/literal_string_transformer_test.go
@@ -32,7 +32,7 @@ func TestLiteralStringTransformer(t *testing.T) {
 		{
 			name:    "error - empty literal",
 			params:  Parameters{},
-			wantErr: errLiteralStringCannotBeEmpty,
+			wantErr: errLiteralStringNotFound,
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -31,6 +31,7 @@ type TransformerType string
 
 const (
 	String                 TransformerType = "string"
+	LiteralString          TransformerType = "literal_string"
 	PhoneNumber            TransformerType = "phone_number"
 	NeosyncString          TransformerType = "neosync_string"
 	GreenmaskString        TransformerType = "greenmask_string"
@@ -68,6 +69,7 @@ const (
 	UInt8ArrayOf16DataType SupportedDataType = "uint8_array_of_16"
 	DateDataType           SupportedDataType = "date"
 	DatetimeDataType       SupportedDataType = "datetime"
+	JSONDataType           SupportedDataType = "json"
 )
 
 const (

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -70,6 +70,7 @@ const (
 	DateDataType           SupportedDataType = "date"
 	DatetimeDataType       SupportedDataType = "datetime"
 	JSONDataType           SupportedDataType = "json"
+	AllDataTypes           SupportedDataType = "all"
 )
 
 const (

--- a/pkg/wal/processor/transformer/wal_transformer_validator.go
+++ b/pkg/wal/processor/transformer/wal_transformer_validator.go
@@ -125,6 +125,8 @@ func pgTypeCompatibleWithTransformerType(compatibleTypes []transformers.Supporte
 		return slices.Contains(compatibleTypes, transformers.DateDataType)
 	case pgtype.TimestampOID, pgtype.TimestamptzOID:
 		return slices.Contains(compatibleTypes, transformers.DatetimeDataType)
+	case pgtype.JSONBOID:
+		return slices.Contains(compatibleTypes, transformers.JSONDataType)
 	default:
 		return false
 	}

--- a/pkg/wal/processor/transformer/wal_transformer_validator.go
+++ b/pkg/wal/processor/transformer/wal_transformer_validator.go
@@ -102,6 +102,9 @@ func (v *PostgresTransformerParser) getFieldDescriptions(ctx context.Context, sc
 }
 
 func pgTypeCompatibleWithTransformerType(compatibleTypes []transformers.SupportedDataType, pgType uint32) bool {
+	if slices.Contains(compatibleTypes, transformers.AllDataTypes) {
+		return true
+	}
 	switch pgType {
 	case pgtype.TextOID, pgtype.VarcharOID, pgtype.BPCharOID:
 		return slices.Contains(compatibleTypes, transformers.StringDataType)
@@ -125,7 +128,7 @@ func pgTypeCompatibleWithTransformerType(compatibleTypes []transformers.Supporte
 		return slices.Contains(compatibleTypes, transformers.DateDataType)
 	case pgtype.TimestampOID, pgtype.TimestamptzOID:
 		return slices.Contains(compatibleTypes, transformers.DatetimeDataType)
-	case pgtype.JSONBOID:
+	case pgtype.JSONBOID, pgtype.JSONOID:
 		return slices.Contains(compatibleTypes, transformers.JSONDataType)
 	default:
 		return false


### PR DESCRIPTION
Adding `LiteralStringTransformer` which transforms anything into given string. This is expected to be used as an escape hatch, mostly for non supported types.

fixes: #311 