### PR TITLE
Add `COPY FROM` support to internal postgres library

### DIFF
--- a/internal/postgres/instrumentation/instrumented_querier.go
+++ b/internal/postgres/instrumentation/instrumented_querier.go
@@ -136,6 +136,12 @@ func (i *Querier) Close(ctx context.Context) (err error) {
 	return i.inner.Close(ctx)
 }
 
+func (i *Querier) CopyFrom(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (rowCount int64, err error) {
+	ctx, span := otel.StartSpan(ctx, i.tracer, "querier.CopyFrom")
+	defer otel.CloseSpan(span, err)
+	return i.inner.CopyFrom(ctx, tableName, columnNames, srcRows)
+}
+
 func (i *Querier) initMetrics() error {
 	if i.meter == nil {
 		return nil

--- a/internal/postgres/mocks/mock_pg_querier.go
+++ b/internal/postgres/mocks/mock_pg_querier.go
@@ -15,6 +15,7 @@ type Querier struct {
 	ExecFn                   func(context.Context, uint, string, ...any) (postgres.CommandTag, error)
 	ExecInTxFn               func(context.Context, func(tx postgres.Tx) error) error
 	ExecInTxWithOptionsFn    func(context.Context, uint, func(tx postgres.Tx) error, postgres.TxOptions) error
+	CopyFromFn               func(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (int64, error)
 	PingFn                   func(context.Context) error
 	CloseFn                  func(context.Context) error
 	execCalls                uint32
@@ -41,6 +42,10 @@ func (m *Querier) ExecInTx(ctx context.Context, fn func(tx postgres.Tx) error) e
 func (m *Querier) ExecInTxWithOptions(ctx context.Context, fn func(tx postgres.Tx) error, opts postgres.TxOptions) error {
 	atomic.AddUint32(&m.execInTxWithOptionsCalls, 1)
 	return m.ExecInTxWithOptionsFn(ctx, uint(atomic.LoadUint32(&m.execInTxWithOptionsCalls)), fn, opts)
+}
+
+func (m *Querier) CopyFrom(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (rowCount int64, err error) {
+	return m.CopyFromFn(ctx, tableName, columnNames, srcRows)
 }
 
 func (m *Querier) Ping(ctx context.Context) error {

--- a/internal/postgres/pg_conn.go
+++ b/internal/postgres/pg_conn.go
@@ -60,6 +60,21 @@ func (c *Conn) ExecInTxWithOptions(ctx context.Context, fn func(Tx) error, opts 
 	return tx.Commit(ctx)
 }
 
+func (c *Conn) CopyFrom(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (int64, error) {
+	identifier, err := newIdentifier(tableName)
+	if err != nil {
+		return -1, err
+	}
+
+	// sanitize the input, removing any added quotes. The CopyFrom will sanitize
+	// them and double quotes will cause errors.
+	for i, c := range columnNames {
+		columnNames[i] = removeQuotes(c)
+	}
+
+	return c.conn.CopyFrom(ctx, identifier, columnNames, pgx.CopyFromRows(srcRows))
+}
+
 func (c *Conn) Ping(ctx context.Context) error {
 	return mapError(c.conn.Ping(ctx))
 }

--- a/internal/postgres/pg_querier.go
+++ b/internal/postgres/pg_querier.go
@@ -15,6 +15,7 @@ type Querier interface {
 	Exec(ctx context.Context, query string, args ...any) (CommandTag, error)
 	ExecInTx(ctx context.Context, fn func(tx Tx) error) error
 	ExecInTxWithOptions(ctx context.Context, fn func(tx Tx) error, txOpts TxOptions) error
+	CopyFrom(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (int64, error)
 	Ping(ctx context.Context) error
 	Close(ctx context.Context) error
 }

--- a/internal/postgres/pg_utils.go
+++ b/internal/postgres/pg_utils.go
@@ -4,7 +4,10 @@ package postgres
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/lib/pq"
 )
 
@@ -20,3 +23,29 @@ type (
 	PGDumpFn    func(context.Context, PGDumpOptions) ([]byte, error)
 	PGRestoreFn func(context.Context, PGRestoreOptions, []byte) (string, error)
 )
+
+func newIdentifier(tableName string) (pgx.Identifier, error) {
+	var identifier pgx.Identifier
+	qualifiedTableName := strings.Split(tableName, ".")
+	switch len(qualifiedTableName) {
+	case 1:
+		identifier = pgx.Identifier{tableName}
+	case 2:
+		identifier = pgx.Identifier{qualifiedTableName[0], qualifiedTableName[1]}
+	default:
+		return nil, fmt.Errorf("invalid table name: %s", tableName)
+	}
+
+	// Remove any quotes from the table name. Identifier has a `Sanitize` method
+	// that will be called and will add quotes, so if there are existing ones,
+	// it will produce an invalid identifier name.
+	for i, part := range identifier {
+		identifier[i] = removeQuotes(part)
+	}
+
+	return identifier, nil
+}
+
+func removeQuotes(s string) string {
+	return strings.Trim(s, `"`)
+}

--- a/internal/postgres/pg_utils_test.go
+++ b/internal/postgres/pg_utils_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_newIdentifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		tableName string
+
+		wantIdentifier pgx.Identifier
+		wantErr        error
+	}{
+		{
+			name:      "ok - table name",
+			tableName: "test_table",
+
+			wantIdentifier: pgx.Identifier{"test_table"},
+			wantErr:        nil,
+		},
+		{
+			name:      "ok - qualified table name",
+			tableName: "test_schema.test_table",
+
+			wantIdentifier: pgx.Identifier{"test_schema", "test_table"},
+			wantErr:        nil,
+		},
+		{
+			name:      "ok - quoted qualified table name",
+			tableName: `"test_schema"."test_table"`,
+
+			wantIdentifier: pgx.Identifier{"test_schema", "test_table"},
+			wantErr:        nil,
+		},
+		{
+			name:      "error - invalid table name",
+			tableName: "invalid.test.table",
+
+			wantIdentifier: nil,
+			wantErr:        errors.New("invalid table name: invalid.test.table"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			id, err := newIdentifier(tc.tableName)
+			require.Equal(t, tc.wantErr, err)
+			require.Equal(t, tc.wantIdentifier, id)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds `CopyFrom` to the `Querier` interface of the internal postgres library, as well as all relevant implementations.