### PR TITLE
Fix snapshot required tables

### DIFF
--- a/pkg/stream/config.go
+++ b/pkg/stream/config.go
@@ -158,7 +158,12 @@ func (c *Config) PostgresReplicationSlot() string {
 func (c *Config) RequiredTables() []string {
 	requiredTables := []string{}
 	if c.Listener.Snapshot != nil {
-		requiredTables = c.Listener.Snapshot.Adapter.Tables
+		requiredTables = append(requiredTables, c.Listener.Snapshot.Adapter.Tables...)
+	}
+	if c.Listener.Postgres != nil {
+		if c.Listener.Postgres.Snapshot != nil {
+			requiredTables = append(requiredTables, c.Listener.Postgres.Snapshot.Adapter.Tables...)
+		}
 	}
 	// TODO: add included tables for the replication case as well
 	return requiredTables

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
@@ -134,7 +134,8 @@ func (v *PostgresTransformerParser) validateAllRequiredTables(ctx context.Contex
 
 func (v *PostgresTransformerParser) getRequiredTablesList(ctx context.Context) ([]string, error) {
 	schemaTablesList := []string{}
-	for _, table := range v.requiredTables {
+	for i := 0; i < len(v.requiredTables); i++ {
+		table := v.requiredTables[i]
 		schemaName, tableName, err := parseTableName(table)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Add `c.Listener.Postgres.Snapshot.Adapter.Tables` as required tables as well, to cover snapshot+replication scenario