### PR TITLE
Add destroy cmd, deprecate teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,14 +145,14 @@ Source status:
  - Reachable: true
 ```
 
-If there are any issues or if you want to revert the pgstream setup, you can use the `tear-down` command to clean up all pgstream state.
+If there are any issues or if you want to revert the pgstream setup, you can use the `destroy` command to clean up all pgstream state.
 
 ```sh
-pgstream tear-down --postgres-url "postgres://postgres:postgres@localhost?sslmode=disable" --replication-slot test
+pgstream destroy --postgres-url "postgres://postgres:postgres@localhost?sslmode=disable" --replication-slot test
 # with yaml configuration file
-pgstream tear-down -c pg2pg.yaml
+pgstream destroy -c pg2pg.yaml
 # with environment configuration file
-pgstream tear-down -c pg2pg.env
+pgstream destroy -c pg2pg.env
 ```
 
 ### Run `pgstream`

--- a/cli-definition.json
+++ b/cli-definition.json
@@ -2,6 +2,26 @@
   "name": "pgstream",
   "commands": [
     {
+      "name": "destroy",
+      "short": "It destroys any pgstream setup, removing the replication slot and all the relevant tables/functions/triggers, along with the internal pgstream schema",
+      "use": "destroy",
+      "example": "\n\tpgstream destroy --postgres-url <source-postgres-url> --replication-slot <replication-slot-name>\n\tpgstream destroy -c config.yaml\n\tpgstream destroy -c config.env",
+      "flags": [
+        {
+          "name": "postgres-url",
+          "description": "Source postgres URL where pgstream destroy will be run",
+          "default": ""
+        },
+        {
+          "name": "replication-slot",
+          "description": "Name of the postgres replication slot to be deleted by pgstream from the source url",
+          "default": ""
+        }
+      ],
+      "subcommands": [],
+      "args": []
+    },
+    {
       "name": "init",
       "short": "Initialises pgstream, creating the replication slot and the relevant tables/functions/triggers under the configured internal pgstream schema",
       "use": "init",
@@ -148,7 +168,7 @@
     },
     {
       "name": "tear-down",
-      "short": "It tears down any pgstream setup, removing the replication slot and all the relevant tables/functions/triggers, along with the internal pgstream schema",
+      "short": "tear-down is deprecated, please use destroy",
       "use": "tear-down",
       "example": "\n\tpgstream tear-down --postgres-url <source-postgres-url> --replication-slot <replication-slot-name>\n\tpgstream tear-down -c config.yaml\n\tpgstream tear-down -c config.env",
       "flags": [

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -50,6 +50,10 @@ func Prepare() *cobra.Command {
 	initCmd.Flags().String("postgres-url", "", "Source postgres URL where pgstream setup will be run")
 	initCmd.Flags().String("replication-slot", "", "Name of the postgres replication slot to be created by pgstream on the source url")
 
+	// destroy cmd
+	destroyCmd.Flags().String("postgres-url", "", "Source postgres URL where pgstream destroy will be run")
+	destroyCmd.Flags().String("replication-slot", "", "Name of the postgres replication slot to be deleted by pgstream from the source url")
+
 	// tear down cmd
 	tearDownCmd.Flags().String("postgres-url", "", "Source postgres URL where pgstream tear down will be run")
 	tearDownCmd.Flags().String("replication-slot", "", "Name of the postgres replication slot to be deleted by pgstream from the source url")
@@ -84,6 +88,7 @@ func Prepare() *cobra.Command {
 
 	// register subcommands
 	rootCmd.AddCommand(initCmd)
+	rootCmd.AddCommand(destroyCmd)
 	rootCmd.AddCommand(tearDownCmd)
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(snapshotCmd)

--- a/docs/tutorials/postgres_kafka.md
+++ b/docs/tutorials/postgres_kafka.md
@@ -67,10 +67,10 @@ Successful initialisation should prompt the following message:
 SUCCESS  pgstream initialisation complete
 ```
 
-If at any point the initialisation performed by pgstream needs to be reverted, all state will be removed by running the `tear-down` CLI command.
+If at any point the initialisation performed by pgstream needs to be reverted, all state will be removed by running the `destroy` CLI command.
 
 ```sh
-pgstream tear-down --postgres-url "postgres://postgres:postgres@localhost:5432?sslmode=disable" --replication-slot pgstream_tutorial_slot
+pgstream destroy --postgres-url "postgres://postgres:postgres@localhost:5432?sslmode=disable" --replication-slot pgstream_tutorial_slot
 ```
 
 ## Prepare `pgstream` configuration

--- a/docs/tutorials/postgres_to_opensearch.md
+++ b/docs/tutorials/postgres_to_opensearch.md
@@ -70,10 +70,10 @@ Successful initialisation should prompt the following message:
 SUCCESS  pgstream initialisation complete
 ```
 
-If at any point the initialisation performed by pgstream needs to be reverted, all state will be removed by running the `tear-down` CLI command.
+If at any point the initialisation performed by pgstream needs to be reverted, all state will be removed by running the `destroy` CLI command.
 
 ```sh
-pgstream tear-down --postgres-url "postgres://postgres:postgres@localhost:5432?sslmode=disable" --replication-slot pgstream_tutorial_slot
+pgstream destroy --postgres-url "postgres://postgres:postgres@localhost:5432?sslmode=disable" --replication-slot pgstream_tutorial_slot
 ```
 
 ## Prepare `pgstream` configuration

--- a/docs/tutorials/postgres_to_postgres.md
+++ b/docs/tutorials/postgres_to_postgres.md
@@ -77,10 +77,10 @@ After initialization, you should see the following message:
 SUCCESS  pgstream initialisation complete
 ```
 
-If at any point the initialisation performed by pgstream needs to be reverted, all state will be removed by running the `tear-down` CLI command.
+If at any point the initialisation performed by pgstream needs to be reverted, all state will be removed by running the `destroy` CLI command.
 
 ```sh
-pgstream tear-down --postgres-url "postgres://postgres:postgres@localhost:5432?sslmode=disable" --replication-slot pgstream_tutorial_slot
+pgstream destroy --postgres-url "postgres://postgres:postgres@localhost:5432?sslmode=disable" --replication-slot pgstream_tutorial_slot
 ```
 
 ## Prepare `pgstream` configuration

--- a/docs/tutorials/postgres_to_webhooks.md
+++ b/docs/tutorials/postgres_to_webhooks.md
@@ -71,10 +71,10 @@ Successful initialisation should prompt the following message:
 SUCCESS  pgstream initialisation complete
 ```
 
-If at any point the initialisation performed by pgstream needs to be reverted, all state will be removed by running the `tear-down` CLI command.
+If at any point the initialisation performed by pgstream needs to be reverted, all state will be removed by running the `destroy` CLI command.
 
 ```sh
-pgstream tear-down --postgres-url "postgres://postgres:postgres@localhost:5432?sslmode=disable" --replication-slot pgstream_tutorial_slot
+pgstream destroy --postgres-url "postgres://postgres:postgres@localhost:5432?sslmode=disable" --replication-slot pgstream_tutorial_slot
 ```
 
 ## Prepare `pgstream` configuration

--- a/docs/tutorials/postgres_transformer.md
+++ b/docs/tutorials/postgres_transformer.md
@@ -70,10 +70,10 @@ Successful initialisation should prompt the following message:
 SUCCESS  pgstream initialisation complete
 ```
 
-If at any point the initialisation performed by pgstream needs to be reverted, all state will be removed by running the `tear-down` CLI command.
+If at any point the initialisation performed by pgstream needs to be reverted, all state will be removed by running the `destroy` CLI command.
 
 ```sh
-pgstream tear-down --postgres-url "postgres://postgres:postgres@localhost:5432?sslmode=disable" --replication-slot pgstream_tutorial_slot
+pgstream destroy --postgres-url "postgres://postgres:postgres@localhost:5432?sslmode=disable" --replication-slot pgstream_tutorial_slot
 ```
 
 ## Prepare `pgstream` configuration

--- a/pkg/stream/stream_init.go
+++ b/pkg/stream/stream_init.go
@@ -76,9 +76,9 @@ func Init(ctx context.Context, pgURL, replicationSlotName string) error {
 	return nil
 }
 
-// TearDown removes the pgstream state from the postgres database provided,
+// Destroy removes the pgstream state from the postgres database provided,
 // as well as removing the replication slot.
-func TearDown(ctx context.Context, pgURL, replicationSlotName string) error {
+func Destroy(ctx context.Context, pgURL, replicationSlotName string) error {
 	if pgURL == "" {
 		return errMissingPostgresURL
 	}
@@ -109,7 +109,7 @@ func TearDown(ctx context.Context, pgURL, replicationSlotName string) error {
 		return fmt.Errorf("failed to run internal pgstream migrations: %w", err)
 	}
 
-	// delete the pgstream schema once the migration tear down has completed
+	// delete the pgstream schema once the migration destroy has completed
 	if err := dropPGStreamSchema(ctx, conn); err != nil {
 		return fmt.Errorf("failed to drop pgstream schema: %w", err)
 	}


### PR DESCRIPTION
Add a new command `destroy` which does the exact same thing as `tear-down` but with a new name. Keeping tear-down functionality with a log message telling that it is deprecated.
Also updating the docs accordingly.

closes: #470 