### PR TITLE
[Snapshot] Set values for dump sequences

### DIFF
--- a/internal/postgres/pg_dump.go
+++ b/internal/postgres/pg_dump.go
@@ -26,6 +26,8 @@ type PGDumpOptions struct {
 	ExcludeTables []string
 	// SchemaOnly if true, only schema will be exported (no data)
 	SchemaOnly bool
+	// DataOnly if true, only data will be exported (no schema)
+	DataOnly bool
 	// do not dump privileges (grant/revoke)
 	NoPrivileges bool
 	// Clean all the objects that will be dumped
@@ -47,6 +49,10 @@ func (opts *PGDumpOptions) ToArgs() []string {
 
 	if opts.SchemaOnly {
 		options = append(options, "--schema-only")
+	}
+
+	if opts.DataOnly {
+		options = append(options, "--data-only")
 	}
 
 	if opts.NoPrivileges {

--- a/internal/postgres/pg_utils.go
+++ b/internal/postgres/pg_utils.go
@@ -4,12 +4,45 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/lib/pq"
 )
+
+type QualifiedName struct {
+	schema string
+	name   string
+}
+
+var errUnexpectedQualifiedName = errors.New("unexpected qualified name format")
+
+func NewQualifiedName(s string) (*QualifiedName, error) {
+	qualifiedName := strings.Split(s, ".")
+	switch len(qualifiedName) {
+	case 1:
+		return &QualifiedName{
+			name: s,
+		}, nil
+	case 2:
+		return &QualifiedName{
+			schema: qualifiedName[0],
+			name:   qualifiedName[1],
+		}, nil
+	default:
+		return nil, errUnexpectedQualifiedName
+	}
+}
+
+func (qn *QualifiedName) Schema() string {
+	return qn.schema
+}
+
+func (qn *QualifiedName) Name() string {
+	return qn.name
+}
 
 func QuoteIdentifier(s string) string {
 	return pq.QuoteIdentifier(s)

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/helper_test.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/helper_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package pgdumprestore
+
+import (
+	"context"
+
+	pglib "github.com/xataio/pgstream/internal/postgres"
+)
+
+type mockPgDump struct {
+	dumpFn    func(context.Context, uint, pglib.PGDumpOptions) ([]byte, error)
+	dumpCalls uint
+}
+
+func newMockPgdump(dumpFn func(context.Context, uint, pglib.PGDumpOptions) ([]byte, error)) pglib.PGDumpFn {
+	m := &mockPgDump{
+		dumpFn: dumpFn,
+	}
+	return m.dump
+}
+
+func (m *mockPgDump) dump(ctx context.Context, po pglib.PGDumpOptions) ([]byte, error) {
+	m.dumpCalls++
+	return m.dumpFn(ctx, m.dumpCalls, po)
+}
+
+type mockPgRestore struct {
+	restoreFn    func(context.Context, uint, pglib.PGRestoreOptions, []byte) (string, error)
+	restoreCalls uint
+}
+
+func newMockPgrestore(restoreFn func(context.Context, uint, pglib.PGRestoreOptions, []byte) (string, error)) pglib.PGRestoreFn {
+	m := &mockPgRestore{
+		restoreFn: restoreFn,
+	}
+	return m.restore
+}
+
+func (m *mockPgRestore) restore(ctx context.Context, po pglib.PGRestoreOptions, dump []byte) (string, error) {
+	m.restoreCalls++
+	return m.restoreFn(ctx, m.restoreCalls, po, dump)
+}


### PR DESCRIPTION
This PR updates the schema snapshot logic to make sure the values for dumped sequences are set appropriately. The `pg_dump` command for the schema uses the`--schema-only` option, which results in the sequences being created but their values are not set as they're considered data. 
The sequence values are added by parsing the sequences created during the dump, doing a data only dump for those and restoring it along the schema.