### PR TITLE
[Snapshot] Do not dump sequence values if there's no sequences

### DIFF
--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -192,6 +192,10 @@ func (s *SnapshotGenerator) dumpSchema(ctx context.Context, ss *snapshot.Snapsho
 }
 
 func (s *SnapshotGenerator) dumpSequenceValues(ctx context.Context, sequences []string) ([]byte, error) {
+	if len(sequences) == 0 {
+		return nil, nil
+	}
+
 	opts := &pglib.PGDumpOptions{
 		ConnectionString: s.sourceURL,
 		Format:           "p",


### PR DESCRIPTION
This PR fixes an edge case when dumping sequence data to only call `pg_dump` if there are sequences created by the schema dump. Currently when there are no sequences the table filter is not used, and all data is dumped.