### PR TITLE
Add basic profiling support to CLI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,7 +44,8 @@ linters:
               reason: This package is deprecated, use `fmt.Errorf` with `%w` instead
     gosec:
       excludes:
-        - G115
+        - G115 # Potential integer overflow when converting between integer types
+        - G108 # Profiling endpoint automatically exposed on /debug/pprof
       severity: low
     makezero:
       always: false

--- a/cli-definition.json
+++ b/cli-definition.json
@@ -29,7 +29,7 @@
       "flags": [
         {
           "name": "profile",
-          "description": "Whether to expose a /debug/pprof/ endpoint on localhost:6060",
+          "description": "Whether to expose a /debug/pprof endpoint on localhost:6060",
           "default": "false"
         },
         {
@@ -84,7 +84,7 @@
         },
         {
           "name": "profile",
-          "description": "Whether to produce CPU and memory profile files, as well as exposing a /debug/pprof/ endpoint on localhost:6060",
+          "description": "Whether to produce CPU and memory profile files, as well as exposing a /debug/pprof endpoint on localhost:6060",
           "default": "false"
         },
         {

--- a/cli-definition.json
+++ b/cli-definition.json
@@ -29,7 +29,7 @@
       "flags": [
         {
           "name": "profile",
-          "description": "Wether to expose a /debug/pprof/ endpoint on localhost:6060",
+          "description": "Whether to expose a /debug/pprof/ endpoint on localhost:6060",
           "default": "false"
         },
         {
@@ -39,7 +39,7 @@
         },
         {
           "name": "reset",
-          "description": "Wether to reset the target before snapshotting (only for postgres target)",
+          "description": "Whether to reset the target before snapshotting (only for postgres target)",
           "default": "false"
         },
         {
@@ -84,12 +84,12 @@
         },
         {
           "name": "profile",
-          "description": "Wether to produce CPU and memory profile files, as well as exposing a /debug/pprof/ endpoint on localhost:6060",
+          "description": "Whether to produce CPU and memory profile files, as well as exposing a /debug/pprof/ endpoint on localhost:6060",
           "default": "false"
         },
         {
           "name": "reset",
-          "description": "Wether to reset the target before snapshotting (only for postgres target)",
+          "description": "Whether to reset the target before snapshotting (only for postgres target)",
           "default": "false"
         },
         {

--- a/cli-definition.json
+++ b/cli-definition.json
@@ -28,6 +28,11 @@
       "example": "\n\tpgstream run --source postgres --source-url <source-postgres-url> --target postgres --target-url <target-postgres-url>\n\tpgstream run --source postgres --source-url <source-postgres-url> --target postgres --target-url <target-postgres-url> --snapshot-tables <schema.table> --reset\n\tpgstream run --source kafka --source-url <kafka-url> --target elasticsearch --target-url <elasticsearch-url>\n\tpgstream run --source postgres --source-url <postgres-url> --target kafka --target-url <kafka-url>\n\tpgstream run --config config.yaml --log-level info\n\tpgstream run --config config.env",
       "flags": [
         {
+          "name": "profile",
+          "description": "Wether to expose a /debug/pprof/ endpoint on localhost:6060",
+          "default": "false"
+        },
+        {
           "name": "replication-slot",
           "description": "Name of the postgres replication slot for pgstream to connect to",
           "default": ""
@@ -76,6 +81,11 @@
           "name": "postgres-url",
           "description": "Source postgres database to perform the snapshot from",
           "default": ""
+        },
+        {
+          "name": "profile",
+          "description": "Wether to produce CPU and memory profile files, as well as exposing a /debug/pprof/ endpoint on localhost:6060",
+          "default": "false"
         },
         {
           "name": "reset",

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -59,8 +59,8 @@ func Prepare() *cobra.Command {
 	snapshotCmd.Flags().String("target", "", "Target type. One of postgres, opensearch, elasticsearch, kafka")
 	snapshotCmd.Flags().String("target-url", "", "Target URL")
 	snapshotCmd.Flags().StringSlice("tables", nil, "List of tables to snapshot, in the format <schema>.<table>. If not specified, the schema `public` will be assumed. Wildcards are supported")
-	snapshotCmd.Flags().Bool("reset", false, "Wether to reset the target before snapshotting (only for postgres target)")
-	snapshotCmd.Flags().Bool("profile", false, "Wether to produce CPU and memory profile files, as well as exposing a /debug/pprof/ endpoint on localhost:6060")
+	snapshotCmd.Flags().Bool("reset", false, "Whether to reset the target before snapshotting (only for postgres target)")
+	snapshotCmd.Flags().Bool("profile", false, "Whether to produce CPU and memory profile files, as well as exposing a /debug/pprof/ endpoint on localhost:6060")
 
 	// run cmd
 	runCmd.Flags().String("source", "", "Source type. One of postgres, kafka")
@@ -69,8 +69,8 @@ func Prepare() *cobra.Command {
 	runCmd.Flags().String("target-url", "", "Target URL")
 	runCmd.Flags().String("replication-slot", "", "Name of the postgres replication slot for pgstream to connect to")
 	runCmd.Flags().StringSlice("snapshot-tables", nil, "List of tables to snapshot if initial snapshot is required, in the format <schema>.<table>. If not specified, the schema `public` will be assumed. Wildcards are supported")
-	runCmd.Flags().Bool("reset", false, "Wether to reset the target before snapshotting (only for postgres target)")
-	runCmd.Flags().Bool("profile", false, "Wether to expose a /debug/pprof/ endpoint on localhost:6060")
+	runCmd.Flags().Bool("reset", false, "Whether to reset the target before snapshotting (only for postgres target)")
+	runCmd.Flags().Bool("profile", false, "Whether to expose a /debug/pprof/ endpoint on localhost:6060")
 
 	// status cmd
 	statusCmd.Flags().String("postgres-url", "", "Source postgres URL where pgstream has been initialised")

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/xataio/pgstream/cmd/config"
+	"github.com/xataio/pgstream/internal/profiling"
 	"github.com/xataio/pgstream/pkg/otel"
 )
 
@@ -59,6 +60,7 @@ func Prepare() *cobra.Command {
 	snapshotCmd.Flags().String("target-url", "", "Target URL")
 	snapshotCmd.Flags().StringSlice("tables", nil, "List of tables to snapshot, in the format <schema>.<table>. If not specified, the schema `public` will be assumed. Wildcards are supported")
 	snapshotCmd.Flags().Bool("reset", false, "Wether to reset the target before snapshotting (only for postgres target)")
+	snapshotCmd.Flags().Bool("profile", false, "Wether to produce CPU and memory profile files, as well as exposing a /debug/pprof/ endpoint on localhost:6060")
 
 	// run cmd
 	runCmd.Flags().String("source", "", "Source type. One of postgres, kafka")
@@ -68,6 +70,7 @@ func Prepare() *cobra.Command {
 	runCmd.Flags().String("replication-slot", "", "Name of the postgres replication slot for pgstream to connect to")
 	runCmd.Flags().StringSlice("snapshot-tables", nil, "List of tables to snapshot if initial snapshot is required, in the format <schema>.<table>. If not specified, the schema `public` will be assumed. Wildcards are supported")
 	runCmd.Flags().Bool("reset", false, "Wether to reset the target before snapshotting (only for postgres target)")
+	runCmd.Flags().Bool("profile", false, "Wether to expose a /debug/pprof/ endpoint on localhost:6060")
 
 	// status cmd
 	statusCmd.Flags().String("postgres-url", "", "Source postgres URL where pgstream has been initialised")
@@ -109,6 +112,32 @@ func withSignalWatcher(fn func(ctx context.Context) error) func(cmd *cobra.Comma
 	return func(cmd *cobra.Command, args []string) error {
 		defer cancel()
 		return fn(ctx)
+	}
+}
+
+func withProfiling(fn func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) (err error) {
+	return func(cmd *cobra.Command, args []string) error {
+		if cmd.Flags().Lookup("profile").Value.String() == "false" {
+			return fn(cmd, args)
+		}
+
+		profiling.StartProfilingServer("localhost:6060")
+		// run is a long running process, do not produce a cpu/mem files but
+		// rather expose the http endpoint only.
+		if cmd.Name() == "run" {
+			return fn(cmd, args)
+		}
+
+		stopCPUProfile, err := profiling.StartCPUProfile("cpu.prof")
+		if err != nil {
+			return err
+		}
+		defer func() {
+			stopCPUProfile()
+			profiling.CreateMemoryProfile("mem.prof")
+		}()
+
+		return fn(cmd, args)
 	}
 }
 

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -60,7 +60,7 @@ func Prepare() *cobra.Command {
 	snapshotCmd.Flags().String("target-url", "", "Target URL")
 	snapshotCmd.Flags().StringSlice("tables", nil, "List of tables to snapshot, in the format <schema>.<table>. If not specified, the schema `public` will be assumed. Wildcards are supported")
 	snapshotCmd.Flags().Bool("reset", false, "Whether to reset the target before snapshotting (only for postgres target)")
-	snapshotCmd.Flags().Bool("profile", false, "Whether to produce CPU and memory profile files, as well as exposing a /debug/pprof/ endpoint on localhost:6060")
+	snapshotCmd.Flags().Bool("profile", false, "Whether to produce CPU and memory profile files, as well as exposing a /debug/pprof endpoint on localhost:6060")
 
 	// run cmd
 	runCmd.Flags().String("source", "", "Source type. One of postgres, kafka")
@@ -70,7 +70,7 @@ func Prepare() *cobra.Command {
 	runCmd.Flags().String("replication-slot", "", "Name of the postgres replication slot for pgstream to connect to")
 	runCmd.Flags().StringSlice("snapshot-tables", nil, "List of tables to snapshot if initial snapshot is required, in the format <schema>.<table>. If not specified, the schema `public` will be assumed. Wildcards are supported")
 	runCmd.Flags().Bool("reset", false, "Whether to reset the target before snapshotting (only for postgres target)")
-	runCmd.Flags().Bool("profile", false, "Whether to expose a /debug/pprof/ endpoint on localhost:6060")
+	runCmd.Flags().Bool("profile", false, "Whether to expose a /debug/pprof endpoint on localhost:6060")
 
 	// status cmd
 	statusCmd.Flags().String("postgres-url", "", "Source postgres URL where pgstream has been initialised")

--- a/cmd/run_cmd.go
+++ b/cmd/run_cmd.go
@@ -18,7 +18,7 @@ var runCmd = &cobra.Command{
 	Use:     "run",
 	Short:   "Run starts a continuous data stream from the configured source to the configured target",
 	PreRunE: runFlagBinding,
-	RunE:    withSignalWatcher(run),
+	RunE:    withProfiling(withSignalWatcher(run)),
 	Example: `
 	pgstream run --source postgres --source-url <source-postgres-url> --target postgres --target-url <target-postgres-url>
 	pgstream run --source postgres --source-url <source-postgres-url> --target postgres --target-url <target-postgres-url> --snapshot-tables <schema.table> --reset

--- a/cmd/snapshot_cmd.go
+++ b/cmd/snapshot_cmd.go
@@ -17,7 +17,7 @@ var snapshotCmd = &cobra.Command{
 	Use:     "snapshot",
 	Short:   "Snapshot performs a snapshot of the configured source Postgres database into the configured target",
 	PreRunE: snapshotFlagBinding,
-	RunE:    withSignalWatcher(snapshot),
+	RunE:    withProfiling(withSignalWatcher(snapshot)),
 	Example: `
 	pgstream snapshot --postgres-url <postgres-url> --target postgres --target-url <target-url> --tables <schema.table> --reset
 	pgstream snapshot --config config.yaml --log-level info

--- a/internal/profiling/profiling.go
+++ b/internal/profiling/profiling.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package profiling
+
+import (
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"runtime"
+	"runtime/pprof"
+)
+
+// StartProfilingServer starts an http server exposing /debug/pprof endpoint
+// with profiling insights.
+func StartProfilingServer(address string) {
+	// by adding _ "net/http/pprof" the profiling endpoint attaches to the
+	// server
+	go func() {
+		http.ListenAndServe(address, nil) //nolint:gosec
+	}()
+}
+
+func StartCPUProfile(fileName string) (func(), error) {
+	if fileName == "" {
+		fileName = "cpu.prof"
+	}
+	cpuFile, err := os.Create(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("could not create CPU profile file: %w", err)
+	}
+
+	if err := pprof.StartCPUProfile(cpuFile); err != nil {
+		return nil, fmt.Errorf("could not start CPU profile: %w", err)
+	}
+
+	return func() {
+		pprof.StopCPUProfile()
+		cpuFile.Close()
+	}, nil
+}
+
+func CreateMemoryProfile(fileName string) error {
+	if fileName == "" {
+		fileName = "mem.prof"
+	}
+	memFile, err := os.Create(fileName)
+	if err != nil {
+		return fmt.Errorf("could not create memory profile file: %w", err)
+	}
+	defer memFile.Close()
+
+	runtime.GC() // get up-to-date statistics
+	// Lookup("allocs") creates a profile similar to go test -memprofile.
+	// Alternatively, use Lookup("heap") for a profile
+	// that has inuse_space as the default index.
+	if err := pprof.Lookup("allocs").WriteTo(memFile, 0); err != nil {
+		return fmt.Errorf("could not write memory profile: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds basic support for profiling for run/snapshot CLI commands. A flag `--profile` is added, which will create cpu and memory profile files if enabled, as well as start an http server exposing a `/debug/pprof` endpoint. The files will only be created on `snapshot` mode, since run is a long running process.

For now the values for the filenames and the server address are hardcoded to `mem.prof`, `cpu.prof` and `localhost:6060`.