### PR TITLE
Phone number dynamic country code

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -744,10 +744,10 @@ transformations:
 | ----------------------------------- |
 | `text`, `varchar`, `char`, `bpchar` |
 
-| Parameter | Type   | Default | Required | Values               |
-| --------- | ------ | ------- | -------- | -------------------- |
-| generator | string | random  | No       | random,deterministic |
-| gender    | string | Any     | No       | Any,Female,Male      |
+| Parameter | Type   | Default | Required | Values               | Dynamic |
+| --------- | ------ | ------- | -------- | -------------------- | ------- |
+| generator | string | random  | No       | random,deterministic | No      |
+| gender    | string | Any     | No       | Any,Female,Male      | Yes     |
 
 `gender` can also be a dynamic parameter, referring to some other column. Please see the below example config.
 
@@ -1130,12 +1130,12 @@ transformations:
 | ----------------------------------- |
 | `text`, `varchar`, `char`, `bpchar` |
 
-| Parameter  | Type   | Default | Required | Values                |
-| ---------- | ------ | ------- | -------- | --------------------- |
-| prefix     | string | ""      | No       | N/A                   |
-| min_length | int    | 6       | No       | N/A                   |
-| max_length | int    | 10      | No       | N/A                   |
-| generator  | string | random  | No       | random, deterministic |
+| Parameter  | Type   | Default | Required | Values                | Dynamic |
+| ---------- | ------ | ------- | -------- | --------------------- | ------- |
+| prefix     | string | ""      | No       | N/A                   | Yes     |
+| min_length | int    | 6       | No       | N/A                   | No      |
+| max_length | int    | 10      | No       | N/A                   | No      |
+| generator  | string | random  | No       | random, deterministic | No      |
 
 If the prefix is set, this transformer will always generate phone numbers starting with the prefix.
 `prefix` can also be a dynamic parameter, referring to some other column. Please see the below example config.

--- a/docs/README.md
+++ b/docs/README.md
@@ -749,6 +749,8 @@ transformations:
 | generator | string | random  | No       | random,deterministic |
 | gender    | string | Any     | No       | Any,Female,Male      |
 
+`gender` can also be a dynamic parameter, referring to some other column. Please see the below example config.
+
 **Example Configuration:**
 
 ```yaml
@@ -761,7 +763,9 @@ transformations:
           name: greenmask_firstname
           parameters:
             generator: deterministic
-            gender: Female
+          dynamic_parameters:
+            gender:
+              column: sex
 ```
 
 **Input-Output Examples:**
@@ -1134,6 +1138,7 @@ transformations:
 | generator  | string | random  | No       | random, deterministic |
 
 If the prefix is set, this transformer will always generate phone numbers starting with the prefix.
+`prefix` can also be a dynamic parameter, referring to some other column. Please see the below example config.
 
 **Example Configuration:**
 
@@ -1146,10 +1151,12 @@ transformations:
         phone:
           name: phone_number
           parameters:
-            prefix: "+90"
             min_length: 9
             max_length: 12
             generator: deterministic
+          dynamic_parameters:
+            gender:
+              column: country_code
 ```
 
 </details>

--- a/pkg/transformers/builder/transformer_builder.go
+++ b/pkg/transformers/builder/transformer_builder.go
@@ -75,7 +75,7 @@ func (b *TransformerBuilder) New(cfg *transformers.Config) (t transformers.Trans
 	case transformers.NeosyncEmail:
 		return neosync.NewEmailTransformer(cfg.Parameters)
 	case transformers.PhoneNumber:
-		return transformers.NewPhoneNumberTransformer(cfg.Parameters)
+		return transformers.NewPhoneNumberTransformer(cfg.Parameters, cfg.DynamicParameters)
 	case transformers.Masking:
 		return transformers.NewMaskingTransformer(cfg.Parameters)
 	case transformers.Template:


### PR DESCRIPTION
This PR adds `prefix` as a dynamic parameter for phone number transformer.
Also updating the docs for dynamic parameters.

fixes: #344 