### PR TITLE
Fix single letter first/last name neosync transformer

### DIFF
--- a/pkg/transformers/neosync/errors.go
+++ b/pkg/transformers/neosync/errors.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package neosync
+
+import (
+	"fmt"
+	"strings"
+)
+
+type errSingleCharName struct {
+	Details string
+}
+
+func (e *errSingleCharName) Error() string {
+	return fmt.Sprintf("no single character naming candidate: %s", e.Details)
+}
+
+func mapError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.HasPrefix(err.Error(), "unable to find candidates with range") && strings.HasSuffix(err.Error(), ":1]") {
+		return &errSingleCharName{Details: err.Error()}
+	}
+	return fmt.Errorf("neosync_transformer: %w", err)
+}

--- a/pkg/transformers/neosync/neosync_firstname_transformer.go
+++ b/pkg/transformers/neosync/neosync_firstname_transformer.go
@@ -3,14 +3,19 @@
 package neosync
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	neosynctransformers "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers"
+	transformer_utils "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/utils"
+	"github.com/nucleuscloud/neosync/worker/pkg/rng"
 	"github.com/xataio/pgstream/pkg/transformers"
 )
 
 type FirstNameTransformer struct {
 	*transformer[string]
+	randomizer rng.Rand
 }
 
 var (
@@ -40,6 +45,8 @@ var (
 	firstNameCompatibleTypes = []transformers.SupportedDataType{
 		transformers.StringDataType,
 	}
+
+	errFirstNameLengthMustBeGreaterThanZero = errors.New("neosync_firstname: max_length must be greater than 0")
 )
 
 func NewFirstNameTransformer(params transformers.ParameterValues) (*FirstNameTransformer, error) {
@@ -53,19 +60,41 @@ func NewFirstNameTransformer(params transformers.ParameterValues) (*FirstNameTra
 		return nil, fmt.Errorf("neosync_firstname: max_length must be an integer: %w", err)
 	}
 
-	seed, err := findParameter[int](params, "seed")
+	if maxLength != nil && *maxLength < 1 {
+		return nil, errFirstNameLengthMustBeGreaterThanZero
+	}
+
+	seedParam, err := findParameter[int](params, "seed")
 	if err != nil {
 		return nil, fmt.Errorf("neosync_firstname: seed must be an integer: %w", err)
 	}
 
-	opts, err := neosynctransformers.NewTransformFirstNameOpts(toInt64Ptr(maxLength), preserveLength, toInt64Ptr(seed))
+	opts, err := neosynctransformers.NewTransformFirstNameOpts(toInt64Ptr(maxLength), preserveLength, toInt64Ptr(seedParam))
 	if err != nil {
 		return nil, err
 	}
 
+	seed, err := transformer_utils.GetSeedOrDefault(toInt64Ptr(seedParam))
+	if err != nil {
+		// not expected, but handle it gracefully
+		return nil, fmt.Errorf("neosync_firstname: unable to generate seed: %w", err)
+	}
+
 	return &FirstNameTransformer{
 		transformer: New[string](neosynctransformers.NewTransformFirstName(), opts),
+		randomizer:  rng.New(seed),
 	}, nil
+}
+
+func (t *FirstNameTransformer) Transform(ctx context.Context, value transformers.Value) (any, error) {
+	transformedValue, err := t.transformer.Transform(ctx, value)
+	if err != nil {
+		var errSingleChar *errSingleCharName
+		if errors.As(err, &errSingleChar) {
+			return string(uppercaseLetters[t.randomizer.Intn(len(uppercaseLetters))]), nil
+		}
+	}
+	return transformedValue, err
 }
 
 func (t *FirstNameTransformer) CompatibleTypes() []transformers.SupportedDataType {

--- a/pkg/transformers/neosync/neosync_firstname_transformer_test.go
+++ b/pkg/transformers/neosync/neosync_firstname_transformer_test.go
@@ -34,6 +34,27 @@ func TestFirstnameTransformer_Transform(t *testing.T) {
 			wantErr:  nil,
 		},
 		{
+			name:  "ok - length 1",
+			value: "alice",
+			params: map[string]any{
+				"max_length": 1,
+				"seed":       12,
+			},
+
+			wantName: "I",
+			wantErr:  nil,
+		},
+		{
+			name:  "error - length -1",
+			value: "alice",
+			params: map[string]any{
+				"max_length": -1,
+				"seed":       12,
+			},
+
+			wantErr: errFirstNameLengthMustBeGreaterThanZero,
+		},
+		{
 			name:  "error - invalid preserve length",
 			value: "alice",
 			params: map[string]any{

--- a/pkg/transformers/neosync/neosync_lastname_transformer_test.go
+++ b/pkg/transformers/neosync/neosync_lastname_transformer_test.go
@@ -31,6 +31,27 @@ func TestNewLastnameTransformer(t *testing.T) {
 			wantName: "Fournaris",
 		},
 		{
+			name:  "ok - length 1",
+			input: "Liddell",
+			params: map[string]any{
+				"max_length": 1,
+				"seed":       12,
+			},
+
+			wantName: "I",
+			wantErr:  nil,
+		},
+		{
+			name:  "error - length -1",
+			input: "alice",
+			params: map[string]any{
+				"max_length": -1,
+				"seed":       12,
+			},
+
+			wantErr: errLastNameLengthMustBeGreaterThanZero,
+		},
+		{
 			name: "error - invalid preserve_length",
 			params: transformers.ParameterValues{
 				"preserve_length": 123,

--- a/pkg/transformers/neosync/neosync_transformer.go
+++ b/pkg/transformers/neosync/neosync_transformer.go
@@ -8,6 +8,11 @@ import (
 	"github.com/xataio/pgstream/pkg/transformers"
 )
 
+const (
+	uppercaseLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	lowercaseLetters = "abcdefghijklmnopqrstuvwxyz"
+)
+
 // transformer is a wrapper around a neosync transformer. Neosync transformers
 // return a pointer to the type, so this implementation is generic to ensure
 // different types are supported.
@@ -30,7 +35,7 @@ func New[T any](t neosyncTransformer, opts any) *transformer[T] {
 func (t *transformer[T]) Transform(_ context.Context, value transformers.Value) (any, error) {
 	retPtr, err := t.neosyncTransformer.Transform(value.TransformValue, t.opts)
 	if err != nil {
-		return nil, err
+		return nil, mapError(err)
 	}
 
 	ret, ok := retPtr.(*T)


### PR DESCRIPTION
This PR adds the error catching mechanism for neosync transformers. As the first error to be catch, this PR catches `unable to find candidates with range` errors that are thrown by first name or last name transformers when trying to generate a name with single character. In that case we ignore the error and return a random letter as the new value.

Adding checks for `max_length` > 0 or not.

Also appending `neosync transformer:` to the beginning of all error messages that come from neosync `Transform` func.

fixes: #393 