### PR TITLE
[Search Processor] Handle uuid type for search mapping

### DIFF
--- a/pkg/wal/processor/search/search_adapter.go
+++ b/pkg/wal/processor/search/search_adapter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/google/uuid"
 	"github.com/xataio/pgstream/internal/json"
 	"github.com/xataio/pgstream/pkg/schemalog"
 	"github.com/xataio/pgstream/pkg/wal"
@@ -256,6 +257,8 @@ func (a *adapter) parseIDColumns(tableName string, idColumns []wal.Column, doc *
 			addToID(strconv.FormatInt(v, 10))
 		case float64:
 			addToID(strconv.FormatFloat(v, 'f', -1, 64))
+		case [16]uint8: // UUID
+			addToID(uuid.UUID(v).String())
 		case nil:
 			return errNilIDValue
 		default:

--- a/pkg/wal/processor/search/search_adapter_test.go
+++ b/pkg/wal/processor/search/search_adapter_test.go
@@ -624,6 +624,7 @@ func TestAdapter_parseIDColumns(t *testing.T) {
 			Data: make(map[string]any),
 		}
 	}
+	testUUID := "99d4f38c-770a-460e-b0ac-419fbc3d5636"
 
 	testTable := "test-table"
 	tests := []struct {
@@ -663,6 +664,14 @@ func TestAdapter_parseIDColumns(t *testing.T) {
 				{Name: "id-1", Value: float64(1.0)},
 			},
 			wantDoc: newDoc(fmt.Sprintf("%s_1", testTable)),
+			wantErr: nil,
+		},
+		{
+			name: "ok - [16]uint8 (UUID)",
+			idColumns: []wal.Column{
+				{Name: "id-1", Value: [16]uint8{153, 212, 243, 140, 119, 10, 70, 14, 176, 172, 65, 159, 188, 61, 86, 54}},
+			},
+			wantDoc: newDoc(fmt.Sprintf("%s_%s", testTable, testUUID)),
 			wantErr: nil,
 		},
 		{

--- a/pkg/wal/processor/search/store/search_pg_mapper_test.go
+++ b/pkg/wal/processor/search/store/search_pg_mapper_test.go
@@ -284,7 +284,7 @@ func TestMapper_MapColumnValue(t *testing.T) {
 			wantErr:   nil,
 		},
 		{
-			name:   "unknonwn column type",
+			name:   "unknown column type",
 			column: schemalog.Column{DataType: "custom_type"},
 			value:  "value",
 

--- a/pkg/wal/processor/search/store/search_pg_mapper_test.go
+++ b/pkg/wal/processor/search/store/search_pg_mapper_test.go
@@ -268,6 +268,22 @@ func TestMapper_MapColumnValue(t *testing.T) {
 			wantErr:   nil,
 		},
 		{
+			name:   "uuid",
+			column: schemalog.Column{DataType: "uuid"},
+			value:  [16]uint8{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0},
+
+			wantValue: "12345678-9abc-def0-1234-56789abcdef0",
+			wantErr:   nil,
+		},
+		{
+			name:   "string array",
+			column: schemalog.Column{DataType: "text[]"},
+			value:  "{value1,value2}",
+
+			wantValue: []string{"value1", "value2"},
+			wantErr:   nil,
+		},
+		{
 			name:   "unknonwn column type",
 			column: schemalog.Column{DataType: "custom_type"},
 			value:  "value",


### PR DESCRIPTION
This PR updates the search mapping to handle UUID types properly, by making them supported identity types and parsing values to use the string representation.

Fixes #433 