### PR TITLE
[Snapshot] Fix pg_dump multi schema support

### DIFF
--- a/pkg/wal/listener/snapshot/builder/wal_listener_snapshot_generator_builder.go
+++ b/pkg/wal/listener/snapshot/builder/wal_listener_snapshot_generator_builder.go
@@ -67,6 +67,17 @@ func NewSnapshotGenerator(ctx context.Context, cfg *SnapshotListenerConfig, p li
 		return nil, err
 	}
 
+	// snapshot table finder layer
+	finderOpts := []pgtablefinder.Option{}
+	if instrumentation.IsEnabled() {
+		finderOpts = append(finderOpts, pgtablefinder.WithInstrumentation(instrumentation))
+	}
+
+	g, err = pgtablefinder.NewSnapshotSchemaTableFinder(ctx, cfg.Generator.URL, g, finderOpts...)
+	if err != nil {
+		return nil, err
+	}
+
 	// postgres schema snapshot generator layer
 	g, err = newSchemaSnapshotGenerator(ctx, &cfg.Schema, g, rowsProcessor.ProcessRow, logger, instrumentation)
 	if err != nil {
@@ -84,17 +95,6 @@ func NewSnapshotGenerator(ctx context.Context, cfg *SnapshotListenerConfig, p li
 			snapshotStore = snapshotstoreinstrumentation.NewStore(snapshotStore, instrumentation)
 		}
 		g = generator.NewSnapshotRecorder(snapshotStore, g, cfg.Recorder.RepeatableSnapshots)
-	}
-
-	// snapshot table finder layer
-	finderOpts := []pgtablefinder.Option{}
-	if instrumentation.IsEnabled() {
-		finderOpts = append(finderOpts, pgtablefinder.WithInstrumentation(instrumentation))
-	}
-
-	g, err = pgtablefinder.NewSnapshotSchemaTableFinder(ctx, cfg.Generator.URL, g, finderOpts...)
-	if err != nil {
-		return nil, err
 	}
 
 	if instrumentation.IsEnabled() {


### PR DESCRIPTION
This PR updates the pgdump/restore snapshot generator to not receive the exploded schema/tables values obtained by the schema/table discovery step, but rather the ones originally requested by the user, since the wildcard values both for tables and schemas, affect the options passed to the `pg_dump` command. 

If we receive all the explicit schemas/tables on input, we'll apply filters that are not necessary and will in some cases produce different outputs than the expected ones. By having the wildcard component, we can optimise and simplify the pg_dump options.

Fixes https://github.com/xataio/xata-actions-demo/actions/runs/15829106209/job/44616940684.