### PR TITLE
chore: fix inconsistent struct name in comment

### DIFF
--- a/internal/log/zerolog/zerolog.go
+++ b/internal/log/zerolog/zerolog.go
@@ -56,7 +56,7 @@ func NewStdLogger(l *zerolog.Logger) loglib.Logger {
 	return zerologlib.NewLogger(l)
 }
 
-// newLogger creates a new logger writing to out.
+// NewLogger creates a new logger writing to out.
 // The logger will emit a timestamp, the caller's filename, and optionally
 // emit the stacktrace for errors that carry a stack trace.
 //

--- a/internal/searchstore/search_client.go
+++ b/internal/searchstore/search_client.go
@@ -36,7 +36,7 @@ type Client interface {
 
 func Ptr[T any](i T) *T { return &i }
 
-// createReader returns a reader on the JSON representation of the given value.
+// CreateReader returns a reader on the JSON representation of the given value.
 func CreateReader(value any) (*bytes.Reader, error) {
 	bytesValue, err := json.Marshal(value)
 	if err != nil {

--- a/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
+++ b/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
@@ -109,7 +109,7 @@ func WithInstrumentation(i *otel.Instrumentation) Option {
 	}
 }
 
-// ProcessWalEvent is called on every new message from the wal. It can be called
+// ProcessWALEvent is called on every new message from the wal. It can be called
 // concurrently.
 func (w *BatchWriter) ProcessWALEvent(ctx context.Context, walEvent *wal.Event) (retErr error) {
 	defer func() {

--- a/pkg/wal/processor/postgres/postgres_batch_writer.go
+++ b/pkg/wal/processor/postgres/postgres_batch_writer.go
@@ -62,7 +62,7 @@ func NewBatchWriter(ctx context.Context, config *Config, opts ...WriterOption) (
 	return bw, nil
 }
 
-// ProcessWalEvent is called on every new message from the wal. It can be called
+// ProcessWALEvent is called on every new message from the wal. It can be called
 // concurrently.
 func (w *BatchWriter) ProcessWALEvent(ctx context.Context, walEvent *wal.Event) (err error) {
 	defer func() {

--- a/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
+++ b/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
@@ -60,7 +60,7 @@ func NewBulkIngestWriter(ctx context.Context, config *Config, opts ...WriterOpti
 	return biw, nil
 }
 
-// ProcessWalEvent is called on every new message from the wal. It can be called
+// ProcessWALEvent is called on every new message from the wal. It can be called
 // concurrently.
 func (w *BulkIngestWriter) ProcessWALEvent(ctx context.Context, walEvent *wal.Event) (err error) {
 	defer func() {


### PR DESCRIPTION
fix inconsistent struct name in comment