### PR TITLE
Fix placeholderOffset for update queries

### DIFF
--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
@@ -111,7 +111,7 @@ func (a *dmlAdapter) buildUpdateQuery(d *wal.Data, generatedColumns []string) (*
 	if setQuery == "" {
 		return &query{}, nil
 	}
-	whereQuery, whereValues, err := a.buildWhereQuery(d, len(d.Columns))
+	whereQuery, whereValues, err := a.buildWhereQuery(d, len(rowColumns))
 	if err != nil {
 		return nil, fmt.Errorf("building update query: %w", err)
 	}


### PR DESCRIPTION
When building UPDATE queries, arg count in the WHERE clause must start from the arg count used in the SET clause. We currently start it from the total column count, resulting error when there's a generated column that is skipped in the SET clause.
Also adding a test for generating update query with a generated column.