### PR TITLE
[Snapshot] Wait for all tables to finish processing data

### DIFF
--- a/pkg/snapshot/generator/mocks/mocks_row_processor.go
+++ b/pkg/snapshot/generator/mocks/mocks_row_processor.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mocks
+
+import (
+	"context"
+
+	"github.com/xataio/pgstream/pkg/snapshot"
+)
+
+type RowsProcessor struct {
+	ProcessRowFn func(context.Context, *snapshot.Row) error
+	CloseFn      func() error
+}
+
+func (m *RowsProcessor) ProcessRow(ctx context.Context, row *snapshot.Row) error {
+	return m.ProcessRowFn(ctx, row)
+}
+
+func (m *RowsProcessor) Close() error {
+	if m.CloseFn != nil {
+		return m.CloseFn()
+	}
+	return nil
+}

--- a/pkg/snapshot/generator/postgres/data/helper_test.go
+++ b/pkg/snapshot/generator/postgres/data/helper_test.go
@@ -18,13 +18,14 @@ type mockRowProcessor struct {
 	once    sync.Once
 }
 
-func (mp *mockRowProcessor) process(ctx context.Context, row *snapshot.Row) error {
+func (mp *mockRowProcessor) ProcessRow(ctx context.Context, row *snapshot.Row) error {
 	mp.rowChan <- row
 	return nil
 }
 
-func (mp *mockRowProcessor) close() {
+func (mp *mockRowProcessor) Close() error {
 	mp.once.Do(func() { close(mp.rowChan) })
+	return nil
 }
 
 func execQuery(t *testing.T, ctx context.Context, pgurl, query string) {

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_integration_test.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_integration_test.go
@@ -32,7 +32,7 @@ func Test_PostgresSnapshotGenerator(t *testing.T) {
 		rowChan: make(chan *snapshot.Row),
 	}
 
-	generator, err := NewSnapshotGenerator(ctx, &Config{URL: pgurl}, mockProcessor.process)
+	generator, err := NewSnapshotGenerator(ctx, &Config{URL: pgurl}, mockProcessor)
 	require.NoError(t, err)
 	defer generator.Close()
 
@@ -49,7 +49,7 @@ func Test_PostgresSnapshotGenerator(t *testing.T) {
 			TableNames: []string{testTable},
 		})
 		require.NoError(t, err)
-		mockProcessor.close()
+		mockProcessor.Close()
 	}()
 
 	rows := make([]*snapshot.Row, 0, 3)

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_test.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_test.go
@@ -19,6 +19,7 @@ import (
 	pglib "github.com/xataio/pgstream/internal/postgres"
 	pgmocks "github.com/xataio/pgstream/internal/postgres/mocks"
 	"github.com/xataio/pgstream/pkg/snapshot"
+	"github.com/xataio/pgstream/pkg/snapshot/generator/mocks"
 	"github.com/xataio/pgstream/pkg/wal"
 )
 
@@ -870,9 +871,11 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 				})),
 				conn:   tc.querier,
 				mapper: pglib.NewMapper(tc.querier),
-				processRow: func(ctx context.Context, e *snapshot.Row) error {
-					rowChan <- e
-					return nil
+				rowsProcessor: &mocks.RowsProcessor{
+					ProcessRowFn: func(ctx context.Context, e *snapshot.Row) error {
+						rowChan <- e
+						return nil
+					},
 				},
 				schemaWorkers: 1,
 				tableWorkers:  1,

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -31,6 +31,11 @@ type Column struct {
 
 type RowProcessor func(context.Context, *Row) error
 
+type RowsProcessor interface {
+	ProcessRow(context.Context, *Row) error
+	Close() error
+}
+
 type Status string
 
 const (

--- a/pkg/stream/stream_run.go
+++ b/pkg/stream/stream_run.go
@@ -121,7 +121,7 @@ func Run(ctx context.Context, logger loglib.Logger, config *Config, instrumentat
 			snapshotGenerator, err := snapshotbuilder.NewSnapshotGenerator(
 				ctx,
 				config.Listener.Postgres.Snapshot,
-				processor.ProcessWALEvent,
+				processor,
 				logger,
 				instrumentation)
 			if err != nil {

--- a/pkg/stream/stream_snapshot.go
+++ b/pkg/stream/stream_snapshot.go
@@ -45,7 +45,7 @@ func Snapshot(ctx context.Context, logger loglib.Logger, config *Config, instrum
 	snapshotGenerator, err := snapshotbuilder.NewSnapshotGenerator(
 		ctx,
 		config.Listener.Snapshot,
-		processor.ProcessWALEvent,
+		processor,
 		logger,
 		instrumentation)
 	if err != nil {

--- a/pkg/wal/listener/snapshot/adapter/wal_process_event_adapter.go
+++ b/pkg/wal/listener/snapshot/adapter/wal_process_event_adapter.go
@@ -13,19 +13,24 @@ import (
 )
 
 type ProcessEventAdapter struct {
-	processEvent listener.ProcessWalEvent
-	clock        clockwork.Clock
+	processor listener.Processor
+
+	clock clockwork.Clock
 }
 
-func NewProcessEventAdapter(processEvent listener.ProcessWalEvent) *ProcessEventAdapter {
+func NewProcessEventAdapter(p listener.Processor) *ProcessEventAdapter {
 	return &ProcessEventAdapter{
-		processEvent: processEvent,
-		clock:        clockwork.NewRealClock(),
+		processor: p,
+		clock:     clockwork.NewRealClock(),
 	}
 }
 
 func (a *ProcessEventAdapter) ProcessRow(ctx context.Context, row *snapshot.Row) error {
-	return a.processEvent(ctx, a.snapshotRowToWalEvent(row))
+	return a.processor.ProcessWALEvent(ctx, a.snapshotRowToWalEvent(row))
+}
+
+func (a *ProcessEventAdapter) Close() error {
+	return a.processor.Close()
 }
 
 func (a *ProcessEventAdapter) snapshotRowToWalEvent(row *snapshot.Row) *wal.Event {

--- a/pkg/wal/listener/wal_listener.go
+++ b/pkg/wal/listener/wal_listener.go
@@ -15,3 +15,8 @@ type Listener interface {
 }
 
 type ProcessWalEvent func(context.Context, *wal.Event) error
+
+type Processor interface {
+	ProcessWALEvent(context.Context, *wal.Event) error
+	Close() error
+}

--- a/pkg/wal/processor/batch/wal_batch_sender.go
+++ b/pkg/wal/processor/batch/wal_batch_sender.go
@@ -200,17 +200,15 @@ func (s *Sender[T]) send(ctx context.Context) error {
 	return err
 }
 
+// Close will stop the sending, and wait for all ongoing batches to finish. It
+// is safe to call multiple times.
 func (s *Sender[T]) Close() {
-	s.cancelFn()
-	// wait for the send loop to finish
-	s.wg.Wait()
-	s.closeMsgChan()
-}
-
-// closeMsgChan closes the internal msg channel. It can be called multiple
-// times.
-func (s *Sender[T]) closeMsgChan() {
 	s.once.Do(func() {
+		s.logger.Trace("closing batch sender")
+		s.cancelFn()
+		// wait for the send loop to finish
+		s.wg.Wait()
 		close(s.msgChan)
+		s.logger.Trace("batch sender closed")
 	})
 }

--- a/pkg/wal/processor/batch/wal_batch_sender_test.go
+++ b/pkg/wal/processor/batch/wal_batch_sender_test.go
@@ -145,7 +145,7 @@ func TestSender_SendMessage(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer func() {
-					batchSender.closeMsgChan()
+					batchSender.Close()
 					wg.Done()
 				}()
 				err := batchSender.SendMessage(ctx, tc.msg)


### PR DESCRIPTION
This PR updates the postgres data snapshot generator to make sure the rows processor has finished before calling the next snapshot step. Otherwise, we can encounter situations where the index/constraint creation starts before all the data has been fully snapshoted, potentially leading to constraint issues since the data is not valid yet.

By closing the processor after the snapshot is done we guarantee that we wait for all the in-flight batches to complete before continuing.