### PR TITLE
[Snapshot] Data progress tracking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/pterm/pterm v0.12.81
 	github.com/rs/xid v1.6.0
 	github.com/rs/zerolog v1.34.0
+	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/segmentio/kafka-go v0.4.48
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
@@ -111,6 +112,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F9
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=
+github.com/chengxilo/virtualterm v1.0.4/go.mod h1:DyxxBZz/x1iqJjFxTFcr6/x+jSpqN0iwWCOK1q10rlY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
 github.com/cloudwego/base64x v0.1.5/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
@@ -290,6 +292,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=
 github.com/mdelapenya/tlscert v0.2.0/go.mod h1:O4njj3ELLnJjGdkN7M/vIVCpZ+Cf0L6muqOG4tLSl8o=
+github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
+github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
@@ -378,6 +382,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
+github.com/schollz/progressbar/v3 v3.18.0 h1:uXdoHABRFmNIjUfte/Ex7WtuyVslrw2wVPQmCN62HpA=
+github.com/schollz/progressbar/v3 v3.18.0/go.mod h1:IsO3lpbaGuzh8zIMzgY3+J8l4C8GjO0Y9S69eFvNsec=
 github.com/segmentio/kafka-go v0.4.48 h1:9jyu9CWK4W5W+SroCe8EffbrRZVqAOkuaLd/ApID4Vs=
 github.com/segmentio/kafka-go v0.4.48/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=

--- a/internal/postgres/pg_restore.go
+++ b/internal/postgres/pg_restore.go
@@ -93,7 +93,7 @@ func RunPGRestore(ctx context.Context, opts PGRestoreOptions, dump []byte) (stri
 	// TODO: add streaming support when large data output is required
 	out, err := cmd.CombinedOutput()
 	if err != nil || strings.Contains(string(out), "ERROR") {
-		return "", fmt.Errorf("error running pg_restore: %w", parsePgRestoreOutputErrs(out))
+		return "", fmt.Errorf("error restoring dump: %w", parsePgRestoreOutputErrs(out))
 	}
 
 	return string(out), nil

--- a/internal/progress/mocks/mock_progress_bar.go
+++ b/internal/progress/mocks/mock_progress_bar.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mocks
+
+type Bar struct {
+	AddFn   func(int) error
+	Add64Fn func(int64) error
+	CloseFn func() error
+}
+
+func (b *Bar) Add(n int) error {
+	if b.AddFn != nil {
+		return b.AddFn(n)
+	}
+	return nil
+}
+
+func (b *Bar) Add64(n int64) error {
+	if b.Add64Fn != nil {
+		return b.Add64Fn(n)
+	}
+	return nil
+}
+
+func (b *Bar) Close() error {
+	if b.CloseFn != nil {
+		return b.CloseFn()
+	}
+	return nil
+}

--- a/internal/progress/progress_bar.go
+++ b/internal/progress/progress_bar.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package progress
+
+import (
+	"fmt"
+
+	"github.com/schollz/progressbar/v3"
+)
+
+type Bar interface {
+	Add(int) error
+	Add64(int64) error
+	Close() error
+}
+
+type ProgressBar struct {
+	*progressbar.ProgressBar
+}
+
+func NewBar(max int, opts ...progressbar.Option) *ProgressBar {
+	return &ProgressBar{
+		ProgressBar: progressbar.NewOptions(max, opts...),
+	}
+}
+
+func NewBytesBar(totalBytes int64, description string) *ProgressBar {
+	return &ProgressBar{
+		ProgressBar: progressbar.NewOptions64(totalBytes,
+			progressbar.OptionShowCount(),
+			progressbar.OptionSetRenderBlankState(true),
+			progressbar.OptionSetPredictTime(true),
+			progressbar.OptionSetWidth(20),
+			progressbar.OptionSetPredictTime(true),
+			progressbar.OptionEnableColorCodes(true),
+			progressbar.OptionShowBytes(true),
+			progressbar.OptionShowTotalBytes(true),
+			progressbar.OptionShowElapsedTimeOnFinish(),
+			progressbar.OptionSetDescription(description),
+			progressbar.OptionOnCompletion(func() {
+				fmt.Printf("\n") //nolint:forbidigo
+			}),
+			progressbar.OptionSetTheme(progressbar.Theme{
+				Saucer:        "[green]=[reset]",
+				SaucerHead:    "[green]>[reset]",
+				SaucerPadding: " ",
+				BarStart:      "[",
+				BarEnd:        "]",
+			})),
+	}
+}

--- a/pkg/snapshot/generator/postgres/data/instrumented_table_snapshot_generator.go
+++ b/pkg/snapshot/generator/postgres/data/instrumented_table_snapshot_generator.go
@@ -22,11 +22,11 @@ func newInstrumentedTableSnapshotGenerator(fn snapshotTableFn, i *otel.Instrumen
 	}
 }
 
-func (i *instrumentedTableSnapshotGenerator) snapshotTable(ctx context.Context, snapshotID string, schema, table string) (err error) {
+func (i *instrumentedTableSnapshotGenerator) snapshotTable(ctx context.Context, snapshotID string, table *table) (err error) {
 	ctx, span := otel.StartSpan(ctx, i.tracer, "tableSnapshotGenerator.SnapshotTable", trace.WithAttributes([]attribute.KeyValue{
-		{Key: "schema", Value: attribute.StringValue(schema)},
-		{Key: "table", Value: attribute.StringValue(table)},
+		{Key: "schema", Value: attribute.StringValue(table.schema)},
+		{Key: "table", Value: attribute.StringValue(table.name)},
 	}...))
 	defer otel.CloseSpan(span, err)
-	return i.snapshotTableFn(ctx, snapshotID, schema, table)
+	return i.snapshotTableFn(ctx, snapshotID, table)
 }

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator.go
@@ -462,7 +462,7 @@ func (sg *SnapshotGenerator) getTableInfo(ctx context.Context, schemaName, table
 	return tableInfo, nil
 }
 
-const tablesBytesQuery = `SELECT SUM(pg_relation_size(c.oid)) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = '%s' AND c.relname IN (%s) AND c.relkind = 'r';`
+const tablesBytesQuery = `SELECT SUM(pg_table_size(c.oid)) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = '%s' AND c.relname IN (%s) AND c.relkind = 'r';`
 
 func (sg *SnapshotGenerator) getSnapshotSchemaTotalBytes(ctx context.Context, snapshotID, schema string, tables []string) (int64, error) {
 	paramRefs := make([]string, 0, len(tables))

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -237,7 +237,7 @@ func (s *SnapshotGenerator) restoreDump(ctx context.Context, schemaTables map[st
 				return err
 			}
 			ignoredErrors := pgrestoreErr.GetIgnoredErrors()
-			s.logger.Warn(nil, fmt.Sprintf("pg_restore: %d errors ignored", len(ignoredErrors)), loglib.Fields{"errors_ignored": ignoredErrors})
+			s.logger.Warn(nil, fmt.Sprintf("restore: %d errors ignored", len(ignoredErrors)), loglib.Fields{"errors_ignored": ignoredErrors})
 		default:
 			return err
 		}

--- a/pkg/wal/listener/snapshot/builder/wal_listener_snapshot_generator_builder.go
+++ b/pkg/wal/listener/snapshot/builder/wal_listener_snapshot_generator_builder.go
@@ -57,6 +57,7 @@ func NewSnapshotGenerator(ctx context.Context, cfg *SnapshotListenerConfig, p li
 	// postgres data snapshot generator layer
 	opts := []pgsnapshotgenerator.Option{
 		pgsnapshotgenerator.WithLogger(logger),
+		pgsnapshotgenerator.WithProgressTracking(),
 	}
 	if instrumentation.IsEnabled() {
 		opts = append(opts, pgsnapshotgenerator.WithInstrumentation(instrumentation))


### PR DESCRIPTION
This PR adds progress tracking to the data snapshots. The initial idea was to have a progress bar for each table being snapshotted. However, libraries supporting multiple progress bars ([multibar](https://github.com/sethgrid/multibar), [mpb](https://github.com/vbauerster/mpb) and [uiprogress](https://github.com/gosuri/uiprogress)) didn't show the progress properly, duplicating the result rather than updating the existing bar. 

Instead, this PR reports the progress for all tables in a schema in the same progress bar, using the [progressbar](https://github.com/schollz/progressbar) library.

The progress uses the total bytes for the snapshotted tables (using `pg_table_size` to avoid including indices which are snapshotted separately), and the average row bytes to calculate the progress made by each batch.

The logging of intermediate table snapshotting steps has been downgraded from `INFO` to `DEBUG` in favour of relying on the progress bar. 


Fixes #286 