### PR TITLE
Refactor all transformers to introduce definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ gen-migrations:
 generate:
 	# Generate the cli-definition.json file
 	go run tools/build-cli-definition.go
+	go run tools/transformer-definition/build-transformers-definition.go
 
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 .PHONY: build

--- a/pkg/transformers/builder/transformer_builder.go
+++ b/pkg/transformers/builder/transformer_builder.go
@@ -18,13 +18,6 @@ type TransformerBuilder struct {
 
 type Option func(b *TransformerBuilder)
 
-type TransformerDefinition struct {
-	SupportedTypes []transformers.SupportedDataType
-	Parameters     []transformers.Parameter
-	Definition     *transformers.Definition
-	BuildFn        func(*transformers.Config) (transformers.Transformer, error)
-}
-
 func NewTransformerBuilder(opts ...Option) *TransformerBuilder {
 	b := &TransformerBuilder{}
 	for _, opt := range opts {
@@ -39,145 +32,128 @@ func WithInstrumentation(i *otel.Instrumentation) Option {
 	}
 }
 
-var TransformersMap = map[transformers.TransformerType]TransformerDefinition{
+var TransformersMap = map[transformers.TransformerType]struct {
+	Definition *transformers.Definition
+	BuildFn    func(cfg *transformers.Config) (transformers.Transformer, error)
+}{
 	transformers.Masking: {
-		SupportedTypes: transformers.MaskingCompatibleTypes,
-		Parameters:     transformers.MaskingParams,
+		Definition: transformers.MaskingTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return transformers.NewMaskingTransformer(cfg.Parameters)
 		},
 	},
 	transformers.Template: {
-		SupportedTypes: transformers.TemplateCompatibleTypes,
-		Parameters:     transformers.TemplateParams,
+		Definition: transformers.TemplateTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return transformers.NewTemplateTransformer(cfg.Parameters)
 		},
 	},
 	transformers.PhoneNumber: {
-		SupportedTypes: transformers.PhoneNumberCompatibleTypes,
-		Parameters:     transformers.PhoneNumberParams,
+		Definition: transformers.PhoneNumberTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return transformers.NewPhoneNumberTransformer(cfg.Parameters, cfg.DynamicParameters)
 		},
 	},
 	transformers.LiteralString: {
-		SupportedTypes: transformers.LiteralStringCompatibleTypes,
-		Parameters:     transformers.LiteralStringParams,
+		Definition: transformers.LiteralStringTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return transformers.NewLiteralStringTransformer(cfg.Parameters)
 		},
 	},
 	transformers.String: {
-		SupportedTypes: transformers.StringCompatibleTypes,
-		Parameters:     transformers.StringParams,
+		Definition: transformers.StringTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return transformers.NewStringTransformer(cfg.Parameters)
 		},
 	},
 	// Greenmask transformers
 	transformers.GreenmaskString: {
-		SupportedTypes: greenmask.StringCompatibleTypes,
-		Parameters:     greenmask.StringParams,
+		Definition: greenmask.StringTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewStringTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskFirstName: {
-		SupportedTypes: greenmask.FirstNameCompatibleTypes,
-		Parameters:     greenmask.FirstNameParams,
+		Definition: greenmask.FirstNameTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewFirstNameTransformer(cfg.Parameters, cfg.DynamicParameters)
 		},
 	},
 	transformers.GreenmaskInteger: {
-		SupportedTypes: greenmask.IntegerCompatibleTypes,
-		Parameters:     greenmask.IntegerParams,
+		Definition: greenmask.IntegerTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewIntegerTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskFloat: {
-		SupportedTypes: greenmask.FloatCompatibleTypes,
-		Parameters:     greenmask.FloatParams,
+		Definition: greenmask.FloatTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewFloatTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskUUID: {
-		SupportedTypes: greenmask.UUIDCompatibleTypes,
-		Parameters:     greenmask.UUIDParams,
+		Definition: greenmask.UUIDTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewUUIDTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskBoolean: {
-		SupportedTypes: greenmask.BooleanCompatibleTypes,
-		Parameters:     greenmask.BooleanParams,
+		Definition: greenmask.BooleanTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewBooleanTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskChoice: {
-		SupportedTypes: greenmask.ChoiceCompatibleTypes,
-		Parameters:     greenmask.ChoiceParams,
+		Definition: greenmask.ChoiceTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewChoiceTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskUnixTimestamp: {
-		SupportedTypes: greenmask.UnixTimestampCompatibleTypes,
-		Parameters:     greenmask.UnixTimestampParams,
+		Definition: greenmask.UnixTimestampTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewUnixTimestampTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskDate: {
-		SupportedTypes: greenmask.DateCompatibleTypes,
-		Parameters:     greenmask.DateParams,
+		Definition: greenmask.DateTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewDateTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskUTCTimestamp: {
-		SupportedTypes: greenmask.UTCTimestampCompatibleTypes,
-		Parameters:     greenmask.UTCTimestampParams,
+		Definition: greenmask.UTCTimestampTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewUTCTimestampTransformer(cfg.Parameters)
 		},
 	},
 	// Neosync transformers
 	transformers.NeosyncString: {
-		SupportedTypes: neosync.StringCompatibleTypes,
-		Parameters:     neosync.StringParams,
+		Definition: neosync.StringTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return neosync.NewStringTransformer(cfg.Parameters)
 		},
 	},
 	transformers.NeosyncFirstName: {
-		SupportedTypes: neosync.FirstNameCompatibleTypes,
-		Parameters:     neosync.FirstNameParams,
+		Definition: neosync.FirstNameTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return neosync.NewFirstNameTransformer(cfg.Parameters)
 		},
 	},
 	transformers.NeosyncLastName: {
-		SupportedTypes: neosync.LastNameCompatibleTypes,
-		Parameters:     neosync.LastNameParams,
+		Definition: neosync.LastNameTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return neosync.NewLastNameTransformer(cfg.Parameters)
 		},
 	},
 	transformers.NeosyncFullName: {
-		SupportedTypes: neosync.FullNameCompatibleTypes,
-		Parameters:     neosync.FullNameParams,
+		Definition: neosync.FullNameTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return neosync.NewFullNameTransformer(cfg.Parameters)
 		},
 	},
 	transformers.NeosyncEmail: {
-		SupportedTypes: neosync.EmailCompatibleTypes,
-		Parameters:     neosync.EmailParams,
+		Definition: neosync.EmailTransformerDefinition(),
 		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return neosync.NewEmailTransformer(cfg.Parameters)
 		},
@@ -191,18 +167,18 @@ func (b *TransformerBuilder) New(cfg *transformers.Config) (t transformers.Trans
 		}
 	}()
 
-	transformerDef, ok := TransformersMap[cfg.Name]
+	transformer, ok := TransformersMap[cfg.Name]
 	if !ok {
 		return nil, fmt.Errorf("%w: unexpected transformer name '%s'", transformers.ErrUnsupportedTransformer, cfg.Name)
 	}
 
-	paramNames := make([]string, len(transformerDef.Parameters))
-	for i, param := range transformerDef.Parameters {
+	paramNames := make([]string, len(transformer.Definition.Parameters))
+	for i, param := range transformer.Definition.Parameters {
 		paramNames[i] = param.Name
 	}
 
 	if err := transformers.ValidateParameters(cfg.Parameters, paramNames); err != nil {
 		return nil, err
 	}
-	return transformerDef.BuildFn(cfg)
+	return transformer.BuildFn(cfg)
 }

--- a/pkg/transformers/builder/transformer_builder.go
+++ b/pkg/transformers/builder/transformer_builder.go
@@ -18,6 +18,12 @@ type TransformerBuilder struct {
 
 type Option func(b *TransformerBuilder)
 
+type TransformerDefinition struct {
+	SupportedTypes []transformers.SupportedDataType
+	Parameters     []transformers.TransformerParameter
+	CreateFunc     func(*transformers.Config) (transformers.Transformer, error)
+}
+
 func NewTransformerBuilder(opts ...Option) *TransformerBuilder {
 	b := &TransformerBuilder{}
 	for _, opt := range opts {
@@ -32,6 +38,151 @@ func WithInstrumentation(i *otel.Instrumentation) Option {
 	}
 }
 
+var TransformersMap = map[transformers.TransformerType]TransformerDefinition{
+	transformers.Masking: {
+		SupportedTypes: transformers.MaskingCompatibleTypes,
+		Parameters:     transformers.MaskingParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return transformers.NewMaskingTransformer(cfg.Parameters)
+		},
+	},
+	transformers.Template: {
+		SupportedTypes: transformers.TemplateCompatibleTypes,
+		Parameters:     transformers.TemplateParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return transformers.NewTemplateTransformer(cfg.Parameters)
+		},
+	},
+	transformers.PhoneNumber: {
+		SupportedTypes: transformers.PhoneNumberCompatibleTypes,
+		Parameters:     transformers.PhoneNumberParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return transformers.NewPhoneNumberTransformer(cfg.Parameters, cfg.DynamicParameters)
+		},
+	},
+	transformers.LiteralString: {
+		SupportedTypes: transformers.LiteralStringCompatibleTypes,
+		Parameters:     transformers.LiteralStringParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return transformers.NewLiteralStringTransformer(cfg.Parameters)
+		},
+	},
+	transformers.String: {
+		SupportedTypes: transformers.StringCompatibleTypes,
+		Parameters:     transformers.StringParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return transformers.NewStringTransformer(cfg.Parameters)
+		},
+	},
+	// Greenmask transformers
+	transformers.GreenmaskString: {
+		SupportedTypes: greenmask.StringCompatibleTypes,
+		Parameters:     greenmask.StringParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return greenmask.NewStringTransformer(cfg.Parameters)
+		},
+	},
+	transformers.GreenmaskFirstName: {
+		SupportedTypes: greenmask.FirstNameCompatibleTypes,
+		Parameters:     greenmask.FirstNameParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return greenmask.NewFirstNameTransformer(cfg.Parameters, cfg.DynamicParameters)
+		},
+	},
+	transformers.GreenmaskInteger: {
+		SupportedTypes: greenmask.IntegerCompatibleTypes,
+		Parameters:     greenmask.IntegerParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return greenmask.NewIntegerTransformer(cfg.Parameters)
+		},
+	},
+	transformers.GreenmaskFloat: {
+		SupportedTypes: greenmask.FloatCompatibleTypes,
+		Parameters:     greenmask.FloatParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return greenmask.NewFloatTransformer(cfg.Parameters)
+		},
+	},
+	transformers.GreenmaskUUID: {
+		SupportedTypes: greenmask.UUIDCompatibleTypes,
+		Parameters:     greenmask.UUIDParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return greenmask.NewUUIDTransformer(cfg.Parameters)
+		},
+	},
+	transformers.GreenmaskBoolean: {
+		SupportedTypes: greenmask.BooleanCompatibleTypes,
+		Parameters:     greenmask.BooleanParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return greenmask.NewBooleanTransformer(cfg.Parameters)
+		},
+	},
+	transformers.GreenmaskChoice: {
+		SupportedTypes: greenmask.ChoiceCompatibleTypes,
+		Parameters:     greenmask.ChoiceParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return greenmask.NewChoiceTransformer(cfg.Parameters)
+		},
+	},
+	transformers.GreenmaskUnixTimestamp: {
+		SupportedTypes: greenmask.UnixTimestampCompatibleTypes,
+		Parameters:     greenmask.UnixTimestampParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return greenmask.NewUnixTimestampTransformer(cfg.Parameters)
+		},
+	},
+	transformers.GreenmaskDate: {
+		SupportedTypes: greenmask.DateCompatibleTypes,
+		Parameters:     greenmask.DateParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return greenmask.NewDateTransformer(cfg.Parameters)
+		},
+	},
+	transformers.GreenmaskUTCTimestamp: {
+		SupportedTypes: greenmask.UTCTimestampCompatibleTypes,
+		Parameters:     greenmask.UTCTimestampParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return greenmask.NewUTCTimestampTransformer(cfg.Parameters)
+		},
+	},
+	// Neosync transformers
+	transformers.NeosyncString: {
+		SupportedTypes: neosync.StringCompatibleTypes,
+		Parameters:     neosync.StringParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return neosync.NewStringTransformer(cfg.Parameters)
+		},
+	},
+	transformers.NeosyncFirstName: {
+		SupportedTypes: neosync.FirstNameCompatibleTypes,
+		Parameters:     neosync.FirstNameParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return neosync.NewFirstNameTransformer(cfg.Parameters)
+		},
+	},
+	transformers.NeosyncLastName: {
+		SupportedTypes: neosync.LastNameCompatibleTypes,
+		Parameters:     neosync.LastNameParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return neosync.NewLastNameTransformer(cfg.Parameters)
+		},
+	},
+	transformers.NeosyncFullName: {
+		SupportedTypes: neosync.FullNameCompatibleTypes,
+		Parameters:     neosync.FullNameParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return neosync.NewFullNameTransformer(cfg.Parameters)
+		},
+	},
+	transformers.NeosyncEmail: {
+		SupportedTypes: neosync.EmailCompatibleTypes,
+		Parameters:     neosync.EmailParams,
+		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return neosync.NewEmailTransformer(cfg.Parameters)
+		},
+	},
+}
+
 func (b *TransformerBuilder) New(cfg *transformers.Config) (t transformers.Transformer, err error) {
 	defer func() {
 		if b.instrumentation != nil {
@@ -39,48 +190,18 @@ func (b *TransformerBuilder) New(cfg *transformers.Config) (t transformers.Trans
 		}
 	}()
 
-	switch cfg.Name {
-	case transformers.GreenmaskString:
-		return greenmask.NewStringTransformer(cfg.Parameters)
-	case transformers.GreenmaskFirstName:
-		return greenmask.NewFirstNameTransformer(cfg.Parameters, cfg.DynamicParameters)
-	case transformers.GreenmaskInteger:
-		return greenmask.NewIntegerTransformer(cfg.Parameters)
-	case transformers.GreenmaskFloat:
-		return greenmask.NewFloatTransformer(cfg.Parameters)
-	case transformers.GreenmaskUUID:
-		return greenmask.NewUUIDTransformer(cfg.Parameters)
-	case transformers.GreenmaskBoolean:
-		return greenmask.NewBooleanTransformer(cfg.Parameters)
-	case transformers.GreenmaskChoice:
-		return greenmask.NewChoiceTransformer(cfg.Parameters)
-	case transformers.GreenmaskUnixTimestamp:
-		return greenmask.NewUnixTimestampTransformer(cfg.Parameters)
-	case transformers.GreenmaskDate:
-		return greenmask.NewDateTransformer(cfg.Parameters)
-	case transformers.GreenmaskUTCTimestamp:
-		return greenmask.NewUTCTimestampTransformer(cfg.Parameters)
-	case transformers.String:
-		return transformers.NewStringTransformer(cfg.Parameters)
-	case transformers.LiteralString:
-		return transformers.NewLiteralStringTransformer(cfg.Parameters)
-	case transformers.NeosyncString:
-		return neosync.NewStringTransformer(cfg.Parameters)
-	case transformers.NeosyncFirstName:
-		return neosync.NewFirstNameTransformer(cfg.Parameters)
-	case transformers.NeosyncLastName:
-		return neosync.NewLastNameTransformer(cfg.Parameters)
-	case transformers.NeosyncFullName:
-		return neosync.NewFullNameTransformer(cfg.Parameters)
-	case transformers.NeosyncEmail:
-		return neosync.NewEmailTransformer(cfg.Parameters)
-	case transformers.PhoneNumber:
-		return transformers.NewPhoneNumberTransformer(cfg.Parameters, cfg.DynamicParameters)
-	case transformers.Masking:
-		return transformers.NewMaskingTransformer(cfg.Parameters)
-	case transformers.Template:
-		return transformers.NewTemplateTransformer(cfg.Parameters)
-	default:
+	transformerDef, ok := TransformersMap[cfg.Name]
+	if !ok {
 		return nil, fmt.Errorf("%w: unexpected transformer name '%s'", transformers.ErrUnsupportedTransformer, cfg.Name)
 	}
+
+	paramNames := make([]string, len(transformerDef.Parameters))
+	for i, param := range transformerDef.Parameters {
+		paramNames[i] = param.Name
+	}
+
+	if err := transformers.ValidateParameters(cfg.Parameters, paramNames); err != nil {
+		return nil, err
+	}
+	return transformerDef.CreateFunc(cfg)
 }

--- a/pkg/transformers/builder/transformer_builder.go
+++ b/pkg/transformers/builder/transformer_builder.go
@@ -20,8 +20,9 @@ type Option func(b *TransformerBuilder)
 
 type TransformerDefinition struct {
 	SupportedTypes []transformers.SupportedDataType
-	Parameters     []transformers.TransformerParameter
-	CreateFunc     func(*transformers.Config) (transformers.Transformer, error)
+	Parameters     []transformers.Parameter
+	Definition     *transformers.Definition
+	BuildFn        func(*transformers.Config) (transformers.Transformer, error)
 }
 
 func NewTransformerBuilder(opts ...Option) *TransformerBuilder {
@@ -42,35 +43,35 @@ var TransformersMap = map[transformers.TransformerType]TransformerDefinition{
 	transformers.Masking: {
 		SupportedTypes: transformers.MaskingCompatibleTypes,
 		Parameters:     transformers.MaskingParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return transformers.NewMaskingTransformer(cfg.Parameters)
 		},
 	},
 	transformers.Template: {
 		SupportedTypes: transformers.TemplateCompatibleTypes,
 		Parameters:     transformers.TemplateParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return transformers.NewTemplateTransformer(cfg.Parameters)
 		},
 	},
 	transformers.PhoneNumber: {
 		SupportedTypes: transformers.PhoneNumberCompatibleTypes,
 		Parameters:     transformers.PhoneNumberParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return transformers.NewPhoneNumberTransformer(cfg.Parameters, cfg.DynamicParameters)
 		},
 	},
 	transformers.LiteralString: {
 		SupportedTypes: transformers.LiteralStringCompatibleTypes,
 		Parameters:     transformers.LiteralStringParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return transformers.NewLiteralStringTransformer(cfg.Parameters)
 		},
 	},
 	transformers.String: {
 		SupportedTypes: transformers.StringCompatibleTypes,
 		Parameters:     transformers.StringParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return transformers.NewStringTransformer(cfg.Parameters)
 		},
 	},
@@ -78,70 +79,70 @@ var TransformersMap = map[transformers.TransformerType]TransformerDefinition{
 	transformers.GreenmaskString: {
 		SupportedTypes: greenmask.StringCompatibleTypes,
 		Parameters:     greenmask.StringParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewStringTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskFirstName: {
 		SupportedTypes: greenmask.FirstNameCompatibleTypes,
 		Parameters:     greenmask.FirstNameParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewFirstNameTransformer(cfg.Parameters, cfg.DynamicParameters)
 		},
 	},
 	transformers.GreenmaskInteger: {
 		SupportedTypes: greenmask.IntegerCompatibleTypes,
 		Parameters:     greenmask.IntegerParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewIntegerTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskFloat: {
 		SupportedTypes: greenmask.FloatCompatibleTypes,
 		Parameters:     greenmask.FloatParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewFloatTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskUUID: {
 		SupportedTypes: greenmask.UUIDCompatibleTypes,
 		Parameters:     greenmask.UUIDParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewUUIDTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskBoolean: {
 		SupportedTypes: greenmask.BooleanCompatibleTypes,
 		Parameters:     greenmask.BooleanParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewBooleanTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskChoice: {
 		SupportedTypes: greenmask.ChoiceCompatibleTypes,
 		Parameters:     greenmask.ChoiceParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewChoiceTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskUnixTimestamp: {
 		SupportedTypes: greenmask.UnixTimestampCompatibleTypes,
 		Parameters:     greenmask.UnixTimestampParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewUnixTimestampTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskDate: {
 		SupportedTypes: greenmask.DateCompatibleTypes,
 		Parameters:     greenmask.DateParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewDateTransformer(cfg.Parameters)
 		},
 	},
 	transformers.GreenmaskUTCTimestamp: {
 		SupportedTypes: greenmask.UTCTimestampCompatibleTypes,
 		Parameters:     greenmask.UTCTimestampParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return greenmask.NewUTCTimestampTransformer(cfg.Parameters)
 		},
 	},
@@ -149,35 +150,35 @@ var TransformersMap = map[transformers.TransformerType]TransformerDefinition{
 	transformers.NeosyncString: {
 		SupportedTypes: neosync.StringCompatibleTypes,
 		Parameters:     neosync.StringParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return neosync.NewStringTransformer(cfg.Parameters)
 		},
 	},
 	transformers.NeosyncFirstName: {
 		SupportedTypes: neosync.FirstNameCompatibleTypes,
 		Parameters:     neosync.FirstNameParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return neosync.NewFirstNameTransformer(cfg.Parameters)
 		},
 	},
 	transformers.NeosyncLastName: {
 		SupportedTypes: neosync.LastNameCompatibleTypes,
 		Parameters:     neosync.LastNameParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return neosync.NewLastNameTransformer(cfg.Parameters)
 		},
 	},
 	transformers.NeosyncFullName: {
 		SupportedTypes: neosync.FullNameCompatibleTypes,
 		Parameters:     neosync.FullNameParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return neosync.NewFullNameTransformer(cfg.Parameters)
 		},
 	},
 	transformers.NeosyncEmail: {
 		SupportedTypes: neosync.EmailCompatibleTypes,
 		Parameters:     neosync.EmailParams,
-		CreateFunc: func(cfg *transformers.Config) (transformers.Transformer, error) {
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
 			return neosync.NewEmailTransformer(cfg.Parameters)
 		},
 	},
@@ -203,5 +204,5 @@ func (b *TransformerBuilder) New(cfg *transformers.Config) (t transformers.Trans
 	if err := transformers.ValidateParameters(cfg.Parameters, paramNames); err != nil {
 		return nil, err
 	}
-	return transformerDef.CreateFunc(cfg)
+	return transformerDef.BuildFn(cfg)
 }

--- a/pkg/transformers/greenmask/greenmask_boolean_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_boolean_transformer.go
@@ -14,7 +14,7 @@ type BooleanTransformer struct {
 }
 
 var (
-	BooleanParams = []transformers.Parameter{
+	booleanParams = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -24,7 +24,7 @@ var (
 			Values:        []any{"random", "deterministic"},
 		},
 	}
-	BooleanCompatibleTypes = []transformers.SupportedDataType{
+	booleanCompatibleTypes = []transformers.SupportedDataType{
 		transformers.BooleanDataType,
 		transformers.ByteArrayDataType,
 	}
@@ -63,9 +63,16 @@ func (bt *BooleanTransformer) Transform(_ context.Context, value transformers.Va
 }
 
 func (bt *BooleanTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return BooleanCompatibleTypes
+	return booleanCompatibleTypes
 }
 
 func (bt *BooleanTransformer) Type() transformers.TransformerType {
 	return transformers.GreenmaskBoolean
+}
+
+func BooleanTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: booleanCompatibleTypes,
+		Parameters:     booleanParams,
+	}
 }

--- a/pkg/transformers/greenmask/greenmask_boolean_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_boolean_transformer.go
@@ -21,6 +21,7 @@ var (
 			Default:       "random",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"random", "deterministic"},
 		},
 	}
 	BooleanCompatibleTypes = []transformers.SupportedDataType{

--- a/pkg/transformers/greenmask/greenmask_boolean_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_boolean_transformer.go
@@ -13,12 +13,23 @@ type BooleanTransformer struct {
 	transformer *greenmasktransformers.RandomBoolean
 }
 
-var booleanTransformerParams = []string{"generator"}
+var (
+	BooleanParams = []transformers.TransformerParameter{
+		{
+			Name:          "generator",
+			SupportedType: "string",
+			Default:       "random",
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+	BooleanCompatibleTypes = []transformers.SupportedDataType{
+		transformers.BooleanDataType,
+		transformers.ByteArrayDataType,
+	}
+)
 
 func NewBooleanTransformer(params transformers.Parameters) (*BooleanTransformer, error) {
-	if err := transformers.ValidateParameters(params, booleanTransformerParams); err != nil {
-		return nil, err
-	}
 	t := greenmasktransformers.NewRandomBoolean()
 	if err := setGenerator(t, params); err != nil {
 		return nil, err
@@ -51,10 +62,7 @@ func (bt *BooleanTransformer) Transform(_ context.Context, value transformers.Va
 }
 
 func (bt *BooleanTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.BooleanDataType,
-		transformers.ByteArrayDataType,
-	}
+	return BooleanCompatibleTypes
 }
 
 func (bt *BooleanTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/greenmask/greenmask_boolean_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_boolean_transformer.go
@@ -14,7 +14,7 @@ type BooleanTransformer struct {
 }
 
 var (
-	BooleanParams = []transformers.TransformerParameter{
+	BooleanParams = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -30,7 +30,7 @@ var (
 	}
 )
 
-func NewBooleanTransformer(params transformers.Parameters) (*BooleanTransformer, error) {
+func NewBooleanTransformer(params transformers.ParameterValues) (*BooleanTransformer, error) {
 	t := greenmasktransformers.NewRandomBoolean()
 	if err := setGenerator(t, params); err != nil {
 		return nil, err

--- a/pkg/transformers/greenmask/greenmask_boolean_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_boolean_transformer_test.go
@@ -14,26 +14,26 @@ func Test_NewBooleanTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		wantErr error
 	}{
 		{
 			name: "ok - valid random",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 			},
 			wantErr: nil,
 		},
 		{
 			name: "ok - valid deterministic",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 			},
 			wantErr: nil,
 		},
 		{
 			name: "error - invalid generator type",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": "invalid",
 			},
 			wantErr: transformers.ErrUnsupportedGenerator,
@@ -56,13 +56,13 @@ func Test_BooleanTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		input   any
 		wantErr error
 	}{
 		{
 			name: "ok - bool, random",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 			},
 			input:   true,
@@ -70,7 +70,7 @@ func Test_BooleanTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - bool, deterministic",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 			},
 			input:   false,
@@ -78,7 +78,7 @@ func Test_BooleanTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - []byte, deterministic",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 			},
 			input:   []byte("123e4567-e89b-12d3-a456-426655440000"),

--- a/pkg/transformers/greenmask/greenmask_choice_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_choice_transformer.go
@@ -16,15 +16,31 @@ type ChoiceTransformer struct {
 	transformer *greenmasktransformers.RandomChoiceTransformer
 }
 
-var choiceTransformerParams = []string{"choices", "generator"}
-
-var errChoicesEmpty = errors.New("greenmask_choice: choices must not be empty")
+var (
+	errChoicesEmpty = errors.New("greenmask_choice: choices must not be empty")
+	ChoiceParams    = []transformers.TransformerParameter{
+		{
+			Name:          "choices",
+			SupportedType: "array",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      true,
+		},
+		{
+			Name:          "generator",
+			SupportedType: "string",
+			Default:       "random",
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+	ChoiceCompatibleTypes = []transformers.SupportedDataType{
+		transformers.StringDataType,
+		transformers.ByteArrayDataType,
+	}
+)
 
 func NewChoiceTransformer(params transformers.Parameters) (*ChoiceTransformer, error) {
-	if err := transformers.ValidateParameters(params, choiceTransformerParams); err != nil {
-		return nil, err
-	}
-
 	choices := []string{}
 	choices, err := findParameterArray(params, "choices", choices)
 	if err != nil {
@@ -72,10 +88,7 @@ func (t *ChoiceTransformer) Transform(_ context.Context, value transformers.Valu
 }
 
 func (t *ChoiceTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.ByteArrayDataType,
-		transformers.StringDataType,
-	}
+	return ChoiceCompatibleTypes
 }
 
 func (t *ChoiceTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/greenmask/greenmask_choice_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_choice_transformer.go
@@ -32,6 +32,7 @@ var (
 			Default:       "random",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"random", "deterministic"},
 		},
 	}
 	ChoiceCompatibleTypes = []transformers.SupportedDataType{

--- a/pkg/transformers/greenmask/greenmask_choice_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_choice_transformer.go
@@ -18,7 +18,7 @@ type ChoiceTransformer struct {
 
 var (
 	errChoicesEmpty = errors.New("greenmask_choice: choices must not be empty")
-	ChoiceParams    = []transformers.TransformerParameter{
+	ChoiceParams    = []transformers.Parameter{
 		{
 			Name:          "choices",
 			SupportedType: "array",
@@ -41,7 +41,7 @@ var (
 	}
 )
 
-func NewChoiceTransformer(params transformers.Parameters) (*ChoiceTransformer, error) {
+func NewChoiceTransformer(params transformers.ParameterValues) (*ChoiceTransformer, error) {
 	choices := []string{}
 	choices, err := findParameterArray(params, "choices", choices)
 	if err != nil {

--- a/pkg/transformers/greenmask/greenmask_choice_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_choice_transformer.go
@@ -18,7 +18,7 @@ type ChoiceTransformer struct {
 
 var (
 	errChoicesEmpty = errors.New("greenmask_choice: choices must not be empty")
-	ChoiceParams    = []transformers.Parameter{
+	choiceParams    = []transformers.Parameter{
 		{
 			Name:          "choices",
 			SupportedType: "array",
@@ -35,7 +35,7 @@ var (
 			Values:        []any{"random", "deterministic"},
 		},
 	}
-	ChoiceCompatibleTypes = []transformers.SupportedDataType{
+	choiceCompatibleTypes = []transformers.SupportedDataType{
 		transformers.StringDataType,
 		transformers.ByteArrayDataType,
 	}
@@ -89,9 +89,16 @@ func (t *ChoiceTransformer) Transform(_ context.Context, value transformers.Valu
 }
 
 func (t *ChoiceTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return ChoiceCompatibleTypes
+	return choiceCompatibleTypes
 }
 
 func (t *ChoiceTransformer) Type() transformers.TransformerType {
 	return transformers.GreenmaskChoice
+}
+
+func ChoiceTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: choiceCompatibleTypes,
+		Parameters:     choiceParams,
+	}
 }

--- a/pkg/transformers/greenmask/greenmask_choice_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_choice_transformer_test.go
@@ -15,12 +15,12 @@ func TestNewChoiceTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		wantErr error
 	}{
 		{
 			name: "ok - valid random",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"choices":   []string{"a", "b", "c", "d"},
 			},
@@ -28,7 +28,7 @@ func TestNewChoiceTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid generator type",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": "invalid",
 				"choices":   []string{"a", "b", "c", "d"},
 			},
@@ -36,7 +36,7 @@ func TestNewChoiceTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid choices",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 			},
 			wantErr: errChoicesEmpty,
@@ -61,13 +61,13 @@ func TestChoiceTransformer_Transform(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   any
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		wantErr error
 	}{
 		{
 			name:  "ok - transform string randomly",
 			input: "test",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"choices":   []string{"a", "b", "c", "d"},
 			},
@@ -76,7 +76,7 @@ func TestChoiceTransformer_Transform(t *testing.T) {
 		{
 			name:  "ok - transform []byte deterministically",
 			input: []byte("test"),
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 				"choices":   []string{"a", "b", "c", "d"},
 			},
@@ -85,7 +85,7 @@ func TestChoiceTransformer_Transform(t *testing.T) {
 		{
 			name:  "ok - transform RawValue deterministically",
 			input: toolkit.NewRawValue([]byte("test"), false),
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 				"choices":   []string{"a", "b", "c", "d"},
 			},
@@ -94,7 +94,7 @@ func TestChoiceTransformer_Transform(t *testing.T) {
 		{
 			name:  "error - invalid input type",
 			input: 1,
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"choices":   []string{"a", "b", "c", "d"},
 			},

--- a/pkg/transformers/greenmask/greenmask_date_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_date_transformer.go
@@ -15,13 +15,38 @@ type DateTransformer struct {
 	transformer *greenmasktransformers.Timestamp
 }
 
-var dateTransformerParams = []string{"min_value", "max_value", "generator"}
+var (
+	DateParams = []transformers.TransformerParameter{
+		{
+			Name:          "generator",
+			SupportedType: "string",
+			Default:       "random",
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "min_value",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      true,
+		},
+		{
+			Name:          "max_value",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      true,
+		},
+	}
+	DateCompatibleTypes = []transformers.SupportedDataType{
+		transformers.StringDataType,
+		transformers.ByteArrayDataType,
+		transformers.DateDataType,
+	}
+)
 
 func NewDateTransformer(params transformers.Parameters) (*DateTransformer, error) {
-	if err := transformers.ValidateParameters(params, dateTransformerParams); err != nil {
-		return nil, err
-	}
-
 	minValue, foundMin, err := transformers.FindParameter[string](params, "min_value")
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_date: min_value must be a string: %w", err)
@@ -90,11 +115,7 @@ func (t *DateTransformer) Transform(_ context.Context, value transformers.Value)
 }
 
 func (t *DateTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.DateDataType,
-		transformers.ByteArrayDataType,
-		transformers.StringDataType,
-	}
+	return DateCompatibleTypes
 }
 
 func (t *DateTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/greenmask/greenmask_date_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_date_transformer.go
@@ -16,7 +16,7 @@ type DateTransformer struct {
 }
 
 var (
-	DateParams = []transformers.Parameter{
+	dateParams = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -40,7 +40,7 @@ var (
 			Required:      true,
 		},
 	}
-	DateCompatibleTypes = []transformers.SupportedDataType{
+	dateCompatibleTypes = []transformers.SupportedDataType{
 		transformers.StringDataType,
 		transformers.ByteArrayDataType,
 		transformers.DateDataType,
@@ -116,9 +116,16 @@ func (t *DateTransformer) Transform(_ context.Context, value transformers.Value)
 }
 
 func (t *DateTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return DateCompatibleTypes
+	return dateCompatibleTypes
 }
 
 func (t *DateTransformer) Type() transformers.TransformerType {
 	return transformers.GreenmaskDate
+}
+
+func DateTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: dateCompatibleTypes,
+		Parameters:     dateParams,
+	}
 }

--- a/pkg/transformers/greenmask/greenmask_date_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_date_transformer.go
@@ -23,6 +23,7 @@ var (
 			Default:       "random",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"random", "deterministic"},
 		},
 		{
 			Name:          "min_value",

--- a/pkg/transformers/greenmask/greenmask_date_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_date_transformer.go
@@ -16,7 +16,7 @@ type DateTransformer struct {
 }
 
 var (
-	DateParams = []transformers.TransformerParameter{
+	DateParams = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -47,7 +47,7 @@ var (
 	}
 )
 
-func NewDateTransformer(params transformers.Parameters) (*DateTransformer, error) {
+func NewDateTransformer(params transformers.ParameterValues) (*DateTransformer, error) {
 	minValue, foundMin, err := transformers.FindParameter[string](params, "min_value")
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_date: min_value must be a string: %w", err)

--- a/pkg/transformers/greenmask/greenmask_date_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_date_transformer_test.go
@@ -16,12 +16,12 @@ func TestNewDateTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		wantErr error
 	}{
 		{
 			name: "ok - valid parameters",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",
@@ -30,7 +30,7 @@ func TestNewDateTransformer(t *testing.T) {
 		},
 		{
 			name: "error - min_value missing",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"max_value": "2022-01-02",
 			},
@@ -38,7 +38,7 @@ func TestNewDateTransformer(t *testing.T) {
 		},
 		{
 			name: "error - min_value after max_value",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"min_value": "2022-01-03",
 				"max_value": "2022-01-02",
@@ -47,7 +47,7 @@ func TestNewDateTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid generator type",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": "invalid",
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",
@@ -72,13 +72,13 @@ func TestDateTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		input   any
 		wantErr error
 	}{
 		{
 			name: "ok - valid random",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",
@@ -88,7 +88,7 @@ func TestDateTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - valid deterministic",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",
@@ -98,7 +98,7 @@ func TestDateTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - valid with time input",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 				"min_value": "2022-01-02",
 				"max_value": "2022-01-02",
@@ -108,7 +108,7 @@ func TestDateTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "error - invalid input",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"min_value": "2021-01-01",
 				"max_value": "2022-01-02",

--- a/pkg/transformers/greenmask/greenmask_firstname_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_firstname_transformer.go
@@ -17,13 +17,30 @@ type FirstNameTransformer struct {
 
 const genderParam = "gender"
 
-var firstNameTransformerParams = []string{genderParam, "generator"}
+var (
+	FirstNameParams = []transformers.TransformerParameter{
+		{
+			Name:          "generator",
+			SupportedType: "string",
+			Default:       "random",
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          genderParam,
+			SupportedType: "string",
+			Default:       greenmasktransformers.AnyGenderName,
+			Dynamic:       true,
+			Required:      false,
+		},
+	}
+	FirstNameCompatibleTypes = []transformers.SupportedDataType{
+		transformers.StringDataType,
+		transformers.ByteArrayDataType,
+	}
+)
 
 func NewFirstNameTransformer(params, dynamicParams transformers.Parameters) (*FirstNameTransformer, error) {
-	if err := transformers.ValidateParameters(params, firstNameTransformerParams); err != nil {
-		return nil, err
-	}
-
 	gender, err := transformers.FindParameterWithDefault(params, genderParam, greenmasktransformers.AnyGenderName)
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_firstname: gender must be a string: %w", err)
@@ -87,10 +104,7 @@ func toGreenmaskGender(gender string) string {
 }
 
 func (fnt *FirstNameTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.StringDataType,
-		transformers.ByteArrayDataType,
-	}
+	return FirstNameCompatibleTypes
 }
 
 func (fnt *FirstNameTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/greenmask/greenmask_firstname_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_firstname_transformer.go
@@ -18,7 +18,7 @@ type FirstNameTransformer struct {
 const genderParam = "gender"
 
 var (
-	FirstNameParams = []transformers.Parameter{
+	firstNameParams = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -36,7 +36,7 @@ var (
 			Values:        []any{"Male", "Female", "Any"},
 		},
 	}
-	FirstNameCompatibleTypes = []transformers.SupportedDataType{
+	firstNameCompatibleTypes = []transformers.SupportedDataType{
 		transformers.StringDataType,
 		transformers.ByteArrayDataType,
 	}
@@ -106,9 +106,16 @@ func toGreenmaskGender(gender string) string {
 }
 
 func (fnt *FirstNameTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return FirstNameCompatibleTypes
+	return firstNameCompatibleTypes
 }
 
 func (fnt *FirstNameTransformer) Type() transformers.TransformerType {
 	return transformers.GreenmaskFirstName
+}
+
+func FirstNameTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: firstNameCompatibleTypes,
+		Parameters:     firstNameParams,
+	}
 }

--- a/pkg/transformers/greenmask/greenmask_firstname_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_firstname_transformer.go
@@ -18,7 +18,7 @@ type FirstNameTransformer struct {
 const genderParam = "gender"
 
 var (
-	FirstNameParams = []transformers.TransformerParameter{
+	FirstNameParams = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -42,7 +42,7 @@ var (
 	}
 )
 
-func NewFirstNameTransformer(params, dynamicParams transformers.Parameters) (*FirstNameTransformer, error) {
+func NewFirstNameTransformer(params, dynamicParams transformers.ParameterValues) (*FirstNameTransformer, error) {
 	gender, err := transformers.FindParameterWithDefault(params, genderParam, greenmasktransformers.AnyGenderName)
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_firstname: gender must be a string: %w", err)

--- a/pkg/transformers/greenmask/greenmask_firstname_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_firstname_transformer.go
@@ -25,6 +25,7 @@ var (
 			Default:       "random",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"random", "deterministic"},
 		},
 		{
 			Name:          genderParam,
@@ -32,6 +33,7 @@ var (
 			Default:       greenmasktransformers.AnyGenderName,
 			Dynamic:       true,
 			Required:      false,
+			Values:        []any{"Male", "Female", "Any"},
 		},
 	}
 	FirstNameCompatibleTypes = []transformers.SupportedDataType{

--- a/pkg/transformers/greenmask/greenmask_firstname_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_firstname_transformer_test.go
@@ -16,8 +16,8 @@ func Test_NewFirstNameTransformer(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		params        transformers.Parameters
-		dynamicParams transformers.Parameters
+		params        transformers.ParameterValues
+		dynamicParams transformers.ParameterValues
 
 		wantErr error
 	}{
@@ -95,8 +95,8 @@ func TestFirstNameTransformer_Transform(t *testing.T) {
 		name          string
 		value         any
 		dynamicValues map[string]any
-		params        transformers.Parameters
-		dynamicParams transformers.Parameters
+		params        transformers.ParameterValues
+		dynamicParams transformers.ParameterValues
 
 		wantName string
 		wantErr  error

--- a/pkg/transformers/greenmask/greenmask_float_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_float_transformer.go
@@ -23,7 +23,7 @@ type FloatTransformer struct {
 }
 
 var (
-	FloatParams = []transformers.TransformerParameter{
+	FloatParams = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -61,7 +61,7 @@ var (
 	}
 )
 
-func NewFloatTransformer(params transformers.Parameters) (*FloatTransformer, error) {
+func NewFloatTransformer(params transformers.ParameterValues) (*FloatTransformer, error) {
 	minValue, err := findParameter(params, "min_value", defaultMinFloat)
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_float: min_value must be a float: %w", err)

--- a/pkg/transformers/greenmask/greenmask_float_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_float_transformer.go
@@ -23,7 +23,7 @@ type FloatTransformer struct {
 }
 
 var (
-	FloatParams = []transformers.Parameter{
+	floatParams = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -54,7 +54,7 @@ var (
 			Required:      false,
 		},
 	}
-	FloatCompatibleTypes = []transformers.SupportedDataType{
+	floatCompatibleTypes = []transformers.SupportedDataType{
 		transformers.Float32DataType,
 		transformers.Float64DataType,
 		transformers.ByteArrayDataType,
@@ -109,11 +109,18 @@ func (ft *FloatTransformer) Transform(_ context.Context, value transformers.Valu
 }
 
 func (ft *FloatTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return FloatCompatibleTypes
+	return floatCompatibleTypes
 }
 
 func (ft *FloatTransformer) Type() transformers.TransformerType {
 	return transformers.GreenmaskFloat
+}
+
+func FloatTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: floatCompatibleTypes,
+		Parameters:     floatParams,
+	}
 }
 
 func getBytesForFloat(f float64) []byte {

--- a/pkg/transformers/greenmask/greenmask_float_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_float_transformer.go
@@ -30,6 +30,7 @@ var (
 			Default:       "random",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"random", "deterministic"},
 		},
 		{
 			Name:          "min_value",

--- a/pkg/transformers/greenmask/greenmask_float_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_float_transformer.go
@@ -22,13 +22,45 @@ type FloatTransformer struct {
 	transformer *greenmasktransformers.RandomFloat64Transformer
 }
 
-var floatTransformerParams = []string{"min_value", "max_value", "precision", "generator"}
+var (
+	FloatParams = []transformers.TransformerParameter{
+		{
+			Name:          "generator",
+			SupportedType: "string",
+			Default:       "random",
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "min_value",
+			SupportedType: "float",
+			Default:       defaultMinFloat,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "max_value",
+			SupportedType: "float",
+			Default:       defaultMaxFloat,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "precision",
+			SupportedType: "int",
+			Default:       defaultPrecision,
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+	FloatCompatibleTypes = []transformers.SupportedDataType{
+		transformers.Float32DataType,
+		transformers.Float64DataType,
+		transformers.ByteArrayDataType,
+	}
+)
 
 func NewFloatTransformer(params transformers.Parameters) (*FloatTransformer, error) {
-	if err := transformers.ValidateParameters(params, floatTransformerParams); err != nil {
-		return nil, err
-	}
-
 	minValue, err := findParameter(params, "min_value", defaultMinFloat)
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_float: min_value must be a float: %w", err)
@@ -76,11 +108,7 @@ func (ft *FloatTransformer) Transform(_ context.Context, value transformers.Valu
 }
 
 func (ft *FloatTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.Float32DataType,
-		transformers.Float64DataType,
-		transformers.ByteArrayDataType,
-	}
+	return FloatCompatibleTypes
 }
 
 func (ft *FloatTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/greenmask/greenmask_float_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_float_transformer_test.go
@@ -17,7 +17,7 @@ func Test_NewFloatTransformer(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		wantErr error
 	}{
 		{
@@ -123,7 +123,7 @@ func TestFloatTransformer_Transform(t *testing.T) {
 	tests := []struct {
 		name    string
 		value   any
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		wantErr error
 	}{
 		{
@@ -140,7 +140,7 @@ func TestFloatTransformer_Transform(t *testing.T) {
 		{
 			name:  "ok - deterministic with float32, with default params",
 			value: float32(5555.5),
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 			},
 			wantErr: nil,

--- a/pkg/transformers/greenmask/greenmask_integer_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_integer_transformer.go
@@ -21,19 +21,58 @@ type IntegerTransformer struct {
 	transformer *greenmasktransformers.RandomInt64Transformer
 }
 
-var errUnsupportedSizeError = errors.New("greenmask_integer: size must be 2 or 4")
-
-var integerTransformerParams = []string{"size", "min_value", "max_value", "generator"}
+var (
+	errUnsupportedSizeError = errors.New("greenmask_integer: size must be 2 or 4")
+	IntegerParams           = []transformers.TransformerParameter{
+		{
+			Name:          "generator",
+			SupportedType: "string",
+			Default:       "random",
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "size",
+			SupportedType: "int",
+			Default:       defaultSize,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "min_value",
+			SupportedType: "int",
+			Default:       math.MinInt32,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "max_value",
+			SupportedType: "int",
+			Default:       math.MaxInt32,
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+	IntegerCompatibleTypes = []transformers.SupportedDataType{
+		transformers.ByteArrayDataType,
+		transformers.Integer8DataType,
+		transformers.UInteger8DataType,
+		transformers.Integer16DataType,
+		transformers.UInteger16DataType,
+		transformers.Integer32DataType,
+		transformers.UInteger32DataType,
+		transformers.Integer64DataType,
+		transformers.UInteger64DataType,
+		transformers.Float32DataType,
+		transformers.Float64DataType,
+	}
+)
 
 // NewIntegerTransformer creates a new IntegerTransformer with the specified
 // generator and parameters. The size parameter must be 2 or 4, and the
 // min_value and max_value parameters must be valid integers within the range of
 // the specified size.
 func NewIntegerTransformer(params transformers.Parameters) (*IntegerTransformer, error) {
-	if err := transformers.ValidateParameters(params, integerTransformerParams); err != nil {
-		return nil, err
-	}
-
 	size, err := findParameter(params, "size", int(defaultSize))
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_integer: size must be an integer: %w", err)
@@ -118,19 +157,7 @@ func (t *IntegerTransformer) Transform(_ context.Context, value transformers.Val
 }
 
 func (t *IntegerTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.Integer8DataType,
-		transformers.UInteger8DataType,
-		transformers.Integer16DataType,
-		transformers.UInteger16DataType,
-		transformers.Integer32DataType,
-		transformers.UInteger32DataType,
-		transformers.Integer64DataType,
-		transformers.UInteger64DataType,
-		transformers.Float32DataType,
-		transformers.Float64DataType,
-		transformers.ByteArrayDataType,
-	}
+	return IntegerCompatibleTypes
 }
 
 func (t *IntegerTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/greenmask/greenmask_integer_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_integer_transformer.go
@@ -23,7 +23,7 @@ type IntegerTransformer struct {
 
 var (
 	errUnsupportedSizeError = errors.New("greenmask_integer: size must be 2 or 4")
-	IntegerParams           = []transformers.TransformerParameter{
+	IntegerParams           = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -74,7 +74,7 @@ var (
 // generator and parameters. The size parameter must be 2 or 4, and the
 // min_value and max_value parameters must be valid integers within the range of
 // the specified size.
-func NewIntegerTransformer(params transformers.Parameters) (*IntegerTransformer, error) {
+func NewIntegerTransformer(params transformers.ParameterValues) (*IntegerTransformer, error) {
 	size, err := findParameter(params, "size", int(defaultSize))
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_integer: size must be an integer: %w", err)

--- a/pkg/transformers/greenmask/greenmask_integer_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_integer_transformer.go
@@ -30,6 +30,7 @@ var (
 			Default:       "random",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"random", "deterministic"},
 		},
 		{
 			Name:          "size",
@@ -37,6 +38,7 @@ var (
 			Default:       defaultSize,
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{2, 4},
 		},
 		{
 			Name:          "min_value",

--- a/pkg/transformers/greenmask/greenmask_integer_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_integer_transformer.go
@@ -23,7 +23,7 @@ type IntegerTransformer struct {
 
 var (
 	errUnsupportedSizeError = errors.New("greenmask_integer: size must be 2 or 4")
-	IntegerParams           = []transformers.Parameter{
+	integerParams           = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -55,7 +55,7 @@ var (
 			Required:      false,
 		},
 	}
-	IntegerCompatibleTypes = []transformers.SupportedDataType{
+	integerCompatibleTypes = []transformers.SupportedDataType{
 		transformers.ByteArrayDataType,
 		transformers.Integer8DataType,
 		transformers.UInteger8DataType,
@@ -159,11 +159,18 @@ func (t *IntegerTransformer) Transform(_ context.Context, value transformers.Val
 }
 
 func (t *IntegerTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return IntegerCompatibleTypes
+	return integerCompatibleTypes
 }
 
 func (t *IntegerTransformer) Type() transformers.TransformerType {
 	return transformers.GreenmaskInteger
+}
+
+func IntegerTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: integerCompatibleTypes,
+		Parameters:     integerParams,
+	}
 }
 
 func minMaxValueForSize(size int) (int, int, error) {

--- a/pkg/transformers/greenmask/greenmask_integer_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_integer_transformer_test.go
@@ -16,19 +16,19 @@ func TestNewIntegerTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		wantErr error
 	}{
 		{
 			name: "ok - valid default parameters",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 			},
 			wantErr: nil,
 		},
 		{
 			name: "ok - valid custom parameters",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 				"size":      4,
 				"min_value": -100,
@@ -38,14 +38,14 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid generator type",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": "invalid",
 			},
 			wantErr: transformers.ErrUnsupportedGenerator,
 		},
 		{
 			name: "error - invalid size, too small",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"size":      0,
 			},
@@ -53,7 +53,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid size, too large",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 				"size":      9,
 			},
@@ -61,7 +61,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name: "error - wrong limits",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"min_value": 100,
 				"max_value": 99,
@@ -70,7 +70,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name: "error - wrong limits not fitting size",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"min_value": math.MaxInt,
 				"size":      2,
@@ -79,7 +79,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid size type",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 				"size":      "invalid",
 			},
@@ -87,7 +87,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid min_value type",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"min_value": "invalid",
 			},
@@ -95,7 +95,7 @@ func TestNewIntegerTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid max_value type",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 				"max_value": "invalid",
 			},
@@ -122,7 +122,7 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 	tests := []struct {
 		name   string
 		input  any
-		params transformers.Parameters
+		params transformers.ParameterValues
 
 		wantErr error
 	}{
@@ -167,28 +167,28 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - transform int64 randomly with default params",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 			},
 			input: int64(500),
 		},
 		{
 			name: "ok - transform int deterministically with default params",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 			},
 			input: int(500),
 		},
 		{
 			name: "ok - transform uint deterministically with default params",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 			},
 			input: uint(4646),
 		},
 		{
 			name: "ok - transform uint32 deterministically with default params",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 			},
 			input: uint32(500000000),

--- a/pkg/transformers/greenmask/greenmask_string_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_string_transformer.go
@@ -16,13 +16,45 @@ type StringTransformer struct {
 
 const defaultSymbols = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 
-var stringTransformerParams = []string{"symbols", "min_length", "max_length", "generator"}
-
-func NewStringTransformer(params transformers.Parameters) (*StringTransformer, error) {
-	if err := transformers.ValidateParameters(params, stringTransformerParams); err != nil {
-		return nil, err
+var (
+	StringCompatibleTypes = []transformers.SupportedDataType{
+		transformers.StringDataType,
+		transformers.ByteArrayDataType,
 	}
 
+	StringParams = []transformers.TransformerParameter{
+		{
+			Name:          "symbols",
+			SupportedType: "string",
+			Default:       defaultSymbols,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "min_length",
+			SupportedType: "int",
+			Default:       1,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "max_length",
+			SupportedType: "int",
+			Default:       100,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "generator",
+			SupportedType: "string",
+			Default:       "random",
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+)
+
+func NewStringTransformer(params transformers.Parameters) (*StringTransformer, error) {
 	symbols, err := findParameter(params, "symbols", defaultSymbols)
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_string: symbols must be a string: %w", err)
@@ -68,10 +100,7 @@ func (st *StringTransformer) Transform(_ context.Context, value transformers.Val
 }
 
 func (st *StringTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.StringDataType,
-		transformers.ByteArrayDataType,
-	}
+	return StringCompatibleTypes
 }
 
 func (st *StringTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/greenmask/greenmask_string_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_string_transformer.go
@@ -17,12 +17,12 @@ type StringTransformer struct {
 const defaultSymbols = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 
 var (
-	StringCompatibleTypes = []transformers.SupportedDataType{
+	stringCompatibleTypes = []transformers.SupportedDataType{
 		transformers.StringDataType,
 		transformers.ByteArrayDataType,
 	}
 
-	StringParams = []transformers.Parameter{
+	stringParams = []transformers.Parameter{
 		{
 			Name:          "symbols",
 			SupportedType: "string",
@@ -101,9 +101,16 @@ func (st *StringTransformer) Transform(_ context.Context, value transformers.Val
 }
 
 func (st *StringTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return StringCompatibleTypes
+	return stringCompatibleTypes
 }
 
 func (st *StringTransformer) Type() transformers.TransformerType {
 	return transformers.GreenmaskString
+}
+
+func StringTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: stringCompatibleTypes,
+		Parameters:     stringParams,
+	}
 }

--- a/pkg/transformers/greenmask/greenmask_string_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_string_transformer.go
@@ -50,6 +50,7 @@ var (
 			Default:       "random",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"random", "deterministic"},
 		},
 	}
 )

--- a/pkg/transformers/greenmask/greenmask_string_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_string_transformer.go
@@ -22,7 +22,7 @@ var (
 		transformers.ByteArrayDataType,
 	}
 
-	StringParams = []transformers.TransformerParameter{
+	StringParams = []transformers.Parameter{
 		{
 			Name:          "symbols",
 			SupportedType: "string",
@@ -55,7 +55,7 @@ var (
 	}
 )
 
-func NewStringTransformer(params transformers.Parameters) (*StringTransformer, error) {
+func NewStringTransformer(params transformers.ParameterValues) (*StringTransformer, error) {
 	symbols, err := findParameter(params, "symbols", defaultSymbols)
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_string: symbols must be a string: %w", err)

--- a/pkg/transformers/greenmask/greenmask_string_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_string_transformer_test.go
@@ -15,7 +15,7 @@ func Test_NewStringTransformer(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		params transformers.Parameters
+		params transformers.ParameterValues
 
 		wantErr error
 	}{
@@ -94,7 +94,7 @@ func TestStringTransformer_Transform(t *testing.T) {
 	tests := []struct {
 		name   string
 		value  any
-		params transformers.Parameters
+		params transformers.ParameterValues
 
 		wantLen int
 		wantStr string

--- a/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
@@ -19,15 +19,44 @@ type UTCTimestampTransformer struct {
 var (
 	errMinMaxTimestampNotSpecified = errors.New("greenmask_timestamp: min_timestamp and max_timestamp must be specified")
 	errInvalidTimestamp            = errors.New("greenmask_timestamp: min_timestamp and max_timestamp must be valid RFC3339 timestamps")
+	UTCTimestampParams             = []transformers.TransformerParameter{
+		{
+			Name:          "generator",
+			SupportedType: "string",
+			Default:       "random",
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "truncate_part",
+			SupportedType: "string",
+			Default:       "",
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "min_timestamp",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      true,
+		},
+		{
+			Name:          "max_timestamp",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      true,
+		},
+	}
+	UTCTimestampCompatibleTypes = []transformers.SupportedDataType{
+		transformers.DatetimeDataType,
+		transformers.ByteArrayDataType,
+		transformers.StringDataType,
+	}
 )
 
-var UTCTimestampTransformerParams = []string{"truncate_part", "min_timestamp", "max_timestamp", "generator"}
-
 func NewUTCTimestampTransformer(params transformers.Parameters) (*UTCTimestampTransformer, error) {
-	if err := transformers.ValidateParameters(params, UTCTimestampTransformerParams); err != nil {
-		return nil, err
-	}
-
 	truncatePart, err := findParameter(params, "truncate_part", "")
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_utc_timestamp: truncate_part must be a string: %w", err)
@@ -90,11 +119,7 @@ func (t *UTCTimestampTransformer) Transform(_ context.Context, value transformer
 }
 
 func (t *UTCTimestampTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.DatetimeDataType,
-		transformers.ByteArrayDataType,
-		transformers.StringDataType,
-	}
+	return UTCTimestampCompatibleTypes
 }
 
 func (t *UTCTimestampTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
@@ -19,7 +19,7 @@ type UTCTimestampTransformer struct {
 var (
 	errMinMaxTimestampNotSpecified = errors.New("greenmask_timestamp: min_timestamp and max_timestamp must be specified")
 	errInvalidTimestamp            = errors.New("greenmask_timestamp: min_timestamp and max_timestamp must be valid RFC3339 timestamps")
-	UTCTimestampParams             = []transformers.TransformerParameter{
+	UTCTimestampParams             = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -58,7 +58,7 @@ var (
 	}
 )
 
-func NewUTCTimestampTransformer(params transformers.Parameters) (*UTCTimestampTransformer, error) {
+func NewUTCTimestampTransformer(params transformers.ParameterValues) (*UTCTimestampTransformer, error) {
 	truncatePart, err := findParameter(params, "truncate_part", "")
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_utc_timestamp: truncate_part must be a string: %w", err)

--- a/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
@@ -26,6 +26,7 @@ var (
 			Default:       "random",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"random", "deterministic"},
 		},
 		{
 			Name:          "truncate_part",
@@ -33,6 +34,7 @@ var (
 			Default:       "",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"year", "month", "day", "hour", "minute", "second", "millisecond", "microsecond", "nanosecond"},
 		},
 		{
 			Name:          "min_timestamp",

--- a/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
@@ -19,7 +19,7 @@ type UTCTimestampTransformer struct {
 var (
 	errMinMaxTimestampNotSpecified = errors.New("greenmask_timestamp: min_timestamp and max_timestamp must be specified")
 	errInvalidTimestamp            = errors.New("greenmask_timestamp: min_timestamp and max_timestamp must be valid RFC3339 timestamps")
-	UTCTimestampParams             = []transformers.Parameter{
+	utcTimestampParams             = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -51,7 +51,7 @@ var (
 			Required:      true,
 		},
 	}
-	UTCTimestampCompatibleTypes = []transformers.SupportedDataType{
+	utcTimestampCompatibleTypes = []transformers.SupportedDataType{
 		transformers.DatetimeDataType,
 		transformers.ByteArrayDataType,
 		transformers.StringDataType,
@@ -121,9 +121,16 @@ func (t *UTCTimestampTransformer) Transform(_ context.Context, value transformer
 }
 
 func (t *UTCTimestampTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return UTCTimestampCompatibleTypes
+	return utcTimestampCompatibleTypes
 }
 
 func (t *UTCTimestampTransformer) Type() transformers.TransformerType {
 	return transformers.GreenmaskUTCTimestamp
+}
+
+func UTCTimestampTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: utcTimestampCompatibleTypes,
+		Parameters:     utcTimestampParams,
+	}
 }

--- a/pkg/transformers/greenmask/greenmask_timestamp_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_timestamp_transformer_test.go
@@ -16,12 +16,12 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		wantErr error
 	}{
 		{
 			name: "ok - valid random",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     random,
 				"min_timestamp": "2021-01-01T00:00:00Z",
 				"max_timestamp": "2022-01-02T00:00:00Z",
@@ -30,7 +30,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid truncate_part",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     deterministic,
 				"truncate_part": 1.2,
 			},
@@ -38,7 +38,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid min_timestamp",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     deterministic,
 				"min_timestamp": 1.2,
 			},
@@ -46,7 +46,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid min_timestamp format",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     deterministic,
 				"min_timestamp": "2021 Jan 01",
 				"max_timestamp": "2022-01-02T00:00:00Z",
@@ -55,7 +55,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid max_timestamp",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     random,
 				"min_timestamp": "2021-01-01T00:00:00Z",
 				"max_timestamp": 1.2,
@@ -64,7 +64,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid max_timestamp format",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     deterministic,
 				"min_timestamp": "2021-01-01T00:00:00Z",
 				"max_timestamp": "2021 Jan 01",
@@ -73,7 +73,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name: "error - min_timestamp not specified",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     random,
 				"max_timestamp": "2022-01-02T00:00:00Z",
 			},
@@ -81,7 +81,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name: "error - min_timestamp equal to max_timestamp",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     deterministic,
 				"min_timestamp": "2023-01-02T00:00:00Z",
 				"max_timestamp": "2023-01-02T00:01:00+01:00",
@@ -90,7 +90,7 @@ func TestNewUTCTimestampTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid generator type",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     "invalid",
 				"min_timestamp": "2021-01-01T00:00:00Z",
 				"max_timestamp": "2022-01-02T00:00:00Z",
@@ -117,13 +117,13 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   any
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		wantErr error
 	}{
 		{
 			name:  "ok - transform string randomly",
 			input: "test",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     random,
 				"min_timestamp": "2022-01-01T00:00:00Z",
 				"max_timestamp": "2023-01-02T00:00:00Z",
@@ -134,7 +134,7 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 		{
 			name:  "ok - transform []byte deterministically",
 			input: []byte("test"),
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     deterministic,
 				"min_timestamp": "2021-01-01T00:00:00Z",
 				"max_timestamp": "2023-01-02T00:00:00Z",
@@ -145,7 +145,7 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 		{
 			name:  "ok - transform time.Time deterministically",
 			input: time.Now(),
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     deterministic,
 				"min_timestamp": "2020-01-01T00:00:00Z",
 				"max_timestamp": "2023-01-02T00:00:00Z",
@@ -156,7 +156,7 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 		{
 			name:  "ok - truncate after millisecond part",
 			input: "2021-01-01T00:00:00Z",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     deterministic,
 				"min_timestamp": "2023-01-01T00:00:00Z",
 				"max_timestamp": "2023-01-01T01:10:00+01:00",
@@ -167,7 +167,7 @@ func TestUTCTimestampTransformer_Transform(t *testing.T) {
 		{
 			name:  "error - invalid input type",
 			input: 1,
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator":     deterministic,
 				"min_timestamp": "2020-01-01T00:00:00Z",
 				"max_timestamp": "2023-01-02T00:00:00Z",

--- a/pkg/transformers/greenmask/greenmask_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_transformer.go
@@ -15,7 +15,7 @@ const (
 	deterministic = "deterministic"
 )
 
-func setGenerator(t greenmasktransformers.Transformer, params transformers.Parameters) error {
+func setGenerator(t greenmasktransformers.Transformer, params transformers.ParameterValues) error {
 	generatorType, err := getGeneratorType(params)
 	if err != nil {
 		return err
@@ -38,16 +38,16 @@ func setGenerator(t greenmasktransformers.Transformer, params transformers.Param
 	return t.SetGenerator(greenmaskGenerator)
 }
 
-func getGeneratorType(params transformers.Parameters) (string, error) {
+func getGeneratorType(params transformers.ParameterValues) (string, error) {
 	// default to using the random generator
 	return findParameter(params, "generator", random)
 }
 
-func findParameter[T any](params transformers.Parameters, name string, defaultVal T) (T, error) {
+func findParameter[T any](params transformers.ParameterValues, name string, defaultVal T) (T, error) {
 	return transformers.FindParameterWithDefault(params, name, defaultVal)
 }
 
-func findParameterArray[T any](params transformers.Parameters, name string, defaultVal []T) ([]T, error) {
+func findParameterArray[T any](params transformers.ParameterValues, name string, defaultVal []T) ([]T, error) {
 	val, found, err := transformers.FindParameterArray[T](params, name)
 	if err != nil {
 		return val, err

--- a/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
@@ -20,6 +20,7 @@ var (
 			Default:       "random",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"random", "deterministic"},
 		},
 		{
 			Name:          "min_value",

--- a/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	errMinMaxValueNotSpecified = errors.New("min_value and max_value must be specified")
-	UnixTimestampParams        = []transformers.TransformerParameter{
+	UnixTimestampParams        = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -44,7 +44,7 @@ type UnixTimestampTransformer struct {
 	*IntegerTransformer
 }
 
-func NewUnixTimestampTransformer(params transformers.Parameters) (*UnixTimestampTransformer, error) {
+func NewUnixTimestampTransformer(params transformers.ParameterValues) (*UnixTimestampTransformer, error) {
 	minValueStr, foundMin, err := transformers.FindParameter[string](params, "min_value")
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_unix_timestamp: min_value must be a string: %w", err)

--- a/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
@@ -11,19 +11,39 @@ import (
 	"github.com/xataio/pgstream/pkg/transformers"
 )
 
-var errMinMaxValueNotSpecified = errors.New("min_value and max_value must be specified")
-
-var unixTimestampTransformerParams = []string{"min_value", "max_value", "generator"}
+var (
+	errMinMaxValueNotSpecified = errors.New("min_value and max_value must be specified")
+	UnixTimestampParams        = []transformers.TransformerParameter{
+		{
+			Name:          "generator",
+			SupportedType: "string",
+			Default:       "random",
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "min_value",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      true,
+		},
+		{
+			Name:          "max_value",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      true,
+		},
+	}
+	UnixTimestampCompatibleTypes = IntegerCompatibleTypes
+)
 
 type UnixTimestampTransformer struct {
 	*IntegerTransformer
 }
 
 func NewUnixTimestampTransformer(params transformers.Parameters) (*UnixTimestampTransformer, error) {
-	if err := transformers.ValidateParameters(params, unixTimestampTransformerParams); err != nil {
-		return nil, err
-	}
-
 	minValueStr, foundMin, err := transformers.FindParameter[string](params, "min_value")
 	if err != nil {
 		return nil, fmt.Errorf("greenmask_unix_timestamp: min_value must be a string: %w", err)

--- a/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	errMinMaxValueNotSpecified = errors.New("min_value and max_value must be specified")
-	UnixTimestampParams        = []transformers.Parameter{
+	unixTimestampParams        = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -37,7 +37,7 @@ var (
 			Required:      true,
 		},
 	}
-	UnixTimestampCompatibleTypes = IntegerCompatibleTypes
+	unixTimestampCompatibleTypes = integerCompatibleTypes
 )
 
 type UnixTimestampTransformer struct {
@@ -92,4 +92,11 @@ func NewUnixTimestampTransformer(params transformers.ParameterValues) (*UnixTime
 
 func (t *UnixTimestampTransformer) Type() transformers.TransformerType {
 	return transformers.GreenmaskUnixTimestamp
+}
+
+func UnixTimestampTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: unixTimestampCompatibleTypes,
+		Parameters:     unixTimestampParams,
+	}
 }

--- a/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer_test.go
@@ -16,12 +16,12 @@ func TestNewUnixTimestampTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		wantErr error
 	}{
 		{
 			name: "ok - valid random",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"min_value": "-1741957250",
 				"max_value": "1741957250",
@@ -30,7 +30,7 @@ func TestNewUnixTimestampTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid generator",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": "invalid",
 				"min_value": "-1741957250",
 				"max_value": "1741957250",
@@ -39,7 +39,7 @@ func TestNewUnixTimestampTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid min_value",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 				"min_value": 3.0,
 			},
@@ -47,7 +47,7 @@ func TestNewUnixTimestampTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid max_value",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 				"min_value": "1741957250",
 				"max_value": 3,
@@ -56,7 +56,7 @@ func TestNewUnixTimestampTransformer(t *testing.T) {
 		},
 		{
 			name: "error - min_value missing",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 				"max_value": "1741957250",
 			},
@@ -64,7 +64,7 @@ func TestNewUnixTimestampTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid limits",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"min_value": "1741957250",
 				"max_value": "1741957250",
@@ -91,11 +91,11 @@ func TestUnixTimestampTransformer_Transform(t *testing.T) {
 	tests := []struct {
 		name   string
 		input  any
-		params transformers.Parameters
+		params transformers.ParameterValues
 	}{
 		{
 			name: "ok - random",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 				"min_value": "1625097600",
 				"max_value": "1625184000",
@@ -104,7 +104,7 @@ func TestUnixTimestampTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - deterministic",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 				"min_value": "1625097600",
 				"max_value": "1625184000",
@@ -144,7 +144,7 @@ func TestUnixTimestampTransformer_Transform(t *testing.T) {
 	}
 }
 
-func mustGetGeneratorType(t *testing.T, params transformers.Parameters) string {
+func mustGetGeneratorType(t *testing.T, params transformers.ParameterValues) string {
 	gt, err := getGeneratorType(params)
 	require.NoError(t, err)
 	return gt

--- a/pkg/transformers/greenmask/greenmask_uuid_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_uuid_transformer.go
@@ -14,12 +14,25 @@ type UUIDTransformer struct {
 	transformer *greenmasktransformers.RandomUuidTransformer
 }
 
-var UUIDTransformerParams = []string{"generator"}
+var (
+	UUIDParams = []transformers.TransformerParameter{
+		{
+			Name:          "generator",
+			SupportedType: "string",
+			Default:       "random",
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+	UUIDCompatibleTypes = []transformers.SupportedDataType{
+		transformers.StringDataType,
+		transformers.ByteArrayDataType,
+		transformers.UUIDDataType,
+		transformers.UInt8ArrayOf16DataType,
+	}
+)
 
 func NewUUIDTransformer(params transformers.Parameters) (*UUIDTransformer, error) {
-	if err := transformers.ValidateParameters(params, UUIDTransformerParams); err != nil {
-		return nil, err
-	}
 	t := greenmasktransformers.NewRandomUuidTransformer()
 	if err := setGenerator(t, params); err != nil {
 		return nil, err
@@ -51,12 +64,7 @@ func (ut *UUIDTransformer) Transform(_ context.Context, value transformers.Value
 }
 
 func (ut *UUIDTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.StringDataType,
-		transformers.UUIDDataType,
-		transformers.ByteArrayDataType,
-		transformers.UInt8ArrayOf16DataType,
-	}
+	return UUIDCompatibleTypes
 }
 
 func (ut *UUIDTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/greenmask/greenmask_uuid_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_uuid_transformer.go
@@ -15,7 +15,7 @@ type UUIDTransformer struct {
 }
 
 var (
-	UUIDParams = []transformers.TransformerParameter{
+	UUIDParams = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -33,7 +33,7 @@ var (
 	}
 )
 
-func NewUUIDTransformer(params transformers.Parameters) (*UUIDTransformer, error) {
+func NewUUIDTransformer(params transformers.ParameterValues) (*UUIDTransformer, error) {
 	t := greenmasktransformers.NewRandomUuidTransformer()
 	if err := setGenerator(t, params); err != nil {
 		return nil, err

--- a/pkg/transformers/greenmask/greenmask_uuid_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_uuid_transformer.go
@@ -22,6 +22,7 @@ var (
 			Default:       "random",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"random", "deterministic"},
 		},
 	}
 	UUIDCompatibleTypes = []transformers.SupportedDataType{

--- a/pkg/transformers/greenmask/greenmask_uuid_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_uuid_transformer.go
@@ -15,7 +15,7 @@ type UUIDTransformer struct {
 }
 
 var (
-	UUIDParams = []transformers.Parameter{
+	uuidParams = []transformers.Parameter{
 		{
 			Name:          "generator",
 			SupportedType: "string",
@@ -25,7 +25,7 @@ var (
 			Values:        []any{"random", "deterministic"},
 		},
 	}
-	UUIDCompatibleTypes = []transformers.SupportedDataType{
+	uuidCompatibleTypes = []transformers.SupportedDataType{
 		transformers.StringDataType,
 		transformers.ByteArrayDataType,
 		transformers.UUIDDataType,
@@ -65,9 +65,16 @@ func (ut *UUIDTransformer) Transform(_ context.Context, value transformers.Value
 }
 
 func (ut *UUIDTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return UUIDCompatibleTypes
+	return uuidCompatibleTypes
 }
 
 func (ut *UUIDTransformer) Type() transformers.TransformerType {
 	return transformers.GreenmaskUUID
+}
+
+func UUIDTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: uuidCompatibleTypes,
+		Parameters:     uuidParams,
+	}
 }

--- a/pkg/transformers/greenmask/greenmask_uuid_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_uuid_transformer_test.go
@@ -16,26 +16,26 @@ func Test_NewUUIDTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		wantErr error
 	}{
 		{
 			name: "ok - valid random",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 			},
 			wantErr: nil,
 		},
 		{
 			name: "ok - valid deterministic",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 			},
 			wantErr: nil,
 		},
 		{
 			name: "error - invalid generator type",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": "invalid",
 			},
 			wantErr: transformers.ErrUnsupportedGenerator,
@@ -59,12 +59,12 @@ func Test_UUIDTransformer_Transform(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   any
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		wantErr error
 	}{
 		{
 			name: "ok - string, random",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 			},
 			input:   "123e4567-e89b-12d3-a456-426655440000",
@@ -72,7 +72,7 @@ func Test_UUIDTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - []byte, deterministic",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 			},
 			input:   []byte("123e4567-e89b-12d3-a456-426655440000"),
@@ -80,7 +80,7 @@ func Test_UUIDTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - uuid.UUID, deterministic",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 			},
 			input:   uuid.MustParse("123e4567-e89b-12d3-a456-426655440000"),
@@ -88,7 +88,7 @@ func Test_UUIDTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - can be any string",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": deterministic,
 			},
 			input:   "this is not a uuid",
@@ -96,7 +96,7 @@ func Test_UUIDTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "error - invalid input type",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"generator": random,
 			},
 			input:   123,

--- a/pkg/transformers/literal_string_transformer.go
+++ b/pkg/transformers/literal_string_transformer.go
@@ -13,15 +13,22 @@ type LiteralStringTransformer struct {
 }
 
 var (
-	literalStringTransformerParams = []string{"literal"}
-	errLiteralStringNotFound       = errors.New("literal_string_transformer: literal parameter not found")
+	errLiteralStringNotFound     = errors.New("literal_string_transformer: literal parameter not found")
+	LiteralStringCompatibleTypes = []SupportedDataType{
+		AllDataTypes,
+	}
+	LiteralStringParams = []TransformerParameter{
+		{
+			Name:          "literal",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      true,
+		},
+	}
 )
 
 func NewLiteralStringTransformer(params Parameters) (*LiteralStringTransformer, error) {
-	if err := ValidateParameters(params, literalStringTransformerParams); err != nil {
-		return nil, err
-	}
-
 	literal, found, err := FindParameter[string](params, "literal")
 	if err != nil {
 		return nil, fmt.Errorf("literal_string_transformer: literal must be a string: %w", err)
@@ -40,9 +47,7 @@ func (lst *LiteralStringTransformer) Transform(_ context.Context, value Value) (
 }
 
 func (lst *LiteralStringTransformer) CompatibleTypes() []SupportedDataType {
-	return []SupportedDataType{
-		AllDataTypes,
-	}
+	return LiteralStringCompatibleTypes
 }
 
 func (lst *LiteralStringTransformer) Type() TransformerType {

--- a/pkg/transformers/literal_string_transformer.go
+++ b/pkg/transformers/literal_string_transformer.go
@@ -14,10 +14,10 @@ type LiteralStringTransformer struct {
 
 var (
 	errLiteralStringNotFound     = errors.New("literal_string_transformer: literal parameter not found")
-	LiteralStringCompatibleTypes = []SupportedDataType{
+	literalStringCompatibleTypes = []SupportedDataType{
 		AllDataTypes,
 	}
-	LiteralStringParams = []Parameter{
+	literalStringParams = []Parameter{
 		{
 			Name:          "literal",
 			SupportedType: "string",
@@ -47,9 +47,16 @@ func (lst *LiteralStringTransformer) Transform(_ context.Context, value Value) (
 }
 
 func (lst *LiteralStringTransformer) CompatibleTypes() []SupportedDataType {
-	return LiteralStringCompatibleTypes
+	return literalStringCompatibleTypes
 }
 
 func (lst *LiteralStringTransformer) Type() TransformerType {
 	return LiteralString
+}
+
+func LiteralStringTransformerDefinition() *Definition {
+	return &Definition{
+		SupportedTypes: literalStringCompatibleTypes,
+		Parameters:     literalStringParams,
+	}
 }

--- a/pkg/transformers/literal_string_transformer.go
+++ b/pkg/transformers/literal_string_transformer.go
@@ -17,7 +17,7 @@ var (
 	LiteralStringCompatibleTypes = []SupportedDataType{
 		AllDataTypes,
 	}
-	LiteralStringParams = []TransformerParameter{
+	LiteralStringParams = []Parameter{
 		{
 			Name:          "literal",
 			SupportedType: "string",
@@ -28,7 +28,7 @@ var (
 	}
 )
 
-func NewLiteralStringTransformer(params Parameters) (*LiteralStringTransformer, error) {
+func NewLiteralStringTransformer(params ParameterValues) (*LiteralStringTransformer, error) {
 	literal, found, err := FindParameter[string](params, "literal")
 	if err != nil {
 		return nil, fmt.Errorf("literal_string_transformer: literal must be a string: %w", err)

--- a/pkg/transformers/literal_string_transformer_test.go
+++ b/pkg/transformers/literal_string_transformer_test.go
@@ -13,26 +13,26 @@ func TestLiteralStringTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		params  Parameters
+		params  ParameterValues
 		wantErr error
 	}{
 		{
 			name: "ok - valid",
-			params: Parameters{
+			params: ParameterValues{
 				"literal": "test",
 			},
 			wantErr: nil,
 		},
 		{
 			name: "error - invalid literal",
-			params: Parameters{
+			params: ParameterValues{
 				"literal": 123,
 			},
 			wantErr: ErrInvalidParameters,
 		},
 		{
 			name:    "error - empty literal",
-			params:  Parameters{},
+			params:  ParameterValues{},
 			wantErr: errLiteralStringNotFound,
 		},
 	}
@@ -53,11 +53,11 @@ func TestLiteralStringTransformer(t *testing.T) {
 func TestLiteralStringTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	wantOutput := "{'output': 'testoutput'"
-	lst, err := NewLiteralStringTransformer(Parameters{"literal": wantOutput})
+	lst, err := NewLiteralStringTransformer(ParameterValues{"literal": wantOutput})
 	require.NoError(t, err)
 	tests := []struct {
 		name    string
-		params  Parameters
+		params  ParameterValues
 		input   any
 		want    any
 		wantErr error

--- a/pkg/transformers/masking_transformer.go
+++ b/pkg/transformers/masking_transformer.go
@@ -42,6 +42,7 @@ var (
 			Default:       "default",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"custom", "password", "name", "address", "email", "mobile", "tel", "id", "credit_card", "url", "default"},
 		},
 		{
 			Name:          "mask_begin",

--- a/pkg/transformers/masking_transformer.go
+++ b/pkg/transformers/masking_transformer.go
@@ -31,6 +31,47 @@ var (
 		"type must be one of 'custom', 'password', 'name', 'address', 'email', 'mobile', 'tel', 'id', 'credit_card', 'url' or 'default'",
 	)
 	errMaskUnmaskCannotBeUsedTogether = errors.New("masking: mask and unmask parameters cannot be used together")
+	MaskingCompatibleTypes            = []SupportedDataType{
+		StringDataType,
+		ByteArrayDataType,
+	}
+	MaskingParams = []TransformerParameter{
+		{
+			Name:          "type",
+			SupportedType: "string",
+			Default:       "default",
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "mask_begin",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "mask_end",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "unmask_begin",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "unmask_end",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
 )
 
 type maskingFunction func(val string) string
@@ -40,14 +81,8 @@ type MaskingTransformer struct {
 	maskingFunction maskingFunction
 }
 
-var maskingTransformerParams = []string{"type", "mask_begin", "mask_end", "unmask_begin", "unmask_end"}
-
 // NewMaskingTransformer creates a new MaskingTransformer with the given masking function.
 func NewMaskingTransformer(params Parameters) (*MaskingTransformer, error) {
-	if err := ValidateParameters(params, maskingTransformerParams); err != nil {
-		return nil, err
-	}
-
 	var mf maskingFunction
 	maskType, found, err := FindParameter[string](params, "type")
 	if err != nil {
@@ -108,10 +143,7 @@ func (t *MaskingTransformer) Transform(_ context.Context, value Value) (any, err
 }
 
 func (t *MaskingTransformer) CompatibleTypes() []SupportedDataType {
-	return []SupportedDataType{
-		StringDataType,
-		ByteArrayDataType,
-	}
+	return MaskingCompatibleTypes
 }
 
 func (t *MaskingTransformer) Type() TransformerType {

--- a/pkg/transformers/masking_transformer.go
+++ b/pkg/transformers/masking_transformer.go
@@ -31,11 +31,11 @@ var (
 		"type must be one of 'custom', 'password', 'name', 'address', 'email', 'mobile', 'tel', 'id', 'credit_card', 'url' or 'default'",
 	)
 	errMaskUnmaskCannotBeUsedTogether = errors.New("masking: mask and unmask parameters cannot be used together")
-	MaskingCompatibleTypes            = []SupportedDataType{
+	maskingCompatibleTypes            = []SupportedDataType{
 		StringDataType,
 		ByteArrayDataType,
 	}
-	MaskingParams = []Parameter{
+	maskingParams = []Parameter{
 		{
 			Name:          "type",
 			SupportedType: "string",
@@ -144,11 +144,18 @@ func (t *MaskingTransformer) Transform(_ context.Context, value Value) (any, err
 }
 
 func (t *MaskingTransformer) CompatibleTypes() []SupportedDataType {
-	return MaskingCompatibleTypes
+	return maskingCompatibleTypes
 }
 
 func (t *MaskingTransformer) Type() TransformerType {
 	return Masking
+}
+
+func MaskingTransformerDefinition() *Definition {
+	return &Definition{
+		SupportedTypes: maskingCompatibleTypes,
+		Parameters:     maskingParams,
+	}
 }
 
 func getCustomMaskingFn(params ParameterValues) (maskingFunction, error) {

--- a/pkg/transformers/masking_transformer.go
+++ b/pkg/transformers/masking_transformer.go
@@ -35,7 +35,7 @@ var (
 		StringDataType,
 		ByteArrayDataType,
 	}
-	MaskingParams = []TransformerParameter{
+	MaskingParams = []Parameter{
 		{
 			Name:          "type",
 			SupportedType: "string",
@@ -83,7 +83,7 @@ type MaskingTransformer struct {
 }
 
 // NewMaskingTransformer creates a new MaskingTransformer with the given masking function.
-func NewMaskingTransformer(params Parameters) (*MaskingTransformer, error) {
+func NewMaskingTransformer(params ParameterValues) (*MaskingTransformer, error) {
 	var mf maskingFunction
 	maskType, found, err := FindParameter[string](params, "type")
 	if err != nil {
@@ -151,7 +151,7 @@ func (t *MaskingTransformer) Type() TransformerType {
 	return Masking
 }
 
-func getCustomMaskingFn(params Parameters) (maskingFunction, error) {
+func getCustomMaskingFn(params ParameterValues) (maskingFunction, error) {
 	maskBegin, maskBeginFound, err := FindParameter[string](params, "mask_begin")
 	if err != nil {
 		return nil, fmt.Errorf("masking: mask_begin must be a string: %w", err)

--- a/pkg/transformers/masking_transformer_test.go
+++ b/pkg/transformers/masking_transformer_test.go
@@ -13,7 +13,7 @@ func TestMaskingTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		params  Parameters
+		params  ParameterValues
 		wantErr error
 	}{
 		{
@@ -22,14 +22,14 @@ func TestMaskingTransformer(t *testing.T) {
 		},
 		{
 			name: "ok - valid custom parameters",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "password",
 			},
 			wantErr: nil,
 		},
 		{
 			name: "error - invalid, custom masking",
-			params: Parameters{
+			params: ParameterValues{
 				"type":         "custom",
 				"mask_begin":   "4",
 				"unmask_begin": "4",
@@ -38,7 +38,7 @@ func TestMaskingTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid param type, custom masking",
-			params: Parameters{
+			params: ParameterValues{
 				"type":       "custom",
 				"mask_begin": 4,
 			},
@@ -46,14 +46,14 @@ func TestMaskingTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid masking type",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "invalid",
 			},
 			wantErr: errInvalidMaskingType,
 		},
 		{
 			name: "error - invalid parameter type",
-			params: Parameters{
+			params: ParameterValues{
 				"type": 123,
 			},
 			wantErr: ErrInvalidParameters,
@@ -78,14 +78,14 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		params  Parameters
+		params  ParameterValues
 		input   any
 		want    any
 		wantErr error
 	}{
 		{
 			name: "ok - password",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "password",
 			},
 			input:   "aVeryStrongPassword123",
@@ -94,7 +94,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - name",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "name",
 			},
 			input:   []byte("John Doe"),
@@ -103,7 +103,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - address",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "address",
 			},
 			input:   "123 Main St, Anytown, USA",
@@ -112,7 +112,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - email",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "email",
 			},
 			input:   "john.doe@example.com",
@@ -121,7 +121,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - mobile",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "mobile",
 			},
 			input:   "1234567890",
@@ -130,7 +130,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - tel",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "tel",
 			},
 			input:   "+1-23-456-789",
@@ -139,7 +139,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - id",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "id",
 			},
 			input:   "123456789",
@@ -148,7 +148,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - credit_card",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "credit_card",
 			},
 			input:   "4111-1111-1111-1111",
@@ -157,7 +157,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - url",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "url",
 			},
 			input:   "http://admin:mysecretpassword@localhost:1234/uri",
@@ -166,7 +166,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - default",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "default",
 			},
 			input:   "Sensitive Data",
@@ -175,7 +175,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - custom masking",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "custom",
 			},
 			input:   "Sensitive Data",
@@ -184,7 +184,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - custom masking with mask indexes",
-			params: Parameters{
+			params: ParameterValues{
 				"type":       "custom",
 				"mask_begin": "4",
 				"mask_end":   "400%",
@@ -195,7 +195,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - custom masking with unmask indexes",
-			params: Parameters{
+			params: ParameterValues{
 				"type":         "custom",
 				"unmask_begin": "78%",
 				"unmask_end":   "-4%",
@@ -206,7 +206,7 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "error - invalid input type",
-			params: Parameters{
+			params: ParameterValues{
 				"type": "default",
 			},
 			input:   123,

--- a/pkg/transformers/neosync/neosync_email_transformer.go
+++ b/pkg/transformers/neosync/neosync_email_transformer.go
@@ -31,7 +31,7 @@ var (
 		neosynctransformers.InvalidEmailAction_Generate.String(),
 	}
 
-	EmailParams = []transformers.TransformerParameter{
+	EmailParams = []transformers.Parameter{
 		{
 			Name:          "seed",
 			SupportedType: "int",
@@ -89,7 +89,7 @@ var (
 	}
 )
 
-func NewEmailTransformer(params transformers.Parameters) (*EmailTransformer, error) {
+func NewEmailTransformer(params transformers.ParameterValues) (*EmailTransformer, error) {
 	preserveLength, err := findParameter[bool](params, "preserve_length")
 	if err != nil {
 		return nil, fmt.Errorf("neosync_email: preserve_length must be a boolean: %w", err)

--- a/pkg/transformers/neosync/neosync_email_transformer.go
+++ b/pkg/transformers/neosync/neosync_email_transformer.go
@@ -73,6 +73,7 @@ var (
 			Default:       "uuidv4",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"uuidv4", "fullname", "any"},
 		},
 		{
 			Name:          "invalid_email_action",
@@ -80,6 +81,7 @@ var (
 			Default:       "reject",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"reject", "passthrough", "null", "generate"},
 		},
 	}
 	EmailCompatibleTypes = []transformers.SupportedDataType{

--- a/pkg/transformers/neosync/neosync_email_transformer.go
+++ b/pkg/transformers/neosync/neosync_email_transformer.go
@@ -31,7 +31,7 @@ var (
 		neosynctransformers.InvalidEmailAction_Generate.String(),
 	}
 
-	EmailParams = []transformers.Parameter{
+	emailParams = []transformers.Parameter{
 		{
 			Name:          "seed",
 			SupportedType: "int",
@@ -84,7 +84,7 @@ var (
 			Values:        []any{"reject", "passthrough", "null", "generate"},
 		},
 	}
-	EmailCompatibleTypes = []transformers.SupportedDataType{
+	emailCompatibleTypes = []transformers.SupportedDataType{
 		transformers.StringDataType,
 	}
 )
@@ -142,9 +142,16 @@ func NewEmailTransformer(params transformers.ParameterValues) (*EmailTransformer
 }
 
 func (t *EmailTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return EmailCompatibleTypes
+	return emailCompatibleTypes
 }
 
 func (t *EmailTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncEmail
+}
+
+func EmailTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: emailCompatibleTypes,
+		Parameters:     emailParams,
+	}
 }

--- a/pkg/transformers/neosync/neosync_email_transformer.go
+++ b/pkg/transformers/neosync/neosync_email_transformer.go
@@ -31,22 +31,63 @@ var (
 		neosynctransformers.InvalidEmailAction_Generate.String(),
 	}
 
-	emailTransformerParams = []string{
-		"preserve_length",
-		"preserve_domain",
-		"excluded_domains",
-		"max_length",
-		"seed",
-		"email_type",
-		"invalid_email_action",
+	EmailParams = []transformers.TransformerParameter{
+		{
+			Name:          "seed",
+			SupportedType: "int",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "preserve_length",
+			SupportedType: "boolean",
+			Default:       false,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "max_length",
+			SupportedType: "int",
+			Default:       100,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "preserve_domain",
+			SupportedType: "boolean",
+			Default:       false,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "excluded_domains",
+			SupportedType: "array",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "email_type",
+			SupportedType: "string",
+			Default:       "uuidv4",
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "invalid_email_action",
+			SupportedType: "string",
+			Default:       "reject",
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+	EmailCompatibleTypes = []transformers.SupportedDataType{
+		transformers.StringDataType,
 	}
 )
 
 func NewEmailTransformer(params transformers.Parameters) (*EmailTransformer, error) {
-	if err := transformers.ValidateParameters(params, emailTransformerParams); err != nil {
-		return nil, err
-	}
-
 	preserveLength, err := findParameter[bool](params, "preserve_length")
 	if err != nil {
 		return nil, fmt.Errorf("neosync_email: preserve_length must be a boolean: %w", err)
@@ -99,9 +140,7 @@ func NewEmailTransformer(params transformers.Parameters) (*EmailTransformer, err
 }
 
 func (t *EmailTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.StringDataType,
-	}
+	return EmailCompatibleTypes
 }
 
 func (t *EmailTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/neosync/neosync_email_transformer_test.go
+++ b/pkg/transformers/neosync/neosync_email_transformer_test.go
@@ -15,17 +15,17 @@ func TestNewEmailTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
-		params  transformers.Parameters
+		params  transformers.ParameterValues
 		wantErr error
 	}{
 		{
 			name:    "ok - valid default parameters",
-			params:  transformers.Parameters{},
+			params:  transformers.ParameterValues{},
 			wantErr: nil,
 		},
 		{
 			name: "ok - valid custom parameters",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"email_type":           "fullname",
 				"invalid_email_action": "generate",
 				"excluded_domains":     []string{"example.com", "example.org"},
@@ -38,63 +38,63 @@ func TestNewEmailTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid preserve_length",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"preserve_length": 1,
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
 			name: "error - invalid preserve_domain",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"preserve_domain": 1,
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
 			name: "error - invalid max_length",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"max_length": "1",
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
 			name: "error - invalid seed",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"seed": "1",
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
 			name: "error - invalid excluded_domains, []any",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"excluded_domains": []any{"example.com", 3},
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
 			name: "error - invalid email_type",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"email_type": 1,
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
 			name: "error - invalid email_type value",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"email_type": "invalid",
 			},
 			wantErr: errInvalidEmailType,
 		},
 		{
 			name: "error - invalid invalid_email_action",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"invalid_email_action": 1,
 			},
 			wantErr: transformers.ErrInvalidParameters,
 		},
 		{
 			name: "error - invalid invalid_email_action value",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"invalid_email_action": "invalid",
 			},
 			wantErr: errInvalidInvalidEmailAction,
@@ -174,7 +174,7 @@ func TestEmailTransformer_Transform(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			params := transformers.Parameters{
+			params := transformers.ParameterValues{
 				"email_type":           tc.emailType,
 				"invalid_email_action": tc.invalidEmailAction,
 				"excluded_domains":     tc.excludedDomains,

--- a/pkg/transformers/neosync/neosync_firstname_transformer.go
+++ b/pkg/transformers/neosync/neosync_firstname_transformer.go
@@ -14,7 +14,7 @@ type FirstNameTransformer struct {
 }
 
 var (
-	FirstNameParams = []transformers.Parameter{
+	firstNameParams = []transformers.Parameter{
 		{
 			Name:          "seed",
 			SupportedType: "int",
@@ -37,7 +37,7 @@ var (
 			Required:      false,
 		},
 	}
-	FirstNameCompatibleTypes = []transformers.SupportedDataType{
+	firstNameCompatibleTypes = []transformers.SupportedDataType{
 		transformers.StringDataType,
 	}
 )
@@ -69,9 +69,16 @@ func NewFirstNameTransformer(params transformers.ParameterValues) (*FirstNameTra
 }
 
 func (t *FirstNameTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return FirstNameCompatibleTypes
+	return firstNameCompatibleTypes
 }
 
 func (t *FirstNameTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncFirstName
+}
+
+func FirstNameTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: firstNameCompatibleTypes,
+		Parameters:     firstNameParams,
+	}
 }

--- a/pkg/transformers/neosync/neosync_firstname_transformer.go
+++ b/pkg/transformers/neosync/neosync_firstname_transformer.go
@@ -13,13 +13,36 @@ type FirstNameTransformer struct {
 	*transformer[string]
 }
 
-var firstNameTransformerParams = []string{"preserve_length", "max_length", "seed"}
+var (
+	FirstNameParams = []transformers.TransformerParameter{
+		{
+			Name:          "seed",
+			SupportedType: "int",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "preserve_length",
+			SupportedType: "boolean",
+			Default:       false,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "max_length",
+			SupportedType: "int",
+			Default:       100,
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+	FirstNameCompatibleTypes = []transformers.SupportedDataType{
+		transformers.StringDataType,
+	}
+)
 
 func NewFirstNameTransformer(params transformers.Parameters) (*FirstNameTransformer, error) {
-	if err := transformers.ValidateParameters(params, firstNameTransformerParams); err != nil {
-		return nil, err
-	}
-
 	preserveLength, err := findParameter[bool](params, "preserve_length")
 	if err != nil {
 		return nil, fmt.Errorf("neosync_firstname: preserve_length must be a boolean: %w", err)
@@ -46,9 +69,7 @@ func NewFirstNameTransformer(params transformers.Parameters) (*FirstNameTransfor
 }
 
 func (t *FirstNameTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.StringDataType,
-	}
+	return FirstNameCompatibleTypes
 }
 
 func (t *FirstNameTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/neosync/neosync_firstname_transformer.go
+++ b/pkg/transformers/neosync/neosync_firstname_transformer.go
@@ -14,7 +14,7 @@ type FirstNameTransformer struct {
 }
 
 var (
-	FirstNameParams = []transformers.TransformerParameter{
+	FirstNameParams = []transformers.Parameter{
 		{
 			Name:          "seed",
 			SupportedType: "int",
@@ -42,7 +42,7 @@ var (
 	}
 )
 
-func NewFirstNameTransformer(params transformers.Parameters) (*FirstNameTransformer, error) {
+func NewFirstNameTransformer(params transformers.ParameterValues) (*FirstNameTransformer, error) {
 	preserveLength, err := findParameter[bool](params, "preserve_length")
 	if err != nil {
 		return nil, fmt.Errorf("neosync_firstname: preserve_length must be a boolean: %w", err)

--- a/pkg/transformers/neosync/neosync_firstname_transformer_test.go
+++ b/pkg/transformers/neosync/neosync_firstname_transformer_test.go
@@ -16,7 +16,7 @@ func TestFirstnameTransformer_Transform(t *testing.T) {
 	tests := []struct {
 		name   string
 		value  any
-		params transformers.Parameters
+		params transformers.ParameterValues
 
 		wantName string
 		wantErr  error

--- a/pkg/transformers/neosync/neosync_fullname_transformer.go
+++ b/pkg/transformers/neosync/neosync_fullname_transformer.go
@@ -14,7 +14,7 @@ type FullNameTransformer struct {
 }
 
 var (
-	FullNameParams = []transformers.TransformerParameter{
+	FullNameParams = []transformers.Parameter{
 		{
 			Name:          "seed",
 			SupportedType: "int",
@@ -42,7 +42,7 @@ var (
 	}
 )
 
-func NewFullNameTransformer(params transformers.Parameters) (*FullNameTransformer, error) {
+func NewFullNameTransformer(params transformers.ParameterValues) (*FullNameTransformer, error) {
 	preserveLength, err := findParameter[bool](params, "preserve_length")
 	if err != nil {
 		return nil, fmt.Errorf("neosync_fullname: preserve_length must be a boolean: %w", err)

--- a/pkg/transformers/neosync/neosync_fullname_transformer.go
+++ b/pkg/transformers/neosync/neosync_fullname_transformer.go
@@ -14,7 +14,7 @@ type FullNameTransformer struct {
 }
 
 var (
-	FullNameParams = []transformers.Parameter{
+	fullNameParams = []transformers.Parameter{
 		{
 			Name:          "seed",
 			SupportedType: "int",
@@ -37,7 +37,7 @@ var (
 			Required:      false,
 		},
 	}
-	FullNameCompatibleTypes = []transformers.SupportedDataType{
+	fullNameCompatibleTypes = []transformers.SupportedDataType{
 		transformers.StringDataType,
 	}
 )
@@ -69,9 +69,16 @@ func NewFullNameTransformer(params transformers.ParameterValues) (*FullNameTrans
 }
 
 func (t *FullNameTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return FullNameCompatibleTypes
+	return fullNameCompatibleTypes
 }
 
 func (t *FullNameTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncFullName
+}
+
+func FullNameTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: fullNameCompatibleTypes,
+		Parameters:     fullNameParams,
+	}
 }

--- a/pkg/transformers/neosync/neosync_fullname_transformer.go
+++ b/pkg/transformers/neosync/neosync_fullname_transformer.go
@@ -13,13 +13,36 @@ type FullNameTransformer struct {
 	*transformer[string]
 }
 
-var fullNameTransformerParams = []string{"preserve_length", "max_length", "seed"}
+var (
+	FullNameParams = []transformers.TransformerParameter{
+		{
+			Name:          "seed",
+			SupportedType: "int",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "preserve_length",
+			SupportedType: "boolean",
+			Default:       false,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "max_length",
+			SupportedType: "int",
+			Default:       100,
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+	FullNameCompatibleTypes = []transformers.SupportedDataType{
+		transformers.StringDataType,
+	}
+)
 
 func NewFullNameTransformer(params transformers.Parameters) (*FullNameTransformer, error) {
-	if err := transformers.ValidateParameters(params, fullNameTransformerParams); err != nil {
-		return nil, err
-	}
-
 	preserveLength, err := findParameter[bool](params, "preserve_length")
 	if err != nil {
 		return nil, fmt.Errorf("neosync_fullname: preserve_length must be a boolean: %w", err)
@@ -46,9 +69,7 @@ func NewFullNameTransformer(params transformers.Parameters) (*FullNameTransforme
 }
 
 func (t *FullNameTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.StringDataType,
-	}
+	return FullNameCompatibleTypes
 }
 
 func (t *FullNameTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/neosync/neosync_fullname_transformer_test.go
+++ b/pkg/transformers/neosync/neosync_fullname_transformer_test.go
@@ -14,14 +14,14 @@ func TestNewFullnameTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name     string
-		params   transformers.Parameters
+		params   transformers.ParameterValues
 		input    any
 		wantErr  error
 		wantName string
 	}{
 		{
 			name: "ok - valid",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"preserve_length": false,
 				"max_length":      20,
 				"seed":            1234,
@@ -32,7 +32,7 @@ func TestNewFullnameTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid preserve_length",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"preserve_length": 123,
 				"max_length":      10,
 				"seed":            123,
@@ -41,7 +41,7 @@ func TestNewFullnameTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid max_length",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"preserve_length": true,
 				"max_length":      "invalid",
 				"seed":            123,
@@ -50,7 +50,7 @@ func TestNewFullnameTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid seed",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"preserve_length": true,
 				"max_length":      10,
 				"seed":            "invalid",

--- a/pkg/transformers/neosync/neosync_lastname_transformer.go
+++ b/pkg/transformers/neosync/neosync_lastname_transformer.go
@@ -14,7 +14,7 @@ type LastNameTransformer struct {
 }
 
 var (
-	LastNameParams = []transformers.TransformerParameter{
+	LastNameParams = []transformers.Parameter{
 		{
 			Name:          "seed",
 			SupportedType: "int",
@@ -42,7 +42,7 @@ var (
 	}
 )
 
-func NewLastNameTransformer(params transformers.Parameters) (*LastNameTransformer, error) {
+func NewLastNameTransformer(params transformers.ParameterValues) (*LastNameTransformer, error) {
 	preserveLength, err := findParameter[bool](params, "preserve_length")
 	if err != nil {
 		return nil, fmt.Errorf("neosync_lastname: preserve_length must be a boolean: %w", err)

--- a/pkg/transformers/neosync/neosync_lastname_transformer.go
+++ b/pkg/transformers/neosync/neosync_lastname_transformer.go
@@ -13,13 +13,36 @@ type LastNameTransformer struct {
 	*transformer[string]
 }
 
-var lastNameTransformerParams = []string{"preserve_length", "max_length", "seed"}
+var (
+	LastNameParams = []transformers.TransformerParameter{
+		{
+			Name:          "seed",
+			SupportedType: "int",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "preserve_length",
+			SupportedType: "boolean",
+			Default:       false,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "max_length",
+			SupportedType: "int",
+			Default:       100,
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+	LastNameCompatibleTypes = []transformers.SupportedDataType{
+		transformers.StringDataType,
+	}
+)
 
 func NewLastNameTransformer(params transformers.Parameters) (*LastNameTransformer, error) {
-	if err := transformers.ValidateParameters(params, lastNameTransformerParams); err != nil {
-		return nil, err
-	}
-
 	preserveLength, err := findParameter[bool](params, "preserve_length")
 	if err != nil {
 		return nil, fmt.Errorf("neosync_lastname: preserve_length must be a boolean: %w", err)
@@ -46,9 +69,7 @@ func NewLastNameTransformer(params transformers.Parameters) (*LastNameTransforme
 }
 
 func (t *LastNameTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.StringDataType,
-	}
+	return LastNameCompatibleTypes
 }
 
 func (t *LastNameTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/neosync/neosync_lastname_transformer.go
+++ b/pkg/transformers/neosync/neosync_lastname_transformer.go
@@ -14,7 +14,7 @@ type LastNameTransformer struct {
 }
 
 var (
-	LastNameParams = []transformers.Parameter{
+	lastNameParams = []transformers.Parameter{
 		{
 			Name:          "seed",
 			SupportedType: "int",
@@ -37,7 +37,7 @@ var (
 			Required:      false,
 		},
 	}
-	LastNameCompatibleTypes = []transformers.SupportedDataType{
+	lastNameCompatibleTypes = []transformers.SupportedDataType{
 		transformers.StringDataType,
 	}
 )
@@ -69,9 +69,16 @@ func NewLastNameTransformer(params transformers.ParameterValues) (*LastNameTrans
 }
 
 func (t *LastNameTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return LastNameCompatibleTypes
+	return lastNameCompatibleTypes
 }
 
 func (t *LastNameTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncLastName
+}
+
+func LastNameTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: lastNameCompatibleTypes,
+		Parameters:     lastNameParams,
+	}
 }

--- a/pkg/transformers/neosync/neosync_lastname_transformer_test.go
+++ b/pkg/transformers/neosync/neosync_lastname_transformer_test.go
@@ -14,14 +14,14 @@ func TestNewLastnameTransformer(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name     string
-		params   transformers.Parameters
+		params   transformers.ParameterValues
 		input    any
 		wantErr  error
 		wantName string
 	}{
 		{
 			name: "ok - valid",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"preserve_length": false,
 				"max_length":      10,
 				"seed":            123,
@@ -32,7 +32,7 @@ func TestNewLastnameTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid preserve_length",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"preserve_length": 123,
 				"max_length":      10,
 				"seed":            123,
@@ -41,7 +41,7 @@ func TestNewLastnameTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid max_length",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"preserve_length": true,
 				"max_length":      "invalid",
 				"seed":            123,
@@ -50,7 +50,7 @@ func TestNewLastnameTransformer(t *testing.T) {
 		},
 		{
 			name: "error - invalid seed",
-			params: transformers.Parameters{
+			params: transformers.ParameterValues{
 				"preserve_length": true,
 				"max_length":      10,
 				"seed":            "invalid",

--- a/pkg/transformers/neosync/neosync_string_transformer.go
+++ b/pkg/transformers/neosync/neosync_string_transformer.go
@@ -14,7 +14,7 @@ type StringTransformer struct {
 }
 
 var (
-	StringParams = []transformers.TransformerParameter{
+	StringParams = []transformers.Parameter{
 		{
 			Name:          "seed",
 			SupportedType: "int",
@@ -49,7 +49,7 @@ var (
 	}
 )
 
-func NewStringTransformer(params transformers.Parameters) (*StringTransformer, error) {
+func NewStringTransformer(params transformers.ParameterValues) (*StringTransformer, error) {
 	preserveLength, err := findParameter[bool](params, "preserve_length")
 	if err != nil {
 		return nil, fmt.Errorf("neosync_string: preserve_length must be a boolean: %w", err)

--- a/pkg/transformers/neosync/neosync_string_transformer.go
+++ b/pkg/transformers/neosync/neosync_string_transformer.go
@@ -13,13 +13,43 @@ type StringTransformer struct {
 	*transformer[string]
 }
 
-var stringTransformerParams = []string{"preserve_length", "min_length", "max_length", "seed"}
+var (
+	StringParams = []transformers.TransformerParameter{
+		{
+			Name:          "seed",
+			SupportedType: "int",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "preserve_length",
+			SupportedType: "boolean",
+			Default:       false,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "min_length",
+			SupportedType: "int",
+			Default:       1,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "max_length",
+			SupportedType: "int",
+			Default:       100,
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+	StringCompatibleTypes = []transformers.SupportedDataType{
+		transformers.StringDataType,
+	}
+)
 
 func NewStringTransformer(params transformers.Parameters) (*StringTransformer, error) {
-	if err := transformers.ValidateParameters(params, stringTransformerParams); err != nil {
-		return nil, err
-	}
-
 	preserveLength, err := findParameter[bool](params, "preserve_length")
 	if err != nil {
 		return nil, fmt.Errorf("neosync_string: preserve_length must be a boolean: %w", err)
@@ -51,9 +81,7 @@ func NewStringTransformer(params transformers.Parameters) (*StringTransformer, e
 }
 
 func (t *StringTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return []transformers.SupportedDataType{
-		transformers.StringDataType,
-	}
+	return StringCompatibleTypes
 }
 
 func (t *StringTransformer) Type() transformers.TransformerType {

--- a/pkg/transformers/neosync/neosync_string_transformer.go
+++ b/pkg/transformers/neosync/neosync_string_transformer.go
@@ -14,7 +14,7 @@ type StringTransformer struct {
 }
 
 var (
-	StringParams = []transformers.Parameter{
+	stringParams = []transformers.Parameter{
 		{
 			Name:          "seed",
 			SupportedType: "int",
@@ -44,7 +44,7 @@ var (
 			Required:      false,
 		},
 	}
-	StringCompatibleTypes = []transformers.SupportedDataType{
+	stringCompatibleTypes = []transformers.SupportedDataType{
 		transformers.StringDataType,
 	}
 )
@@ -81,9 +81,16 @@ func NewStringTransformer(params transformers.ParameterValues) (*StringTransform
 }
 
 func (t *StringTransformer) CompatibleTypes() []transformers.SupportedDataType {
-	return StringCompatibleTypes
+	return stringCompatibleTypes
 }
 
 func (t *StringTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncString
+}
+
+func StringTransformerDefinition() *transformers.Definition {
+	return &transformers.Definition{
+		SupportedTypes: stringCompatibleTypes,
+		Parameters:     stringParams,
+	}
 }

--- a/pkg/transformers/neosync/neosync_string_transformer_test.go
+++ b/pkg/transformers/neosync/neosync_string_transformer_test.go
@@ -16,7 +16,7 @@ func TestStringTransformer_Transform(t *testing.T) {
 	tests := []struct {
 		name   string
 		value  any
-		params transformers.Parameters
+		params transformers.ParameterValues
 
 		wantString string
 		wantErr    error

--- a/pkg/transformers/neosync/neosync_transformer.go
+++ b/pkg/transformers/neosync/neosync_transformer.go
@@ -40,7 +40,7 @@ func (t *transformer[T]) Transform(_ context.Context, value transformers.Value) 
 	return *ret, nil
 }
 
-func findParameter[T any](params transformers.Parameters, name string) (*T, error) {
+func findParameter[T any](params transformers.ParameterValues, name string) (*T, error) {
 	var found bool
 	var err error
 
@@ -55,7 +55,7 @@ func findParameter[T any](params transformers.Parameters, name string) (*T, erro
 	return val, nil
 }
 
-func findParameterArray[T any](params transformers.Parameters, name string) ([]T, error) {
+func findParameterArray[T any](params transformers.ParameterValues, name string) ([]T, error) {
 	val, found, err := transformers.FindParameterArray[T](params, name)
 	if err != nil {
 		return val, err

--- a/pkg/transformers/phone_number_transformer.go
+++ b/pkg/transformers/phone_number_transformer.go
@@ -23,7 +23,7 @@ var (
 		ByteArrayDataType,
 	}
 
-	PhoneNumberParams = []TransformerParameter{
+	PhoneNumberParams = []Parameter{
 		{
 			Name:          "prefix",
 			SupportedType: "string",
@@ -58,7 +58,7 @@ var (
 
 const prefixParam = "prefix"
 
-func NewPhoneNumberTransformer(params, dynamicParams Parameters) (*PhoneNumberTransformer, error) {
+func NewPhoneNumberTransformer(params, dynamicParams ParameterValues) (*PhoneNumberTransformer, error) {
 	prefix, err := FindParameterWithDefault(params, "prefix", "")
 	if err != nil {
 		return nil, fmt.Errorf("phone_number: prefix must be a string: %w", err)

--- a/pkg/transformers/phone_number_transformer.go
+++ b/pkg/transformers/phone_number_transformer.go
@@ -51,6 +51,7 @@ var (
 			Default:       "random",
 			Dynamic:       false,
 			Required:      false,
+			Values:        []any{"random", "deterministic"},
 		},
 	}
 )

--- a/pkg/transformers/phone_number_transformer.go
+++ b/pkg/transformers/phone_number_transformer.go
@@ -17,15 +17,47 @@ type PhoneNumberTransformer struct {
 	dynamicParams map[string]*DynamicParameter
 }
 
-var phoneNumberTransformerParams = []string{"prefix", "max_length", "min_length", "generator"}
+var (
+	PhoneNumberCompatibleTypes = []SupportedDataType{
+		StringDataType,
+		ByteArrayDataType,
+	}
+
+	PhoneNumberParams = []TransformerParameter{
+		{
+			Name:          "prefix",
+			SupportedType: "string",
+			Default:       "",
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "min_length",
+			SupportedType: "int",
+			Default:       6,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "max_length",
+			SupportedType: "int",
+			Default:       10,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "generator",
+			SupportedType: "string",
+			Default:       "random",
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+)
 
 const prefixParam = "prefix"
 
 func NewPhoneNumberTransformer(params, dynamicParams Parameters) (*PhoneNumberTransformer, error) {
-	if err := ValidateParameters(params, phoneNumberTransformerParams); err != nil {
-		return nil, err
-	}
-
 	prefix, err := FindParameterWithDefault(params, "prefix", "")
 	if err != nil {
 		return nil, fmt.Errorf("phone_number: prefix must be a string: %w", err)
@@ -135,10 +167,7 @@ func (t *PhoneNumberTransformer) transform(value []byte, dynamicValues map[strin
 }
 
 func (t *PhoneNumberTransformer) CompatibleTypes() []SupportedDataType {
-	return []SupportedDataType{
-		StringDataType,
-		ByteArrayDataType,
-	}
+	return PhoneNumberCompatibleTypes
 }
 
 func (t *PhoneNumberTransformer) Type() TransformerType {

--- a/pkg/transformers/phone_number_transformer.go
+++ b/pkg/transformers/phone_number_transformer.go
@@ -18,12 +18,12 @@ type PhoneNumberTransformer struct {
 }
 
 var (
-	PhoneNumberCompatibleTypes = []SupportedDataType{
+	phoneNumberCompatibleTypes = []SupportedDataType{
 		StringDataType,
 		ByteArrayDataType,
 	}
 
-	PhoneNumberParams = []Parameter{
+	phoneNumberParams = []Parameter{
 		{
 			Name:          "prefix",
 			SupportedType: "string",
@@ -168,9 +168,16 @@ func (t *PhoneNumberTransformer) transform(value []byte, dynamicValues map[strin
 }
 
 func (t *PhoneNumberTransformer) CompatibleTypes() []SupportedDataType {
-	return PhoneNumberCompatibleTypes
+	return phoneNumberCompatibleTypes
 }
 
 func (t *PhoneNumberTransformer) Type() TransformerType {
 	return PhoneNumber
+}
+
+func PhoneNumberTransformerDefinition() *Definition {
+	return &Definition{
+		SupportedTypes: phoneNumberCompatibleTypes,
+		Parameters:     phoneNumberParams,
+	}
 }

--- a/pkg/transformers/phone_number_transformer_test.go
+++ b/pkg/transformers/phone_number_transformer_test.go
@@ -14,8 +14,8 @@ func TestPhoneNumberTransformer_Transform(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		params        Parameters
-		dynamicParams Parameters
+		params        ParameterValues
+		dynamicParams ParameterValues
 		dynamicValues map[string]any
 		value         any
 		wantPrefix    string
@@ -24,7 +24,7 @@ func TestPhoneNumberTransformer_Transform(t *testing.T) {
 	}{
 		{
 			name: "ok - string with prefix",
-			params: Parameters{
+			params: ParameterValues{
 				"prefix":     "(030) ",
 				"min_length": 10,
 				"max_length": 10,
@@ -36,7 +36,7 @@ func TestPhoneNumberTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - []byte without prefix",
-			params: Parameters{
+			params: ParameterValues{
 				"min_length": 6,
 				"max_length": 6,
 			},
@@ -47,7 +47,7 @@ func TestPhoneNumberTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - []byte without prefix, deterministic generator",
-			params: Parameters{
+			params: ParameterValues{
 				"min_length": 6,
 				"max_length": 6,
 				"generator":  "deterministic",
@@ -59,7 +59,7 @@ func TestPhoneNumberTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "ok - with dynamic country code",
-			params: Parameters{
+			params: ParameterValues{
 				"min_length": 12,
 				"max_length": 12,
 			},
@@ -78,7 +78,7 @@ func TestPhoneNumberTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "error - prefix longer than min_length",
-			params: Parameters{
+			params: ParameterValues{
 				"prefix":     "12345678",
 				"min_length": 6,
 				"max_length": 10,
@@ -88,7 +88,7 @@ func TestPhoneNumberTransformer_Transform(t *testing.T) {
 		},
 		{
 			name: "error - max_length less than min_length",
-			params: Parameters{
+			params: ParameterValues{
 				"min_length": 10,
 				"max_length": 8,
 			},

--- a/pkg/transformers/string_transformer.go
+++ b/pkg/transformers/string_transformer.go
@@ -15,12 +15,15 @@ type StringTransformer struct {
 	// minLength int
 }
 
-var stringTransformerParams = []string{}
+var (
+	StringParams          = []TransformerParameter{}
+	StringCompatibleTypes = []SupportedDataType{
+		StringDataType,
+		ByteArrayDataType,
+	}
+)
 
 func NewStringTransformer(params Parameters) (*StringTransformer, error) {
-	if err := ValidateParameters(params, stringTransformerParams); err != nil {
-		return nil, err
-	}
 	return &StringTransformer{}, nil
 }
 
@@ -46,10 +49,7 @@ func (st *StringTransformer) transform(str string) string {
 }
 
 func (st *StringTransformer) CompatibleTypes() []SupportedDataType {
-	return []SupportedDataType{
-		StringDataType,
-		ByteArrayDataType,
-	}
+	return StringCompatibleTypes
 }
 
 func (st *StringTransformer) Type() TransformerType {

--- a/pkg/transformers/string_transformer.go
+++ b/pkg/transformers/string_transformer.go
@@ -16,14 +16,14 @@ type StringTransformer struct {
 }
 
 var (
-	StringParams          = []TransformerParameter{}
+	StringParams          = []Parameter{}
 	StringCompatibleTypes = []SupportedDataType{
 		StringDataType,
 		ByteArrayDataType,
 	}
 )
 
-func NewStringTransformer(params Parameters) (*StringTransformer, error) {
+func NewStringTransformer(params ParameterValues) (*StringTransformer, error) {
 	return &StringTransformer{}, nil
 }
 

--- a/pkg/transformers/string_transformer.go
+++ b/pkg/transformers/string_transformer.go
@@ -16,8 +16,8 @@ type StringTransformer struct {
 }
 
 var (
-	StringParams          = []Parameter{}
-	StringCompatibleTypes = []SupportedDataType{
+	stringParams          = []Parameter{}
+	stringCompatibleTypes = []SupportedDataType{
 		StringDataType,
 		ByteArrayDataType,
 	}
@@ -49,9 +49,16 @@ func (st *StringTransformer) transform(str string) string {
 }
 
 func (st *StringTransformer) CompatibleTypes() []SupportedDataType {
-	return StringCompatibleTypes
+	return stringCompatibleTypes
 }
 
 func (st *StringTransformer) Type() TransformerType {
 	return String
+}
+
+func StringTransformerDefinition() *Definition {
+	return &Definition{
+		SupportedTypes: stringCompatibleTypes,
+		Parameters:     stringParams,
+	}
 }

--- a/pkg/transformers/template_transformer.go
+++ b/pkg/transformers/template_transformer.go
@@ -23,7 +23,7 @@ var (
 		StringDataType,
 		ByteArrayDataType,
 	}
-	TemplateParams = []TransformerParameter{
+	TemplateParams = []Parameter{
 		{
 			Name:          "template",
 			SupportedType: "string",
@@ -34,7 +34,7 @@ var (
 	}
 )
 
-func NewTemplateTransformer(params Parameters) (*TemplateTransformer, error) {
+func NewTemplateTransformer(params ParameterValues) (*TemplateTransformer, error) {
 	templateStr, found, err := FindParameter[string](params, "template")
 	if err != nil {
 		return nil, fmt.Errorf("template_transformer: template must be a string: %w", err)

--- a/pkg/transformers/template_transformer.go
+++ b/pkg/transformers/template_transformer.go
@@ -19,11 +19,11 @@ type TemplateTransformer struct {
 
 var (
 	errTemplateMustBeProvided = errors.New("template_transformer: template parameter must be provided")
-	TemplateCompatibleTypes   = []SupportedDataType{
+	templateCompatibleTypes   = []SupportedDataType{
 		StringDataType,
 		ByteArrayDataType,
 	}
-	TemplateParams = []Parameter{
+	templateParams = []Parameter{
 		{
 			Name:          "template",
 			SupportedType: "string",
@@ -59,9 +59,16 @@ func (t *TemplateTransformer) Transform(_ context.Context, value Value) (any, er
 }
 
 func (t *TemplateTransformer) CompatibleTypes() []SupportedDataType {
-	return TemplateCompatibleTypes
+	return templateCompatibleTypes
 }
 
 func (t *TemplateTransformer) Type() TransformerType {
 	return Template
+}
+
+func TemplateTransformerDefinition() *Definition {
+	return &Definition{
+		SupportedTypes: templateCompatibleTypes,
+		Parameters:     templateParams,
+	}
 }

--- a/pkg/transformers/template_transformer.go
+++ b/pkg/transformers/template_transformer.go
@@ -18,14 +18,23 @@ type TemplateTransformer struct {
 }
 
 var (
-	templateTransformerParams = []string{"template"}
 	errTemplateMustBeProvided = errors.New("template_transformer: template parameter must be provided")
+	TemplateCompatibleTypes   = []SupportedDataType{
+		StringDataType,
+		ByteArrayDataType,
+	}
+	TemplateParams = []TransformerParameter{
+		{
+			Name:          "template",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      true,
+		},
+	}
 )
 
 func NewTemplateTransformer(params Parameters) (*TemplateTransformer, error) {
-	if err := ValidateParameters(params, templateTransformerParams); err != nil {
-		return nil, err
-	}
 	templateStr, found, err := FindParameter[string](params, "template")
 	if err != nil {
 		return nil, fmt.Errorf("template_transformer: template must be a string: %w", err)
@@ -50,9 +59,7 @@ func (t *TemplateTransformer) Transform(_ context.Context, value Value) (any, er
 }
 
 func (t *TemplateTransformer) CompatibleTypes() []SupportedDataType {
-	return []SupportedDataType{
-		AllDataTypes,
-	}
+	return TemplateCompatibleTypes
 }
 
 func (t *TemplateTransformer) Type() TransformerType {

--- a/pkg/transformers/template_transformer_test.go
+++ b/pkg/transformers/template_transformer_test.go
@@ -26,14 +26,6 @@ func TestNewTemplateTransformer(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "error - invalid parameter",
-			params: Parameters{
-				"template": "{{- if eq .GetValue \"hello\" -}} first {{- else -}} second {{- end -}}",
-				"invalid":  "invalid",
-			},
-			wantErr: ErrUnknownParameter,
-		},
-		{
 			name:    "error - template not provided",
 			params:  Parameters{},
 			wantErr: errTemplateMustBeProvided,

--- a/pkg/transformers/template_transformer_test.go
+++ b/pkg/transformers/template_transformer_test.go
@@ -15,24 +15,24 @@ func TestNewTemplateTransformer(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		params  Parameters
+		params  ParameterValues
 		wantErr error
 	}{
 		{
 			name: "ok - template",
-			params: Parameters{
+			params: ParameterValues{
 				"template": "{{- if eq .GetValue \"hello\" -}} first {{- else -}} second {{- end -}}",
 			},
 			wantErr: nil,
 		},
 		{
 			name:    "error - template not provided",
-			params:  Parameters{},
+			params:  ParameterValues{},
 			wantErr: errTemplateMustBeProvided,
 		},
 		{
 			name: "error - template cannot be parsed",
-			params: Parameters{
+			params: ParameterValues{
 				"template": "{{- if eq syntaxerror",
 			},
 			wantErr: errors.New("template_transformer: error parsing template"),
@@ -63,7 +63,7 @@ func TestTemplateTransformer_Transform(t *testing.T) {
 	tests := []struct {
 		name   string
 		value  any
-		params Parameters
+		params ParameterValues
 
 		wantOutput string
 		wantErr    error
@@ -71,7 +71,7 @@ func TestTemplateTransformer_Transform(t *testing.T) {
 		{
 			name:  "ok - basic template",
 			value: "hello",
-			params: Parameters{
+			params: ParameterValues{
 				"template": "hello world",
 			},
 			wantOutput: "hello world",
@@ -80,7 +80,7 @@ func TestTemplateTransformer_Transform(t *testing.T) {
 		{
 			name:  "ok - GetValue with if statement",
 			value: "hello",
-			params: Parameters{
+			params: ParameterValues{
 				"template": "{{- if eq .GetValue \"hello\" -}} first {{- else -}} second {{- end -}}",
 			},
 
@@ -90,7 +90,7 @@ func TestTemplateTransformer_Transform(t *testing.T) {
 		{
 			name:  "ok - GetValue with if statement - else",
 			value: "world",
-			params: Parameters{
+			params: ParameterValues{
 				"template": "{{- if eq .GetValue \"hello\" -}} first {{- else -}} second {{- end -}}",
 			},
 
@@ -100,7 +100,7 @@ func TestTemplateTransformer_Transform(t *testing.T) {
 		{
 			name:  "incompatible types for comparison",
 			value: 1,
-			params: Parameters{
+			params: ParameterValues{
 				"template": "{{- if eq .GetValue \"hello\" -}} first {{- else -}} second {{- end -}}",
 			},
 			wantOutput: "",
@@ -136,7 +136,7 @@ func TestTemplateTransformer_Transform_WithDynamicValues(t *testing.T) {
 		name          string
 		value         any
 		dynamicValues map[string]any
-		params        Parameters
+		params        ParameterValues
 		wantOutput    string
 		wantErr       error
 	}{
@@ -147,7 +147,7 @@ func TestTemplateTransformer_Transform_WithDynamicValues(t *testing.T) {
 				"value1": "first",
 				"value2": "second",
 			},
-			params: Parameters{
+			params: ParameterValues{
 				"template": "{{- if eq .GetValue \"hello\" -}} {{.GetDynamicValue \"value1\" }} {{- else -}} {{.GetDynamicValue \"value2\" }} {{- end -}}",
 			},
 			wantOutput: "first",
@@ -160,7 +160,7 @@ func TestTemplateTransformer_Transform_WithDynamicValues(t *testing.T) {
 				"value1": "first",
 				"value2": "second",
 			},
-			params: Parameters{
+			params: ParameterValues{
 				"template": "{{- if eq .GetValue \"hello\" -}} {{.GetDynamicValue \"value1\" }} {{- else -}} {{.GetDynamicValue \"value2\" }} {{- end -}}",
 			},
 			wantOutput: "second",
@@ -170,7 +170,7 @@ func TestTemplateTransformer_Transform_WithDynamicValues(t *testing.T) {
 			name:          "error - no dynamic values",
 			value:         "hello",
 			dynamicValues: nil,
-			params: Parameters{
+			params: ParameterValues{
 				"template": "{{- if eq .GetValue \"hello\" -}} {{.GetDynamicValue \"value1\" }} {{- else -}} {{.GetDynamicValue \"value2\" }} {{- end -}}",
 			},
 			wantOutput: "",
@@ -182,7 +182,7 @@ func TestTemplateTransformer_Transform_WithDynamicValues(t *testing.T) {
 			dynamicValues: map[string]any{
 				"value1": "first",
 			},
-			params: Parameters{
+			params: ParameterValues{
 				"template": "{{- if eq .GetValue \"hello\" -}} {{.GetDynamicValue \"value1\" }} {{- else -}} {{.GetDynamicValue \"value2\" }} {{- end -}}",
 			},
 			wantOutput: "",
@@ -220,7 +220,7 @@ func TestTemplateTransformer_Transform_WithGreenmaskToolkitFuncs(t *testing.T) {
 		name          string
 		value         any
 		dynamicValues map[string]any
-		params        Parameters
+		params        ParameterValues
 		wantOutput    string
 		wantErr       error
 	}{
@@ -231,7 +231,7 @@ func TestTemplateTransformer_Transform_WithGreenmaskToolkitFuncs(t *testing.T) {
 				"value1": nil,
 				"value2": "john.doe@xata.io",
 			},
-			params: Parameters{
+			params: ParameterValues{
 				"template": "{{ $first := .GetDynamicValue \"value1\" }}{{ $second :=.GetDynamicValue \"value2\" }} {{- if eq $first nil -}} {{ masking .GetValue $second }} {{- else -}} {{ masking .GetValue $first }} {{- end -}}",
 			},
 			wantOutput: "joh****e@xata.io",
@@ -240,7 +240,7 @@ func TestTemplateTransformer_Transform_WithGreenmaskToolkitFuncs(t *testing.T) {
 		{
 			name:  "ok - random integer",
 			value: 3,
-			params: Parameters{
+			params: ParameterValues{
 				"template": "{{ $randval := randomInt 0 .GetValue}} {{- if and (isInt $randval) (ge $randval 0) (lt $randval .GetValue) -}} {{\"yes\"}} {{- else -}} {{\"no\"}} {{- end -}}",
 			},
 			wantOutput: "yes",

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -25,8 +25,8 @@ type DynamicParameter struct {
 
 type Config struct {
 	Name              TransformerType
-	Parameters        Parameters
-	DynamicParameters Parameters
+	Parameters        ParameterValues
+	DynamicParameters ParameterValues
 }
 
 type TransformerType string
@@ -82,7 +82,12 @@ const (
 	columnDynamicParam = "column"
 )
 
-type TransformerParameter struct {
+type Definition struct {
+	SupportedTypes []SupportedDataType
+	Parameters     []Parameter
+}
+
+type Parameter struct {
 	Name          string
 	SupportedType string
 	Default       any
@@ -91,7 +96,7 @@ type TransformerParameter struct {
 	Values        []any
 }
 
-type Parameters map[string]any
+type ParameterValues map[string]any
 
 var (
 	ErrUnsupportedValueType     = errors.New("unsupported value type for transformer")
@@ -109,7 +114,7 @@ func NewValue(transformValue any, dynamicValues map[string]any) Value {
 	}
 }
 
-func FindParameter[T any](params Parameters, name string) (T, bool, error) {
+func FindParameter[T any](params ParameterValues, name string) (T, bool, error) {
 	valAny, found := params[name]
 	if !found {
 		return *new(T), false, nil
@@ -123,7 +128,7 @@ func FindParameter[T any](params Parameters, name string) (T, bool, error) {
 	return val, true, nil
 }
 
-func FindParameterWithDefault[T any](params Parameters, name string, defaultValue T) (T, error) {
+func FindParameterWithDefault[T any](params ParameterValues, name string, defaultValue T) (T, error) {
 	val, found, err := FindParameter[T](params, name)
 	if err != nil {
 		return val, err
@@ -134,7 +139,7 @@ func FindParameterWithDefault[T any](params Parameters, name string, defaultValu
 	return val, nil
 }
 
-func FindParameterArray[T any](params Parameters, name string) ([]T, bool, error) {
+func FindParameterArray[T any](params ParameterValues, name string) ([]T, bool, error) {
 	// first check if the array is of the expected type
 	arrValue, found, err := FindParameter[[]T](params, name)
 	if err == nil {
@@ -159,7 +164,7 @@ func FindParameterArray[T any](params Parameters, name string) ([]T, bool, error
 	return valArray, true, nil
 }
 
-func ParseDynamicParameters(params Parameters) (map[string]*DynamicParameter, error) {
+func ParseDynamicParameters(params ParameterValues) (map[string]*DynamicParameter, error) {
 	dynamicParamMap := make(map[string]*DynamicParameter, len(params))
 	for param, anyVal := range params {
 		if param == "" {

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -82,6 +82,14 @@ const (
 	columnDynamicParam = "column"
 )
 
+type TransformerParameter struct {
+	Name          string
+	SupportedType string
+	Default       any
+	Dynamic       bool
+	Required      bool
+}
+
 type Parameters map[string]any
 
 var (

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -88,6 +88,7 @@ type TransformerParameter struct {
 	Default       any
 	Dynamic       bool
 	Required      bool
+	Values        []any
 }
 
 type Parameters map[string]any

--- a/pkg/transformers/transformer_test.go
+++ b/pkg/transformers/transformer_test.go
@@ -13,7 +13,7 @@ func Test_FindParameter(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		params    Parameters
+		params    ParameterValues
 		paramName string
 
 		wantFound bool
@@ -72,7 +72,7 @@ func Test_FindParameterWithDefault(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		params       Parameters
+		params       ParameterValues
 		paramName    string
 		defaultValue int
 
@@ -130,7 +130,7 @@ func Test_FindParameterArray(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		params    Parameters
+		params    ParameterValues
 		paramName string
 
 		wantFound bool
@@ -211,7 +211,7 @@ func Test_ParseDynamicParameters(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		params  Parameters
+		params  ParameterValues
 		want    map[string]*DynamicParameter
 		wantErr error
 	}{

--- a/tools/transformer-definition/build-transformers-definition.go
+++ b/tools/transformer-definition/build-transformers-definition.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+
+	"github.com/xataio/pgstream/pkg/transformers"
+	"github.com/xataio/pgstream/pkg/transformers/builder"
+)
+
+type Result struct {
+	Name         string        `json:"name"`
+	Transformers []Transformer `json:"transformers"`
+}
+
+type Transformer struct {
+	Name           string      `json:"name"`
+	SupportedTypes []string    `json:"supported_types"`
+	Parameters     []Parameter `json:"parameters"`
+}
+
+type Parameter struct {
+	Name          string `json:"name"`
+	SupportedType string `json:"supported_type"`
+	Default       any    `json:"default"`
+	Dynamic       bool   `json:"dynamic"`
+	Required      bool   `json:"required"`
+}
+
+func main() {
+	log.Println("Generating Transformers JSON schema...")
+
+	result := Result{
+		Name:         "transformers",
+		Transformers: extractTransformers(builder.TransformersMap),
+	}
+
+	if err := writeJSONToFile("transformers-definition.json", result); err != nil {
+		log.Fatalf("failed to write JSON to file: %v", err)
+	}
+
+	log.Println("Transformers JSON schema generated successfully")
+}
+
+func extractTransformers(transformersMap map[transformers.TransformerType]builder.TransformerDefinition) []Transformer {
+	// Sort the keys to ensure consistent ordering
+	keys := make([]string, 0, len(transformersMap))
+	for trName := range transformersMap {
+		keys = append(keys, string(trName))
+	}
+	sort.Strings(keys)
+
+	transformersList := make([]Transformer, 0, len(transformersMap))
+	for _, trName := range keys {
+		transformer := transformersMap[transformers.TransformerType(trName)]
+		transformersList = append(transformersList, Transformer{
+			Name:           trName,
+			SupportedTypes: extractSupportedTypes(transformer.SupportedTypes),
+			Parameters:     extractParameters(transformer.Parameters),
+		})
+	}
+
+	return transformersList
+}
+
+func extractSupportedTypes(types []transformers.SupportedDataType) []string {
+	supportedTypes := make([]string, 0, len(types))
+	for _, st := range types {
+		supportedTypes = append(supportedTypes, string(st))
+	}
+	return supportedTypes
+}
+
+func extractParameters(params []transformers.TransformerParameter) []Parameter {
+	parameters := make([]Parameter, 0, len(params))
+	for _, param := range params {
+		parameters = append(parameters, Parameter{
+			Name:          param.Name,
+			SupportedType: param.SupportedType,
+			Default:       param.Default,
+			Dynamic:       param.Dynamic,
+			Required:      param.Required,
+		})
+	}
+	return parameters
+}
+
+func writeJSONToFile(filename string, data any) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode(data); err != nil {
+		return fmt.Errorf("failed to encode JSON: %w", err)
+	}
+	return nil
+}

--- a/tools/transformer-definition/build-transformers-definition.go
+++ b/tools/transformer-definition/build-transformers-definition.go
@@ -30,6 +30,7 @@ type Parameter struct {
 	Default       any    `json:"default"`
 	Dynamic       bool   `json:"dynamic"`
 	Required      bool   `json:"required"`
+	Values        []any  `json:"values,omitempty"`
 }
 
 func main() {
@@ -85,6 +86,7 @@ func extractParameters(params []transformers.TransformerParameter) []Parameter {
 			Default:       param.Default,
 			Dynamic:       param.Dynamic,
 			Required:      param.Required,
+			Values:        param.Values,
 		})
 	}
 	return parameters

--- a/tools/transformer-definition/build-transformers-definition.go
+++ b/tools/transformer-definition/build-transformers-definition.go
@@ -48,7 +48,11 @@ func main() {
 	log.Println("Transformers JSON schema generated successfully")
 }
 
-func extractTransformers(transformersMap map[transformers.TransformerType]builder.TransformerDefinition) []Transformer {
+func extractTransformers(transformersMap map[transformers.TransformerType]struct {
+	Definition *transformers.Definition
+	BuildFn    func(cfg *transformers.Config) (transformers.Transformer, error)
+},
+) []Transformer {
 	// Sort the keys to ensure consistent ordering
 	keys := make([]string, 0, len(transformersMap))
 	for trName := range transformersMap {
@@ -61,8 +65,8 @@ func extractTransformers(transformersMap map[transformers.TransformerType]builde
 		transformer := transformersMap[transformers.TransformerType(trName)]
 		transformersList = append(transformersList, Transformer{
 			Name:           trName,
-			SupportedTypes: extractSupportedTypes(transformer.SupportedTypes),
-			Parameters:     extractParameters(transformer.Parameters),
+			SupportedTypes: extractSupportedTypes(transformer.Definition.SupportedTypes),
+			Parameters:     extractParameters(transformer.Definition.Parameters),
 		})
 	}
 

--- a/tools/transformer-definition/build-transformers-definition.go
+++ b/tools/transformer-definition/build-transformers-definition.go
@@ -77,7 +77,7 @@ func extractSupportedTypes(types []transformers.SupportedDataType) []string {
 	return supportedTypes
 }
 
-func extractParameters(params []transformers.TransformerParameter) []Parameter {
+func extractParameters(params []transformers.Parameter) []Parameter {
 	parameters := make([]Parameter, 0, len(params))
 	for _, param := range params {
 		parameters = append(parameters, Parameter{

--- a/transformers-definition.json
+++ b/transformers-definition.json
@@ -13,7 +13,11 @@
           "supported_type": "string",
           "default": "random",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "random",
+            "deterministic"
+          ]
         }
       ]
     },
@@ -36,7 +40,11 @@
           "supported_type": "string",
           "default": "random",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "random",
+            "deterministic"
+          ]
         }
       ]
     },
@@ -53,7 +61,11 @@
           "supported_type": "string",
           "default": "random",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "random",
+            "deterministic"
+          ]
         },
         {
           "name": "min_value",
@@ -83,14 +95,23 @@
           "supported_type": "string",
           "default": "random",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "random",
+            "deterministic"
+          ]
         },
         {
           "name": "gender",
           "supported_type": "string",
           "default": "Any",
           "dynamic": true,
-          "required": false
+          "required": false,
+          "values": [
+            "Male",
+            "Female",
+            "Any"
+          ]
         }
       ]
     },
@@ -107,7 +128,11 @@
           "supported_type": "string",
           "default": "random",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "random",
+            "deterministic"
+          ]
         },
         {
           "name": "min_value",
@@ -153,14 +178,22 @@
           "supported_type": "string",
           "default": "random",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "random",
+            "deterministic"
+          ]
         },
         {
           "name": "size",
           "supported_type": "int",
           "default": 4,
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            2,
+            4
+          ]
         },
         {
           "name": "min_value",
@@ -211,7 +244,11 @@
           "supported_type": "string",
           "default": "random",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "random",
+            "deterministic"
+          ]
         }
       ]
     },
@@ -236,7 +273,11 @@
           "supported_type": "string",
           "default": "random",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "random",
+            "deterministic"
+          ]
         },
         {
           "name": "min_value",
@@ -267,14 +308,29 @@
           "supported_type": "string",
           "default": "random",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "random",
+            "deterministic"
+          ]
         },
         {
           "name": "truncate_part",
           "supported_type": "string",
           "default": "",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "year",
+            "month",
+            "day",
+            "hour",
+            "minute",
+            "second",
+            "millisecond",
+            "microsecond",
+            "nanosecond"
+          ]
         },
         {
           "name": "min_timestamp",
@@ -306,7 +362,11 @@
           "supported_type": "string",
           "default": "random",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "random",
+            "deterministic"
+          ]
         }
       ]
     },
@@ -337,7 +397,20 @@
           "supported_type": "string",
           "default": "default",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "custom",
+            "password",
+            "name",
+            "address",
+            "email",
+            "mobile",
+            "tel",
+            "id",
+            "credit_card",
+            "url",
+            "default"
+          ]
         },
         {
           "name": "mask_begin",
@@ -415,14 +488,25 @@
           "supported_type": "string",
           "default": "uuidv4",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "uuidv4",
+            "fullname",
+            "any"
+          ]
         },
         {
           "name": "invalid_email_action",
           "supported_type": "string",
           "default": "reject",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "reject",
+            "passthrough",
+            "null",
+            "generate"
+          ]
         }
       ]
     },
@@ -582,7 +666,11 @@
           "supported_type": "string",
           "default": "random",
           "dynamic": false,
-          "required": false
+          "required": false,
+          "values": [
+            "random",
+            "deterministic"
+          ]
         }
       ]
     },

--- a/transformers-definition.json
+++ b/transformers-definition.json
@@ -1,0 +1,614 @@
+{
+  "name": "transformers",
+  "transformers": [
+    {
+      "name": "greenmask_boolean",
+      "supported_types": [
+        "boolean",
+        "byte_array"
+      ],
+      "parameters": [
+        {
+          "name": "generator",
+          "supported_type": "string",
+          "default": "random",
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "greenmask_choice",
+      "supported_types": [
+        "string",
+        "byte_array"
+      ],
+      "parameters": [
+        {
+          "name": "choices",
+          "supported_type": "array",
+          "default": null,
+          "dynamic": false,
+          "required": true
+        },
+        {
+          "name": "generator",
+          "supported_type": "string",
+          "default": "random",
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "greenmask_date",
+      "supported_types": [
+        "string",
+        "byte_array",
+        "date"
+      ],
+      "parameters": [
+        {
+          "name": "generator",
+          "supported_type": "string",
+          "default": "random",
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "min_value",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": true
+        },
+        {
+          "name": "max_value",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "greenmask_firstname",
+      "supported_types": [
+        "string",
+        "byte_array"
+      ],
+      "parameters": [
+        {
+          "name": "generator",
+          "supported_type": "string",
+          "default": "random",
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "gender",
+          "supported_type": "string",
+          "default": "Any",
+          "dynamic": true,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "greenmask_float",
+      "supported_types": [
+        "float32",
+        "float64",
+        "byte_array"
+      ],
+      "parameters": [
+        {
+          "name": "generator",
+          "supported_type": "string",
+          "default": "random",
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "min_value",
+          "supported_type": "float",
+          "default": -3.4028234663852886e+38,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "max_value",
+          "supported_type": "float",
+          "default": 3.4028234663852886e+38,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "precision",
+          "supported_type": "int",
+          "default": 2,
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "greenmask_integer",
+      "supported_types": [
+        "byte_array",
+        "integer8",
+        "uinteger8",
+        "integer16",
+        "uinteger16",
+        "integer32",
+        "uinteger32",
+        "integer64",
+        "uinteger64",
+        "float32",
+        "float64"
+      ],
+      "parameters": [
+        {
+          "name": "generator",
+          "supported_type": "string",
+          "default": "random",
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "size",
+          "supported_type": "int",
+          "default": 4,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "min_value",
+          "supported_type": "int",
+          "default": -2147483648,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "max_value",
+          "supported_type": "int",
+          "default": 2147483647,
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "greenmask_string",
+      "supported_types": [
+        "string",
+        "byte_array"
+      ],
+      "parameters": [
+        {
+          "name": "symbols",
+          "supported_type": "string",
+          "default": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "min_length",
+          "supported_type": "int",
+          "default": 1,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "max_length",
+          "supported_type": "int",
+          "default": 100,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "generator",
+          "supported_type": "string",
+          "default": "random",
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "greenmask_unix_timestamp",
+      "supported_types": [
+        "byte_array",
+        "integer8",
+        "uinteger8",
+        "integer16",
+        "uinteger16",
+        "integer32",
+        "uinteger32",
+        "integer64",
+        "uinteger64",
+        "float32",
+        "float64"
+      ],
+      "parameters": [
+        {
+          "name": "generator",
+          "supported_type": "string",
+          "default": "random",
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "min_value",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": true
+        },
+        {
+          "name": "max_value",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "greenmask_utc_timestamp",
+      "supported_types": [
+        "datetime",
+        "byte_array",
+        "string"
+      ],
+      "parameters": [
+        {
+          "name": "generator",
+          "supported_type": "string",
+          "default": "random",
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "truncate_part",
+          "supported_type": "string",
+          "default": "",
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "min_timestamp",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": true
+        },
+        {
+          "name": "max_timestamp",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "greenmask_uuid",
+      "supported_types": [
+        "string",
+        "byte_array",
+        "uuid",
+        "uint8_array_of_16"
+      ],
+      "parameters": [
+        {
+          "name": "generator",
+          "supported_type": "string",
+          "default": "random",
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "literal_string",
+      "supported_types": [
+        "all"
+      ],
+      "parameters": [
+        {
+          "name": "literal",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "masking",
+      "supported_types": [
+        "string",
+        "byte_array"
+      ],
+      "parameters": [
+        {
+          "name": "type",
+          "supported_type": "string",
+          "default": "default",
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "mask_begin",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "mask_end",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "unmask_begin",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "unmask_end",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "neosync_email",
+      "supported_types": [
+        "string"
+      ],
+      "parameters": [
+        {
+          "name": "seed",
+          "supported_type": "int",
+          "default": null,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "preserve_length",
+          "supported_type": "boolean",
+          "default": false,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "max_length",
+          "supported_type": "int",
+          "default": 100,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "preserve_domain",
+          "supported_type": "boolean",
+          "default": false,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "excluded_domains",
+          "supported_type": "array",
+          "default": null,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "email_type",
+          "supported_type": "string",
+          "default": "uuidv4",
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "invalid_email_action",
+          "supported_type": "string",
+          "default": "reject",
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "neosync_firstname",
+      "supported_types": [
+        "string"
+      ],
+      "parameters": [
+        {
+          "name": "seed",
+          "supported_type": "int",
+          "default": null,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "preserve_length",
+          "supported_type": "boolean",
+          "default": false,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "max_length",
+          "supported_type": "int",
+          "default": 100,
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "neosync_fullname",
+      "supported_types": [
+        "string"
+      ],
+      "parameters": [
+        {
+          "name": "seed",
+          "supported_type": "int",
+          "default": null,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "preserve_length",
+          "supported_type": "boolean",
+          "default": false,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "max_length",
+          "supported_type": "int",
+          "default": 100,
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "neosync_lastname",
+      "supported_types": [
+        "string"
+      ],
+      "parameters": [
+        {
+          "name": "seed",
+          "supported_type": "int",
+          "default": null,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "preserve_length",
+          "supported_type": "boolean",
+          "default": false,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "max_length",
+          "supported_type": "int",
+          "default": 100,
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "neosync_string",
+      "supported_types": [
+        "string"
+      ],
+      "parameters": [
+        {
+          "name": "seed",
+          "supported_type": "int",
+          "default": null,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "preserve_length",
+          "supported_type": "boolean",
+          "default": false,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "min_length",
+          "supported_type": "int",
+          "default": 1,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "max_length",
+          "supported_type": "int",
+          "default": 100,
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "phone_number",
+      "supported_types": [
+        "string",
+        "byte_array"
+      ],
+      "parameters": [
+        {
+          "name": "prefix",
+          "supported_type": "string",
+          "default": "",
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "min_length",
+          "supported_type": "int",
+          "default": 6,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "max_length",
+          "supported_type": "int",
+          "default": 10,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "generator",
+          "supported_type": "string",
+          "default": "random",
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "string",
+      "supported_types": [
+        "string",
+        "byte_array"
+      ],
+      "parameters": []
+    },
+    {
+      "name": "template",
+      "supported_types": [
+        "string",
+        "byte_array"
+      ],
+      "parameters": [
+        {
+          "name": "template",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds `TransformerDefinition` struct to package `builder`, which has the info of compatible types, parameters and the create function for every transformer defined. Also by adding a map of all transformers to their definitions, helps both when building transformers and also creating a json definition file to be used with `xata clone`.
```
type TransformerDefinition struct {
	SupportedTypes []transformers.SupportedDataType
	Parameters     []transformers.TransformerParameter
	CreateFunc     func(*transformers.Config) (transformers.Transformer, error)
}
```

With that, instead of having a huge `switch` statement for matching transformer names with their build functions, we can directly call the `CreateFunc` when building a transformer. Also, since now we have the parameters info during creation, we'll be verifying parameters right away, by calling `ValidateParameters` only once, instead of calling it at the beginning of every `New.....Transformer` function.

This map gets all the information (types and params) directly from each transformer. Use the `CreateFunc` defined in the map, will prevent any accidental case that we add a new transformer but forget to add it's definiton. Because in that case we'll get a `unexpected transformer name` error.

Also adding a `TransformerParameter` struct to package `transformers`, which is defined in each transformer file, to be used in the `builder`.
```
type TransformerParameter struct {
	Name          string
	SupportedType string
	Default       any
	Dynamic       bool
	Required      bool
}
```

Finally, adding a script `build-transformers-definition.go` that creates the json definition file for all transformers, using the map previously mentioned.

fixes: #347 

edit: Looks like copilot summarized the PR better than I do :D
> This PR refactors all transformer implementations to use structured definitions for supported parameters and compatible types while integrating them into a centralized transformer builder.
* Refactors parameter definitions from string slices to structured TransformerParameter arrays.
* Introduces corresponding CompatibleTypes and updates each transformer’s New* function accordingly.
* Updates the transformer builder to use a map-based approach and enhances Makefile to run the transformer definitions builder.