### PR TITLE
[Snapshot] Do not copy generated columns

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -412,7 +412,7 @@ One of exponential/constant backoff policies can be provided for the search stor
 
 <details>
   <summary>Traces</summary>
-   
+
 | Environment Variable                 | Default | Required | Description                                                                                                                     |
 | ------------------------------------ | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | PGSTREAM_TRACES_ENDPOINT             | N/A     | No       | Endpoint where the pgstream traces will be exported to.                                                                         |

--- a/pkg/stream/integration/helper_test.go
+++ b/pkg/stream/integration/helper_test.go
@@ -43,6 +43,14 @@ var (
 	elasticsearchURL string
 )
 
+const (
+	withBulkIngestion    = true
+	withoutBulkIngestion = false
+
+	withGeneratedColumn    = true
+	withoutGeneratedColumn = false
+)
+
 type mockProcessor struct {
 	eventChan chan *wal.Event
 }
@@ -230,17 +238,19 @@ func testWebhookProcessorCfg() stream.ProcessorConfig {
 	}
 }
 
-func testPostgresProcessorCfg(sourcePGURL string) stream.ProcessorConfig {
+func testPostgresProcessorCfg(sourcePGURL string, bulkIngestion bool) stream.ProcessorConfig {
 	return stream.ProcessorConfig{
 		Postgres: &stream.PostgresProcessorConfig{
 			BatchWriter: postgres.Config{
 				URL: targetPGURL,
 				BatchConfig: batch.Config{
-					BatchTimeout: 50 * time.Millisecond,
+					MaxBatchSize: 1,
+					// BatchTimeout: 50 * time.Millisecond,
 				},
 				SchemaLogStore: schemalogpg.Config{
 					URL: sourcePGURL,
 				},
+				BulkIngestEnabled: bulkIngestion,
 			},
 		},
 		Injector: &injector.Config{

--- a/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
+++ b/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
@@ -25,6 +25,9 @@ type BulkIngestWriter struct {
 	batchSenderMapMutex *sync.RWMutex
 	batchSenderMap      map[string]queryBatchSender
 	batchSenderBuilder  func(ctx context.Context) (queryBatchSender, error)
+
+	tableColumns      map[string][]string
+	tableColumnsMutex *sync.RWMutex
 }
 
 const bulkIngestWriter = "postgres_bulk_ingest_writer"
@@ -53,6 +56,8 @@ func NewBulkIngestWriter(ctx context.Context, config *Config, opts ...WriterOpti
 		Writer:              w,
 		batchSenderMapMutex: &sync.RWMutex{},
 		batchSenderMap:      make(map[string]queryBatchSender),
+		tableColumns:        map[string][]string{},
+		tableColumnsMutex:   &sync.RWMutex{},
 	}
 
 	biw.batchSenderBuilder = func(ctx context.Context) (queryBatchSender, error) {
@@ -170,20 +175,23 @@ func (w *BulkIngestWriter) copyFromInsertQueries(ctx context.Context, inserts []
 	if len(inserts) == 0 {
 		return nil
 	}
-	// Get the column names from the first insert query, since all the inserts
+
+	// Get the table name from the first insert query, since all the inserts
 	// in the batch will be for the same schema.table
 	query := inserts[0]
-	srcRows := [][]any{}
-	for _, q := range inserts {
-		srcRows = append(srcRows, q.args)
+	// get column names for the table, removing generated columns, since the
+	// COPY command does not support them.
+	columnNames, err := w.getTableColumnNames(ctx, query.schema, query.table)
+	if err != nil {
+		return err
 	}
 
-	err := w.pgConn.ExecInTx(ctx, func(tx pglib.Tx) error {
+	err = w.pgConn.ExecInTx(ctx, func(tx pglib.Tx) error {
 		if err := w.setReplicationRoleToReplica(ctx, tx); err != nil {
 			return err
 		}
 
-		rowsCopied, err := tx.CopyFrom(ctx, pglib.QuoteQualifiedIdentifier(query.schema, query.table), query.columnNames, srcRows)
+		rowsCopied, err := tx.CopyFrom(ctx, pglib.QuoteQualifiedIdentifier(query.schema, query.table), columnNames, w.getSrcRows(inserts, columnNames))
 		if err != nil {
 			return err
 		}
@@ -199,4 +207,77 @@ func (w *BulkIngestWriter) copyFromInsertQueries(ctx context.Context, inserts []
 		return fmt.Errorf("copy from: %w", err)
 	}
 	return nil
+}
+
+func (w *BulkIngestWriter) getTableColumnNames(ctx context.Context, schema, table string) ([]string, error) {
+	key := pglib.QuoteQualifiedIdentifier(schema, table)
+	w.tableColumnsMutex.RLock()
+	columnNames, found := w.tableColumns[key]
+	w.tableColumnsMutex.RUnlock()
+	if found {
+		return columnNames, nil
+	}
+
+	colNames, err := w.queryTableColumnNames(ctx, schema, table)
+	if err != nil {
+		return nil, err
+	}
+
+	w.tableColumnsMutex.Lock()
+	w.tableColumns[key] = colNames
+	w.tableColumnsMutex.Unlock()
+
+	return colNames, nil
+}
+
+func (w *BulkIngestWriter) getSrcRows(inserts []*query, columnNames []string) [][]any {
+	srcRows := [][]any{}
+	columnMap := make(map[string]struct{}, len(columnNames))
+	for _, col := range columnNames {
+		columnMap[pglib.QuoteIdentifier(col)] = struct{}{}
+	}
+	for _, q := range inserts {
+		// we need to make sure we only add the arguments for the
+		// relevant column names (this removes any generated columns row values)
+		rows := []any{}
+		for i, colName := range q.columnNames {
+			if _, found := columnMap[colName]; !found {
+				continue
+			}
+			rows = append(rows, q.args[i])
+		}
+		srcRows = append(srcRows, rows)
+	}
+
+	return srcRows
+}
+
+const tableColumnsQuery = `SELECT attname FROM pg_attribute
+		WHERE attnum > 0
+		AND attrelid = (SELECT c.oid FROM pg_class c JOIN pg_namespace n ON c.relnamespace=n.oid WHERE c.relname=$1 and n.nspname=$2)
+		AND attgenerated = ''`
+
+func (w *BulkIngestWriter) queryTableColumnNames(ctx context.Context, schemaName, tableName string) ([]string, error) {
+	columnNames := []string{}
+	// filter out generated columns (excluding identities) since they will
+	// be generated automatically, and they can't be overwriten.
+	rows, err := w.pgConn.Query(ctx, tableColumnsQuery, tableName, schemaName)
+	if err != nil {
+		return nil, fmt.Errorf("getting table column names for table %s.%s: %w", schemaName, tableName, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var columnName string
+		if err := rows.Scan(&columnName); err != nil {
+			return nil, fmt.Errorf("scanning table column name: %w", err)
+		}
+		columnNames = append(columnNames, columnName)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return columnNames, nil
 }


### PR DESCRIPTION
This PR updates the postgres bulk ingest writer logic to prevent copying generated columns (excluding identities). Generated columns are computed when written, and cannot be written to directly. The COPY command does not support them. 
https://www.postgresql.org/docs/current/ddl-generated-columns.htm 

Instead of modifying the snapshotting process to remove the generated columns from the snapshot, the changes are done on the postgres target side, since the snapshot can be used with any supported target, and this is only an issue for the postgres usecase. For any other target, we'll need to have the generated columns along with the rest, since they won't have the postgres logic embedded to generate it.

Fixes #373 