### PR TITLE
[Snapshot] Filter out constraint/index/trigger comments on pgdump

### DIFF
--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -449,7 +449,10 @@ func (s *SnapshotGenerator) parseDump(d []byte) *dump {
 		case strings.HasPrefix(line, "CREATE INDEX"),
 			strings.HasPrefix(line, "CREATE UNIQUE INDEX"),
 			strings.HasPrefix(line, "CREATE CONSTRAINT"),
-			strings.HasPrefix(line, "CREATE TRIGGER"):
+			strings.HasPrefix(line, "CREATE TRIGGER"),
+			strings.HasPrefix(line, "COMMENT ON CONSTRAINT"),
+			strings.HasPrefix(line, "COMMENT ON INDEX"),
+			strings.HasPrefix(line, "COMMENT ON TRIGGER"):
 			indicesAndConstraints.WriteString(line)
 			indicesAndConstraints.WriteString("\n\n")
 		case strings.HasPrefix(line, "ALTER TABLE") && strings.Contains(line, "ADD CONSTRAINT"):

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump.sql
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump.sql
@@ -255,6 +255,8 @@ ALTER TABLE ONLY musicbrainz.alternative_medium_track
 CREATE INDEX area_alias_idx_txt ON musicbrainz.area_alias USING gin (musicbrainz.mb_simple_tsvector((name)::text));
 
 
+COMMENT ON INDEX area_alias_idx_txt ON musicbrainz.area_alias IS 'test';
+
 --
 -- Name: area_alias_type_idx_gid; Type: INDEX; Schema: musicbrainz; Owner: postgres
 --
@@ -269,6 +271,8 @@ CREATE UNIQUE INDEX area_alias_type_idx_gid ON musicbrainz.area_alias_type USING
 CREATE TRIGGER a_del_alternative_medium_track AFTER DELETE ON musicbrainz.alternative_medium_track FOR EACH ROW EXECUTE FUNCTION musicbrainz.a_del_alternative_medium_track();
 
 
+COMMENT ON TRIGGER a_del_alternative_medium_track ON musicbrainz.alternative_medium_track IS 'test';
+
 --
 -- Name: alternative_release a_del_alternative_release; Type: TRIGGER; Schema: musicbrainz; Owner: postgres
 --
@@ -281,6 +285,8 @@ CREATE TRIGGER a_del_alternative_release AFTER DELETE ON musicbrainz.alternative
 
 CREATE CONSTRAINT TRIGGER apply_artist_release_group_pending_updates AFTER INSERT OR DELETE OR UPDATE ON musicbrainz.release DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION musicbrainz.apply_artist_release_group_pending_updates();
 
+
+COMMENT ON CONSTRAINT apply_artist_release_group_pending_updates ON musicbrainz.release IS 'test';
 
 --
 -- Name: release_group apply_artist_release_group_pending_updates; Type: TRIGGER; Schema: musicbrainz; Owner: postgres

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump_constraints.sql
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump_constraints.sql
@@ -8,13 +8,19 @@ ALTER TABLE ONLY musicbrainz.alternative_medium_track
 
 CREATE INDEX area_alias_idx_txt ON musicbrainz.area_alias USING gin (musicbrainz.mb_simple_tsvector((name)::text));
 
+COMMENT ON INDEX area_alias_idx_txt ON musicbrainz.area_alias IS 'test';
+
 CREATE UNIQUE INDEX area_alias_type_idx_gid ON musicbrainz.area_alias_type USING btree (gid);
 
 CREATE TRIGGER a_del_alternative_medium_track AFTER DELETE ON musicbrainz.alternative_medium_track FOR EACH ROW EXECUTE FUNCTION musicbrainz.a_del_alternative_medium_track();
 
+COMMENT ON TRIGGER a_del_alternative_medium_track ON musicbrainz.alternative_medium_track IS 'test';
+
 CREATE TRIGGER a_del_alternative_release AFTER DELETE ON musicbrainz.alternative_release FOR EACH ROW EXECUTE FUNCTION musicbrainz.a_del_alternative_release_or_track();
 
 CREATE CONSTRAINT TRIGGER apply_artist_release_group_pending_updates AFTER INSERT OR DELETE OR UPDATE ON musicbrainz.release DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION musicbrainz.apply_artist_release_group_pending_updates();
+
+COMMENT ON CONSTRAINT apply_artist_release_group_pending_updates ON musicbrainz.release IS 'test';
 
 CREATE CONSTRAINT TRIGGER apply_artist_release_group_pending_updates AFTER INSERT OR DELETE OR UPDATE ON musicbrainz.release_group DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION musicbrainz.apply_artist_release_group_pending_updates();
 

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump_filtered.sql
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump_filtered.sql
@@ -250,6 +250,7 @@ ALTER TABLE ONLY musicbrainz.alternative_medium_track
 
 
 
+
 --
 -- Name: area_alias_type_idx_gid; Type: INDEX; Schema: musicbrainz; Owner: postgres
 --
@@ -262,6 +263,7 @@ ALTER TABLE ONLY musicbrainz.alternative_medium_track
 
 
 
+
 --
 -- Name: alternative_release a_del_alternative_release; Type: TRIGGER; Schema: musicbrainz; Owner: postgres
 --
@@ -270,6 +272,7 @@ ALTER TABLE ONLY musicbrainz.alternative_medium_track
 --
 -- Name: release apply_artist_release_group_pending_updates; Type: TRIGGER; Schema: musicbrainz; Owner: postgres
 --
+
 
 
 


### PR DESCRIPTION
This PR filters comments on constraints, indices and triggers along with their creation to be applied together. Otherwise, the restore process will try to create a comment for an index/constraint/trigger that doesn't yet exist (since they're created last).

Fixes https://github.com/xataio/xata-actions-demo/actions/runs/15486471181/job/43602183538. 