### PR TITLE
[Transformers] Add support for citext type to email transformer

### DIFF
--- a/pkg/transformers/neosync/neosync_email_transformer.go
+++ b/pkg/transformers/neosync/neosync_email_transformer.go
@@ -86,6 +86,7 @@ var (
 	}
 	emailCompatibleTypes = []transformers.SupportedDataType{
 		transformers.StringDataType,
+		transformers.CitextDataType,
 	}
 )
 

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -77,6 +77,7 @@ const (
 	DatetimeDataType       SupportedDataType = "datetime"
 	JSONDataType           SupportedDataType = "json"
 	AllDataTypes           SupportedDataType = "all"
+	CitextDataType         SupportedDataType = "citext"
 )
 
 const (


### PR DESCRIPTION
This PR updates the neosync email transformer to support citext postgres type. 
It also updates the validator handling to check against data type name when the OID is unknown to cover for extension/custom types.

Fixes #471 