### PR TITLE
[Snapshot] Support multi-schema snapshots

### DIFF
--- a/cmd/config/config_env.go
+++ b/cmd/config/config_env.go
@@ -196,14 +196,14 @@ func parseSnapshotListenerConfig() *snapshotbuilder.SnapshotListenerConfig {
 func parseSnapshotConfig(pgURL string) *snapshotbuilder.SnapshotListenerConfig {
 	cfg := &snapshotbuilder.SnapshotListenerConfig{
 		Generator: pgsnapshotgenerator.Config{
-			URL:           pgURL,
-			BatchPageSize: viper.GetUint("PGSTREAM_POSTGRES_SNAPSHOT_BATCH_PAGE_SIZE"),
-			SchemaWorkers: viper.GetUint("PGSTREAM_POSTGRES_SNAPSHOT_SCHEMA_WORKERS"),
-			TableWorkers:  viper.GetUint("PGSTREAM_POSTGRES_SNAPSHOT_TABLE_WORKERS"),
+			URL:             pgURL,
+			BatchPageSize:   viper.GetUint("PGSTREAM_POSTGRES_SNAPSHOT_BATCH_PAGE_SIZE"),
+			SchemaWorkers:   viper.GetUint("PGSTREAM_POSTGRES_SNAPSHOT_SCHEMA_WORKERS"),
+			TableWorkers:    viper.GetUint("PGSTREAM_POSTGRES_SNAPSHOT_TABLE_WORKERS"),
+			SnapshotWorkers: viper.GetUint("PGSTREAM_POSTGRES_SNAPSHOT_WORKERS"),
 		},
 		Adapter: adapter.SnapshotConfig{
-			Tables:          viper.GetStringSlice("PGSTREAM_POSTGRES_SNAPSHOT_TABLES"),
-			SnapshotWorkers: viper.GetUint("PGSTREAM_POSTGRES_SNAPSHOT_WORKERS"),
+			Tables: viper.GetStringSlice("PGSTREAM_POSTGRES_SNAPSHOT_TABLES"),
 		},
 		Schema: parseSchemaSnapshotConfig(pgURL),
 	}

--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -433,8 +433,7 @@ func (c *YAMLConfig) parseSnapshotConfig() (*snapshotbuilder.SnapshotListenerCon
 
 	streamCfg := &snapshotbuilder.SnapshotListenerConfig{
 		Adapter: adapter.SnapshotConfig{
-			Tables:          snapshotConfig.Tables,
-			SnapshotWorkers: uint(snapshotConfig.SnapshotWorkers),
+			Tables: snapshotConfig.Tables,
 		},
 	}
 
@@ -456,10 +455,11 @@ func (c *YAMLConfig) parseSnapshotConfig() (*snapshotbuilder.SnapshotListenerCon
 
 	if snapshotConfig.Mode == fullSnapshotMode || snapshotConfig.Mode == dataSnapshotMode {
 		streamCfg.Generator = pgsnapshotgenerator.Config{
-			URL:           c.Source.Postgres.URL,
-			BatchPageSize: uint(snapshotConfig.Data.BatchPageSize),
-			SchemaWorkers: uint(snapshotConfig.Data.SchemaWorkers),
-			TableWorkers:  uint(snapshotConfig.Data.TableWorkers),
+			URL:             c.Source.Postgres.URL,
+			BatchPageSize:   uint(snapshotConfig.Data.BatchPageSize),
+			SchemaWorkers:   uint(snapshotConfig.Data.SchemaWorkers),
+			TableWorkers:    uint(snapshotConfig.Data.TableWorkers),
+			SnapshotWorkers: uint(snapshotConfig.SnapshotWorkers),
 		}
 	}
 

--- a/cmd/config/helper_test.go
+++ b/cmd/config/helper_test.go
@@ -20,7 +20,7 @@ func validateTestStreamConfig(t *testing.T, streamConfig *stream.Config) {
 	assert.Equal(t, "pgstream_mydatabase_slot", streamConfig.Listener.Postgres.Replication.ReplicationSlotName)
 	assert.NotNil(t, streamConfig.Listener.Postgres.Snapshot)
 	assert.ElementsMatch(t, []string{"test", "test_schema.Test", "another_schema.*"}, streamConfig.Listener.Postgres.Snapshot.Adapter.Tables)
-	assert.Equal(t, uint(4), streamConfig.Listener.Postgres.Snapshot.Adapter.SnapshotWorkers)
+	assert.Equal(t, uint(4), streamConfig.Listener.Postgres.Snapshot.Generator.SnapshotWorkers)
 	assert.Equal(t, uint(4), streamConfig.Listener.Postgres.Snapshot.Generator.SchemaWorkers)
 	assert.Equal(t, uint(4), streamConfig.Listener.Postgres.Snapshot.Generator.TableWorkers)
 	assert.Equal(t, uint(1000), streamConfig.Listener.Postgres.Snapshot.Generator.BatchPageSize)

--- a/pkg/snapshot/errors.go
+++ b/pkg/snapshot/errors.go
@@ -7,98 +7,136 @@ import (
 	"strings"
 )
 
-type Errors struct {
-	SnapshotErrMsgs []string     `json:"snapshot,omitempty"`
-	Tables          []TableError `json:"tables,omitempty"`
-}
+type (
+	Errors       map[string]*SchemaErrors
+	SchemaErrors struct {
+		Schema       string            `json:"schema,omitempty"`
+		GlobalErrors []string          `json:"snapshot,omitempty"`
+		TableErrors  map[string]string `json:"tables,omitempty"`
+	}
+)
 
-type TableError struct {
-	Table    string `json:"table"`
-	ErrorMsg string `json:"error"`
-}
-
-func NewErrors(err error) *Errors {
+func NewErrors(schema string, err error) Errors {
 	if err == nil {
 		return nil
 	}
-	var snapshotErrs *Errors
-	if errors.As(err, &snapshotErrs) {
-		return snapshotErrs
+	errs := make(Errors)
+	if errors.As(err, &errs) {
+		return errs
 	}
-	return &Errors{
-		SnapshotErrMsgs: []string{err.Error()},
+	return Errors{
+		schema: NewSchemaErrors(schema, err),
 	}
 }
 
-func (e *Errors) Error() string {
+func (e Errors) GetSchemaErrors(schema string) *SchemaErrors {
+	if e == nil {
+		return nil
+	}
+
+	if errs, found := e[schema]; found {
+		return errs
+	}
+	return nil
+}
+
+func (e Errors) AddError(schema string, err error) {
+	if e == nil {
+		e = make(Errors)
+	}
+
+	schemaErrs, found := e[schema]
+	if found {
+		schemaErrs.AddGlobalError(err)
+		return
+	}
+	e[schema] = NewSchemaErrors(schema, err)
+}
+
+func (e Errors) Error() string {
+	var errMsg strings.Builder
+	for _, errs := range e {
+		errMsg.WriteString(errs.Error())
+	}
+	return errMsg.String()
+}
+
+func NewSchemaErrors(schema string, err error) *SchemaErrors {
+	if err == nil {
+		return nil
+	}
+	var schemaErrs *SchemaErrors
+	if errors.As(err, &schemaErrs) {
+		return schemaErrs
+	}
+	return &SchemaErrors{
+		Schema:       schema,
+		GlobalErrors: []string{err.Error()},
+	}
+}
+
+func (e *SchemaErrors) Error() string {
 	if e == nil {
 		return ""
 	}
-	errMsgs := make([]string, 0, len(e.SnapshotErrMsgs))
-	errMsgs = append(errMsgs, e.SnapshotErrMsgs...)
+	errMsgs := make([]string, 0, len(e.GlobalErrors))
+	errMsgs = append(errMsgs, e.GlobalErrors...)
 
-	for _, table := range e.Tables {
-		errMsgs = append(errMsgs, table.Error())
+	for table, errMsg := range e.TableErrors {
+		errMsgs = append(errMsgs, table+": "+errMsg)
 	}
-	return strings.Join(errMsgs, ";")
+	return e.Schema + ": " + strings.Join(errMsgs, ";")
 }
 
-func (e *Errors) AddSnapshotError(err error) {
+func (e *SchemaErrors) AddGlobalError(err error) {
 	if e == nil {
 		return
 	}
-	if e.SnapshotErrMsgs == nil {
-		e.SnapshotErrMsgs = []string{err.Error()}
+
+	e.GlobalErrors = append(e.GlobalErrors, err.Error())
+}
+
+func (e *SchemaErrors) AddTableError(table string, err error) {
+	if e == nil || err == nil {
 		return
 	}
-	e.SnapshotErrMsgs = append(e.SnapshotErrMsgs, err.Error())
+
+	if e.TableErrors == nil {
+		e.TableErrors = make(map[string]string)
+	}
+
+	e.TableErrors[table] = err.Error()
 }
 
-func (e *Errors) IsSnapshotError() bool {
-	return e != nil && len(e.SnapshotErrMsgs) > 0
+func (e *SchemaErrors) IsGlobalError() bool {
+	return e != nil && len(e.GlobalErrors) > 0
 }
 
-func (e *Errors) IsTableError(table string) bool {
+func (e *SchemaErrors) IsTableError(table string) bool {
 	if e == nil {
 		return false
 	}
 
-	if e.SnapshotErrMsgs != nil {
+	if len(e.GlobalErrors) > 0 {
 		return true
 	}
 
 	// treat wildcard table errors as true if there are any table errors.
-	if table == "*" && len(e.Tables) > 0 {
+	if table == "*" && len(e.TableErrors) > 0 {
 		return true
 	}
 
-	for _, tableErr := range e.Tables {
-		if tableErr.Table == table {
-			return true
-		}
-	}
-	return false
+	_, found := e.TableErrors[table]
+	return found
 }
 
-func (e *Errors) GetFailedTables() []string {
+func (e *SchemaErrors) GetFailedTables() []string {
 	if e == nil {
 		return nil
 	}
-	failedTables := make([]string, 0, len(e.Tables))
-	for _, table := range e.Tables {
-		failedTables = append(failedTables, table.Table)
+	failedTables := make([]string, 0, len(e.TableErrors))
+	for table := range e.TableErrors {
+		failedTables = append(failedTables, table)
 	}
 	return failedTables
-}
-
-func NewTableError(table string, err error) TableError {
-	errMsg := ""
-	if err != nil {
-		errMsg = err.Error()
-	}
-	return TableError{Table: table, ErrorMsg: errMsg}
-}
-
-func (e TableError) Error() string {
-	return e.Table + ": " + e.ErrorMsg
 }

--- a/pkg/snapshot/generator/instrumentation/instrumented_snapshot_generator.go
+++ b/pkg/snapshot/generator/instrumentation/instrumented_snapshot_generator.go
@@ -87,11 +87,11 @@ func (i *SnapshotGenerator) snapshotAttributes(s *snapshot.Snapshot) []attribute
 	return []attribute.KeyValue{
 		{
 			Key:   snapshotSchemaAttributeKey,
-			Value: attribute.StringValue(s.SchemaName),
+			Value: attribute.StringSliceValue(s.GetSchemas()),
 		},
 		{
 			Key:   snapshotTablesAttributeKey,
-			Value: attribute.StringSliceValue(s.TableNames),
+			Value: attribute.StringSliceValue(s.GetTables()),
 		},
 	}
 }

--- a/pkg/snapshot/generator/postgres/data/config.go
+++ b/pkg/snapshot/generator/postgres/data/config.go
@@ -8,6 +8,10 @@ type Config struct {
 	// BatchPageSize represents the size of the table page range that will be
 	// processed concurrently by the table workers. Defaults to 1000.
 	BatchPageSize uint
+	// SnapshotWorkers represents the number of snapshots the generator will
+	// process concurrently. This doesn't affect the parallelism of the tables
+	// within each individual snapshot request. It defaults to 1.
+	SnapshotWorkers uint
 	// SchemaWorkers represents the number of tables the snapshot generator will
 	// process concurrently per schema. Defaults to 4.
 	SchemaWorkers uint
@@ -17,9 +21,10 @@ type Config struct {
 }
 
 const (
-	defaultBatchPageSize = 1000
-	defaultTableWorkers  = 4
-	defaultSchemaWorkers = 4
+	defaultBatchPageSize   = 1000
+	defaultTableWorkers    = 4
+	defaultSchemaWorkers   = 4
+	defaultSnapshotWorkers = 1
 )
 
 func (c *Config) batchPageSize() uint {
@@ -41,4 +46,11 @@ func (c *Config) tableWorkers() uint {
 		return c.TableWorkers
 	}
 	return defaultTableWorkers
+}
+
+func (c *Config) snapshotWorkers() uint {
+	if c.SnapshotWorkers > 0 {
+		return c.SnapshotWorkers
+	}
+	return defaultSnapshotWorkers
 }

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_integration_test.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_integration_test.go
@@ -45,8 +45,9 @@ func Test_PostgresSnapshotGenerator(t *testing.T) {
 
 	go func() {
 		err = generator.CreateSnapshot(ctx, &snapshot.Snapshot{
-			SchemaName: "public",
-			TableNames: []string{testTable},
+			SchemaTables: map[string][]string{
+				"public": {testTable},
+			},
 		})
 		require.NoError(t, err)
 		mockProcessor.Close()

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_test.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_test.go
@@ -908,16 +908,3 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 		})
 	}
 }
-
-// func sortSnapshotTableErrors(err error) error {
-// 	var snapshotErrs snapshot.Errors
-// 	if errors.As(err, &snapshotErrs) {
-// 		for _, schemaErrs := range snapshotErrs {
-// 			sort.Slice(schemaErrs.Tables, func(i, j int) bool {
-// 				return snapshotErrs.Tables[i].Table < snapshotErrs.Tables[j].Table
-// 			})
-// 		}
-// 		return snapshotErrs
-// 	}
-// 	return err
-// }

--- a/pkg/snapshot/generator/postgres/tablefinder/pg_snapshot_table_finder.go
+++ b/pkg/snapshot/generator/postgres/tablefinder/pg_snapshot_table_finder.go
@@ -64,11 +64,13 @@ func WithInstrumentation(i *otel.Instrumentation) Option {
 }
 
 func (s *SnapshotTableFinder) CreateSnapshot(ctx context.Context, ss *snapshot.Snapshot) error {
-	if slices.Contains(ss.TableNames, wildcard) {
-		var err error
-		ss.TableNames, err = s.discoveryFn(ctx, s.conn, ss.SchemaName)
-		if err != nil {
-			return err
+	for schema, tables := range ss.SchemaTables {
+		if slices.Contains(tables, wildcard) {
+			var err error
+			ss.SchemaTables[schema], err = s.discoveryFn(ctx, s.conn, schema)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return s.wrapped.CreateSnapshot(ctx, ss)

--- a/pkg/snapshot/generator/postgres/tablefinder/pg_snapshot_table_finder_test.go
+++ b/pkg/snapshot/generator/postgres/tablefinder/pg_snapshot_table_finder_test.go
@@ -23,8 +23,9 @@ func TestSnapshotTableFinder_CreateSnapshot(t *testing.T) {
 
 	newTestSnapshot := func(tables []string) *snapshot.Snapshot {
 		return &snapshot.Snapshot{
-			SchemaName: testSchema,
-			TableNames: tables,
+			SchemaTables: map[string][]string{
+				testSchema: tables,
+			},
 		}
 	}
 
@@ -70,8 +71,9 @@ func TestSnapshotTableFinder_CreateSnapshot(t *testing.T) {
 				},
 			},
 			snapshot: &snapshot.Snapshot{
-				SchemaName: testSchema,
-				TableNames: []string{wildcard},
+				SchemaTables: map[string][]string{
+					testSchema: {wildcard},
+				},
 			},
 			generator: &mocks.Generator{
 				CreateSnapshotFn: func(ctx context.Context, snapshot *snapshot.Snapshot) error {
@@ -103,8 +105,9 @@ func TestSnapshotTableFinder_CreateSnapshot(t *testing.T) {
 				},
 			},
 			snapshot: &snapshot.Snapshot{
-				SchemaName: testSchema,
-				TableNames: []string{"table-a", "table-b", wildcard},
+				SchemaTables: map[string][]string{
+					testSchema: {"table-a", "table-b", wildcard},
+				},
 			},
 			generator: &mocks.Generator{
 				CreateSnapshotFn: func(ctx context.Context, snapshot *snapshot.Snapshot) error {
@@ -125,8 +128,9 @@ func TestSnapshotTableFinder_CreateSnapshot(t *testing.T) {
 				},
 			},
 			snapshot: &snapshot.Snapshot{
-				SchemaName: testSchema,
-				TableNames: []string{"table-a", "table-b", wildcard},
+				SchemaTables: map[string][]string{
+					testSchema: {"table-a", "table-b", wildcard},
+				},
 			},
 			generator: &mocks.Generator{
 				CreateSnapshotFn: func(ctx context.Context, snapshot *snapshot.Snapshot) error {
@@ -153,8 +157,9 @@ func TestSnapshotTableFinder_CreateSnapshot(t *testing.T) {
 				},
 			},
 			snapshot: &snapshot.Snapshot{
-				SchemaName: testSchema,
-				TableNames: []string{"table-a", "table-b", wildcard},
+				SchemaTables: map[string][]string{
+					testSchema: {"table-a", "table-b", wildcard},
+				},
 			},
 			generator: &mocks.Generator{
 				CreateSnapshotFn: func(ctx context.Context, snapshot *snapshot.Snapshot) error {
@@ -178,8 +183,9 @@ func TestSnapshotTableFinder_CreateSnapshot(t *testing.T) {
 				},
 			},
 			snapshot: &snapshot.Snapshot{
-				SchemaName: testSchema,
-				TableNames: []string{"table-a", "table-b", wildcard},
+				SchemaTables: map[string][]string{
+					testSchema: {"table-a", "table-b", wildcard},
+				},
 			},
 			generator: &mocks.Generator{
 				CreateSnapshotFn: func(ctx context.Context, snapshot *snapshot.Snapshot) error {

--- a/pkg/snapshot/generator/snapshot_generator_recorder.go
+++ b/pkg/snapshot/generator/snapshot_generator_recorder.go
@@ -4,11 +4,13 @@ package generator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/xataio/pgstream/pkg/snapshot"
 	snapshotstore "github.com/xataio/pgstream/pkg/snapshot/store"
+	"golang.org/x/sync/errgroup"
 )
 
 // SnapshotRecorder is a decorator around a snapshot generator that will record
@@ -33,28 +35,26 @@ func NewSnapshotRecorder(store snapshotstore.Store, generator SnapshotGenerator,
 }
 
 func (s *SnapshotRecorder) CreateSnapshot(ctx context.Context, ss *snapshot.Snapshot) error {
-	filteredTables, err := s.filterOutExistingSnapshots(ctx, ss.SchemaName, ss.TableNames)
+	var err error
+	ss.SchemaTables, err = s.filterOutExistingSnapshots(ctx, ss.SchemaTables)
 	if err != nil {
-		return snapshot.NewErrors(err)
+		return err
 	}
 
 	// no tables to snapshot
-	if len(filteredTables) == 0 {
+	if !ss.HasTables() {
 		return nil
 	}
 
-	ss.TableNames = filteredTables
-	req := &snapshot.Request{
-		Snapshot: *ss,
-	}
+	requests := s.createRequests(ss)
 
-	if err := s.markSnapshotInProgress(ctx, req); err != nil {
-		return snapshot.NewErrors(err)
+	if err := s.markSnapshotInProgress(ctx, requests); err != nil {
+		return err
 	}
 
 	err = s.wrapped.CreateSnapshot(ctx, ss)
 
-	return s.markSnapshotCompleted(ctx, req, err)
+	return s.markSnapshotCompleted(ctx, requests, err)
 }
 
 func (s *SnapshotRecorder) Close() error {
@@ -62,16 +62,36 @@ func (s *SnapshotRecorder) Close() error {
 	return s.wrapped.Close()
 }
 
-func (s *SnapshotRecorder) markSnapshotInProgress(ctx context.Context, req *snapshot.Request) error {
-	if err := s.store.CreateSnapshotRequest(ctx, req); err != nil {
-		return err
+func (s *SnapshotRecorder) createRequests(ss *snapshot.Snapshot) []*snapshot.Request {
+	requests := make([]*snapshot.Request, 0, len(ss.SchemaTables))
+	for schema, tables := range ss.SchemaTables {
+		req := &snapshot.Request{
+			Schema: schema,
+			Tables: tables,
+		}
+		requests = append(requests, req)
 	}
-	// the snapshot will start immediately
-	req.MarkInProgress()
-	return s.store.UpdateSnapshotRequest(ctx, req)
+	return requests
 }
 
-func (s *SnapshotRecorder) markSnapshotCompleted(ctx context.Context, req *snapshot.Request, err error) error {
+func (s *SnapshotRecorder) markSnapshotInProgress(ctx context.Context, requests []*snapshot.Request) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	// create one request per schema
+	for _, req := range requests {
+		eg.Go(func() error {
+			if err := s.store.CreateSnapshotRequest(ctx, req); err != nil {
+				return err
+			}
+			// the snapshot will start immediately
+			req.MarkInProgress()
+			return s.store.UpdateSnapshotRequest(ctx, req)
+		})
+	}
+
+	return eg.Wait()
+}
+
+func (s *SnapshotRecorder) markSnapshotCompleted(ctx context.Context, requests []*snapshot.Request, err error) error {
 	// make sure we can update the request status in the store regardless of
 	// context cancelations
 	if ctx.Err() != nil {
@@ -80,24 +100,58 @@ func (s *SnapshotRecorder) markSnapshotCompleted(ctx context.Context, req *snaps
 	ctx, cancel := context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
-	req.MarkCompleted(err)
-	if updateErr := s.store.UpdateSnapshotRequest(ctx, req); updateErr != nil {
+	getSchemaErrors := func(schema string, err error) *snapshot.SchemaErrors {
 		if err == nil {
-			return snapshot.NewErrors(updateErr)
+			return nil
 		}
-		snapshotErr := snapshot.NewErrors(err)
-		snapshotErr.AddSnapshotError(updateErr)
-		return snapshotErr
+		snapshotErr := &snapshot.Errors{}
+		if errors.As(err, &snapshotErr) {
+			return snapshotErr.GetSchemaErrors(schema)
+		}
+		return snapshot.NewSchemaErrors(schema, err)
+	}
+
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, req := range requests {
+		eg.Go(func() error {
+			schemaErrs := getSchemaErrors(req.Schema, err)
+			req.MarkCompleted(req.Schema, schemaErrs)
+			if updateErr := s.store.UpdateSnapshotRequest(ctx, req); updateErr != nil {
+				if err == nil {
+					return updateErr
+				}
+				schemaErrs.AddGlobalError(updateErr)
+			}
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return err
 	}
 	return err
 }
 
-func (s *SnapshotRecorder) filterOutExistingSnapshots(ctx context.Context, schema string, tables []string) ([]string, error) {
+func (s *SnapshotRecorder) filterOutExistingSnapshots(ctx context.Context, schemaTables map[string][]string) (map[string][]string, error) {
 	// if we want to be able to repeat snapshots, we don't filter out existing ones
 	if s.repeatableSnapshots {
-		return tables, nil
+		return schemaTables, nil
 	}
 
+	filteredSchemaTables := make(map[string][]string, len(schemaTables))
+	for schema, tables := range schemaTables {
+		filteredTables, err := s.filterOutExistingSchemaTables(ctx, schema, tables)
+		if err != nil {
+			return nil, fmt.Errorf("filtering existing snapshots for schema %s: %w", schema, err)
+		}
+		if len(filteredTables) > 0 {
+			filteredSchemaTables[schema] = filteredTables
+		}
+	}
+	return filteredSchemaTables, nil
+}
+
+func (s *SnapshotRecorder) filterOutExistingSchemaTables(ctx context.Context, schema string, tables []string) ([]string, error) {
 	snapshotRequests, err := s.store.GetSnapshotRequestsBySchema(ctx, schema)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving existing snapshots for schema: %w", err)
@@ -109,7 +163,7 @@ func (s *SnapshotRecorder) filterOutExistingSnapshots(ctx context.Context, schem
 
 	existingRequests := map[string]*snapshot.Request{}
 	for _, req := range snapshotRequests {
-		for _, table := range req.Snapshot.TableNames {
+		for _, table := range req.Tables {
 			existingRequests[table] = req
 		}
 	}
@@ -120,7 +174,7 @@ func (s *SnapshotRecorder) filterOutExistingSnapshots(ctx context.Context, schem
 		wildCardReq, wildcardFound := existingRequests[wildcard]
 		switch table {
 		case wildcard:
-			if wildcardFound && !wildCardReq.Errors.IsSnapshotError() {
+			if wildcardFound && !wildCardReq.Errors.IsGlobalError() {
 				filteredTables = append(filteredTables, wildCardReq.Errors.GetFailedTables()...)
 				break
 			}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -7,8 +7,7 @@ import (
 )
 
 type Snapshot struct {
-	SchemaName string
-	TableNames []string
+	SchemaTables map[string][]string
 }
 
 type Request struct {
@@ -44,8 +43,43 @@ const (
 	StatusCompleted  = Status("completed")
 )
 
-func (s *Snapshot) IsValid() bool {
-	return s != nil && s.SchemaName != "" && len(s.TableNames) > 0
+func (s *Snapshot) GetSchemas() []string {
+	if s == nil {
+		return nil
+	}
+
+	schemas := make([]string, 0, len(s.SchemaTables))
+	for schema := range s.SchemaTables {
+		schemas = append(schemas, schema)
+	}
+	return schemas
+}
+
+func (s *Snapshot) GetTables() []string {
+	if s == nil {
+		return nil
+	}
+
+	tables := []string{}
+	for schema, tables := range s.SchemaTables {
+		for _, table := range tables {
+			tables = append(tables, schema+"."+table)
+		}
+	}
+	return tables
+}
+
+func (s *Snapshot) HasTables() bool {
+	if s == nil {
+		return false
+	}
+
+	for _, tables := range s.SchemaTables {
+		if len(tables) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Request) MarkCompleted(err error) {

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -11,9 +11,10 @@ type Snapshot struct {
 }
 
 type Request struct {
-	Snapshot Snapshot
-	Status   Status
-	Errors   *Errors
+	Schema string
+	Tables []string
+	Status Status
+	Errors *SchemaErrors
 }
 
 type Row struct {
@@ -82,9 +83,9 @@ func (s *Snapshot) HasTables() bool {
 	return false
 }
 
-func (r *Request) MarkCompleted(err error) {
+func (r *Request) MarkCompleted(schema string, err error) {
 	r.Status = StatusCompleted
-	r.Errors = NewErrors(err)
+	r.Errors = NewSchemaErrors(schema, err)
 }
 
 func (r *Request) MarkInProgress() {

--- a/pkg/snapshot/store/instrumentation/instrumented_snapshot_store.go
+++ b/pkg/snapshot/store/instrumentation/instrumented_snapshot_store.go
@@ -65,8 +65,8 @@ func (i *Store) Close() error {
 
 func (i *Store) requestAttributes(req *snapshot.Request) []attribute.KeyValue {
 	return []attribute.KeyValue{
-		{Key: "schema", Value: attribute.StringValue(req.Snapshot.SchemaName)},
-		{Key: "tables", Value: attribute.StringSliceValue(req.Snapshot.TableNames)},
+		{Key: "schema", Value: attribute.StringValue(req.Schema)},
+		{Key: "tables", Value: attribute.StringSliceValue(req.Tables)},
 		{Key: "status", Value: attribute.StringValue(string(req.Status))},
 	}
 }

--- a/pkg/wal/listener/snapshot/adapter/config.go
+++ b/pkg/wal/listener/snapshot/adapter/config.go
@@ -8,13 +8,7 @@ import (
 
 type SnapshotConfig struct {
 	Tables []string
-	// SnapshotWorkers represents the number of snapshots the generator will
-	// process concurrently. This doesn't affect the parallelism of the tables
-	// within each individual snapshot request. It defaults to 1.
-	SnapshotWorkers uint
 }
-
-const defaultSnapshotWorkers = 1
 
 const publicSchema = "public"
 
@@ -31,11 +25,4 @@ func (c *SnapshotConfig) schemaTableMap() map[string][]string {
 		schemaTableMap[schemaName] = append(schemaTableMap[schemaName], tableName)
 	}
 	return schemaTableMap
-}
-
-func (c *SnapshotConfig) snapshotWorkers() uint {
-	if c.SnapshotWorkers > 0 {
-		return c.SnapshotWorkers
-	}
-	return defaultSnapshotWorkers
 }

--- a/pkg/wal/listener/snapshot/adapter/wal_snapshot_generator_adapter_test.go
+++ b/pkg/wal/listener/snapshot/adapter/wal_snapshot_generator_adapter_test.go
@@ -31,8 +31,9 @@ func TestSnapshotGeneratorAdapter_CreateSnapshot(t *testing.T) {
 			generator: &generatormocks.Generator{
 				CreateSnapshotFn: func(ctx context.Context, ss *snapshot.Snapshot) error {
 					require.Equal(t, &snapshot.Snapshot{
-						SchemaName: publicSchema,
-						TableNames: []string{"*"},
+						SchemaTables: map[string][]string{
+							publicSchema: {"*"},
+						},
 					}, ss)
 					return nil
 				},
@@ -63,10 +64,9 @@ func TestSnapshotGeneratorAdapter_CreateSnapshot(t *testing.T) {
 			t.Parallel()
 
 			ga := SnapshotGeneratorAdapter{
-				logger:          log.NewNoopLogger(),
-				generator:       tc.generator,
-				schemaTables:    tc.schemaTables,
-				snapshotWorkers: 1,
+				logger:       log.NewNoopLogger(),
+				generator:    tc.generator,
+				schemaTables: tc.schemaTables,
 			}
 			defer ga.Close()
 


### PR DESCRIPTION
This PR updates the snapshot interface to support providing multiple schemas per snapshot. This will allow to perform the pg_dump of different schemas together to prevent missing dependencies, since it currently performs separate dumps that will fail if they are dependent on each other. 

This fixes https://github.com/xataio/xata-actions-demo/actions/runs/15486471181/job/43602182511.

The main changes are the switch from handling a single schema/tables to handling multiple. Most of the logic remains the same. Main changes:

- The wal snapshot adapter logic is moved to the data snapshot generator, since it's the one that will now parallelise the schema processing
- The pgdump/pgrestore schema snapshot generator is updated to provide the options for all schemas and their tables
- The snapshot requests remain at the schema level to maintain readability
- The snapshot errors are updated to register per schema errors

It's a pretty large PR, since the `Snapshot` type has been modified, so the commits are split to update each of the different dependent implementations separately. 