### PR TITLE
[Postgres Writer] Create schema if not exists

### DIFF
--- a/pkg/wal/listener/snapshot/builder/wal_listener_snapshot_generator_builder.go
+++ b/pkg/wal/listener/snapshot/builder/wal_listener_snapshot_generator_builder.go
@@ -124,7 +124,8 @@ func newSchemaSnapshotGenerator(ctx context.Context, cfg *SchemaSnapshotConfig, 
 		return schemalogsnapshotgenerator.NewSnapshotGenerator(
 			schemaLogStore,
 			processRow,
-			schemalogsnapshotgenerator.WithSnapshotGenerator(g)), nil
+			schemalogsnapshotgenerator.WithSnapshotGenerator(g),
+			schemalogsnapshotgenerator.WithLogger(logger)), nil
 	case cfg.DumpRestore != nil:
 		// postgres pgdump/pgrestore schema snapshot generator
 		opts := []pgdumprestoregenerator.Option{

--- a/pkg/wal/processor/postgres/postgres_wal_ddl_adapter_test.go
+++ b/pkg/wal/processor/postgres/postgres_wal_ddl_adapter_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rs/xid"
 	"github.com/stretchr/testify/require"
+	pglib "github.com/xataio/pgstream/internal/postgres"
 	"github.com/xataio/pgstream/pkg/schemalog"
 	schemalogmocks "github.com/xataio/pgstream/pkg/schemalog/mocks"
 )
@@ -67,6 +68,11 @@ func TestDDLAdapter_walDataToQueries(t *testing.T) {
 			wantQueries: []*query{
 				{
 					schema: testSchema,
+					sql:    fmt.Sprintf(createSchemaIfNotExistsQuery, pglib.QuoteIdentifier(testSchema)),
+					isDDL:  true,
+				},
+				{
+					schema: testSchema,
 					table:  table2,
 					sql:    fmt.Sprintf("ALTER TABLE %s RENAME TO %s", quotedTableName(testSchema, table1), table2),
 					isDDL:  true,
@@ -99,6 +105,11 @@ func TestDDLAdapter_walDataToQueries(t *testing.T) {
 			logEntry: testLogEntry(1),
 
 			wantQueries: []*query{
+				{
+					schema: testSchema,
+					sql:    fmt.Sprintf(createSchemaIfNotExistsQuery, pglib.QuoteIdentifier(testSchema)),
+					isDDL:  true,
+				},
 				{
 					schema: testSchema,
 					table:  table2,


### PR DESCRIPTION
Currently any non `public` schemas are not replicated to postgres, since the `CREATE SCHEMA` query is not executed. This affects both the schema snapshot in `schemalog` mode and the replication to postgres.

This PR updates the DDL adapter to create the schema if it doesn't exist when receiving a DDL event. It also fixes the condition to not add `DEFAULT` statements in table creation to generated columns.