### PR TITLE
Fix snapshots with infinity date/time values

### DIFF
--- a/pkg/wal/processor/postgres/postgres_batch_writer.go
+++ b/pkg/wal/processor/postgres/postgres_batch_writer.go
@@ -40,7 +40,7 @@ func NewBatchWriter(ctx context.Context, config *Config, opts ...WriterOption) (
 		schemaLogStore = schemalog.NewStoreCache(schemaLogStore)
 	}
 
-	adapter, err := newAdapter(ctx, schemaLogStore, config.URL, config.OnConflictAction)
+	adapter, err := newAdapter(ctx, schemaLogStore, config.URL, config.OnConflictAction, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
+++ b/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
@@ -37,7 +37,7 @@ var errUnexpectedCopiedRows = errors.New("number of rows copied doesn't match th
 func NewBulkIngestWriter(ctx context.Context, config *Config, opts ...WriterOption) (*BulkIngestWriter, error) {
 	// the bulk ingest writer only processes insert events, so we don't need a
 	// DDL adapter
-	adapter, err := newAdapter(ctx, nil, config.URL, config.OnConflictAction)
+	adapter, err := newAdapter(ctx, nil, config.URL, config.OnConflictAction, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/wal/processor/postgres/postgres_wal_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_adapter.go
@@ -29,13 +29,13 @@ type adapter struct {
 	columnObserver columnObserver
 }
 
-func newAdapter(ctx context.Context, schemaQuerier schemalogQuerier, pgURL string, onConflictAction string) (*adapter, error) {
+func newAdapter(ctx context.Context, schemaQuerier schemalogQuerier, pgURL string, onConflictAction string, forCopy bool) (*adapter, error) {
 	columnObserver, err := newPGColumnObserver(ctx, pgURL)
 	if err != nil {
 		return nil, err
 	}
 
-	dmlAdapter, err := newDMLAdapter(onConflictAction)
+	dmlAdapter, err := newDMLAdapter(onConflictAction, forCopy)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR handles `infinity` and `-infinity` values for columns with type `date`, `timestamp`, `timestamptz`. Passing a flag to DML adapter in bulk ingest scenario, as the [issue](https://github.com/xataio/pgstream/issues/451) only happens for snapshots, but not in the replication case.
`infinity` value is possible for `float` and `interval` data types as well, but they are already handled without any issues.
Other keywords like `tomorrow` and `yesterday` are not handled, because they are automatically converted to regular date/timestamp values accordingly, causing no issues. For ref: https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-SPECIAL-VALUES

fixes: #451 