### PR TITLE
[Postgres] Support bulk initial snapshots in replication

### DIFF
--- a/cmd/run_cmd.go
+++ b/cmd/run_cmd.go
@@ -88,10 +88,26 @@ func initialSnapshotFlagBinding(cmd *cobra.Command) {
 		}
 	}
 
+	// if the souce and target are postgres, and snapshot and replication mode
+	// is enabled, default to using bulk ingest if not set
+	if viper.GetString("source.postgres.url") != "" && viper.GetString("target.postgres.url") != "" &&
+		viper.GetString("source.postgres.mode") == "snapshot_and_replication" &&
+		viper.GetString("target.postgres.bulk_ingest.enabled") == "" {
+		viper.Set("target.postgres.bulk_ingest.enabled", true)
+	}
+
 	// to be able to overwrite configuration with flags when env config file is
 	// provided or when no configuration is provided
 	viper.BindPFlag("PGSTREAM_POSTGRES_SNAPSHOT_TABLES", cmd.Flags().Lookup("snapshot-tables"))
 	viper.BindPFlag("PGSTREAM_POSTGRES_SNAPSHOT_CLEAN_TARGET_DB", cmd.Flags().Lookup("reset"))
+
+	// if the soure and target are postgres, with replication + initial snapshot
+	// enabled, default to using bulk ingest if not set
+	if viper.GetString("PGSTREAM_POSTGRES_LISTENER_URL") != "" && viper.GetString("PGSTREAM_POSTGRES_WRITER_TARGET_URL") != "" &&
+		viper.GetString("PGSTREAM_POSTGRES_SNAPSHOT_TABLES") != "" &&
+		viper.GetString("PGSTREAM_POSTGRES_WRITER_BULK_INGEST_ENABLED") == "" {
+		viper.Set("PGSTREAM_POSTGRES_WRITER_BULK_INGEST_ENABLED", true)
+	}
 }
 
 func sourceFlagBinding(cmd *cobra.Command) error {

--- a/cmd/run_cmd.go
+++ b/cmd/run_cmd.go
@@ -88,11 +88,11 @@ func initialSnapshotFlagBinding(cmd *cobra.Command) {
 		}
 	}
 
-	// if the souce and target are postgres, and snapshot and replication mode
+	// if the source and target are postgres, and snapshot and replication mode
 	// is enabled, default to using bulk ingest if not set
 	if viper.GetString("source.postgres.url") != "" && viper.GetString("target.postgres.url") != "" &&
 		viper.GetString("source.postgres.mode") == "snapshot_and_replication" &&
-		viper.GetString("target.postgres.bulk_ingest.enabled") == "" {
+		!viper.IsSet("target.postgres.bulk_ingest.enabled") {
 		viper.Set("target.postgres.bulk_ingest.enabled", true)
 	}
 
@@ -101,7 +101,7 @@ func initialSnapshotFlagBinding(cmd *cobra.Command) {
 	viper.BindPFlag("PGSTREAM_POSTGRES_SNAPSHOT_TABLES", cmd.Flags().Lookup("snapshot-tables"))
 	viper.BindPFlag("PGSTREAM_POSTGRES_SNAPSHOT_CLEAN_TARGET_DB", cmd.Flags().Lookup("reset"))
 
-	// if the soure and target are postgres, with replication + initial snapshot
+	// if the source and target are postgres, with replication + initial snapshot
 	// enabled, default to using bulk ingest if not set
 	if viper.GetString("PGSTREAM_POSTGRES_LISTENER_URL") != "" && viper.GetString("PGSTREAM_POSTGRES_WRITER_TARGET_URL") != "" &&
 		viper.GetString("PGSTREAM_POSTGRES_SNAPSHOT_TABLES") != "" &&

--- a/pg2pg.yaml
+++ b/pg2pg.yaml
@@ -25,6 +25,7 @@ target:
       size: 100 # number of messages in a batch
     disable_triggers: false # whether to disable triggers on the target database
     on_conflict_action: "nothing" # options are update, nothing or error
+    schema_log_store_url: "postgres://postgres:postgres@localhost:5432?sslmode=disable" # URL of the schemalog database, if different from the source database
 
 modifiers:
   injector:

--- a/pkg/stream/stream_run.go
+++ b/pkg/stream/stream_run.go
@@ -95,7 +95,7 @@ func Run(ctx context.Context, logger loglib.Logger, config *Config, instrumentat
 
 	// Processor
 
-	processor, closer, err := newProcessor(ctx, logger, config, checkpoint, instrumentation)
+	processor, closer, err := newProcessor(ctx, logger, config, checkpoint, processorTypeReplication, instrumentation)
 	defer closer()
 	if err != nil {
 		return err
@@ -115,7 +115,7 @@ func Run(ctx context.Context, logger loglib.Logger, config *Config, instrumentat
 			// use a dedicated processor for the snapshot phase, to be able to
 			// close it and make sure the snapshot is complete before starting
 			// to process the WAL replication events.
-			snapshotProcessor, snapshotCloser, err := newProcessor(ctx, logger, config, checkpoint, instrumentation)
+			snapshotProcessor, snapshotCloser, err := newProcessor(ctx, logger, config, checkpoint, processorTypeSnapshot, instrumentation)
 			defer snapshotCloser()
 			if err != nil {
 				return fmt.Errorf("error creating snapshot processor: %w", err)
@@ -171,8 +171,8 @@ var noopCloser func() error = func() error {
 	return nil
 }
 
-func newProcessor(ctx context.Context, logger loglib.Logger, config *Config, checkpoint checkpointer.Checkpoint, instrumentation *otel.Instrumentation) (processor.Processor, closerFn, error) {
-	processor, err := buildProcessor(ctx, logger, &config.Processor, checkpoint, instrumentation)
+func newProcessor(ctx context.Context, logger loglib.Logger, config *Config, checkpoint checkpointer.Checkpoint, processorType processorType, instrumentation *otel.Instrumentation) (processor.Processor, closerFn, error) {
+	processor, err := buildProcessor(ctx, logger, &config.Processor, checkpoint, processorType, instrumentation)
 	if err != nil {
 		return nil, noopCloser, err
 	}

--- a/pkg/stream/stream_snapshot.go
+++ b/pkg/stream/stream_snapshot.go
@@ -27,7 +27,7 @@ func Snapshot(ctx context.Context, logger loglib.Logger, config *Config, instrum
 
 	// Processor
 
-	processor, err := buildProcessor(ctx, logger, &config.Processor, nil, instrumentation)
+	processor, err := buildProcessor(ctx, logger, &config.Processor, nil, processorTypeSnapshot, instrumentation)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR updates the stream processor constructor to factor in if the postgres processor is for replication or snapshots, and only applies the bulk ingest configuration for the snapshots. 
The bulk ingest is enabled by default when `snapshot_and_replication` mode is enabled, while keeping the normal batch writer for replication traffic, required for keeping up with all types of workloads and DDL changes while preserving the order.

Without these changes either the bulk load was applied to both snapshot and replication traffic, or to none. Given the constraints of the replication traffic, it forced initial snapshots to be performed using the basic postgres writer instead of the bulk one, which is much faster and efficient for larger databases.

Closes #434 