### PR TITLE
Fix config data crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ integration-test:
 .PHONY: fuzz
 fuzz:
 	@echo "Fuzzing YAML to Stream Config"
-	@go test -fuzz=FuzzYAMLToStreamConfig --fuzztime 5s github.com/xataio/pgstream/cmd/config
+	@go test -fuzz=FuzzYAMLToStreamConfig --fuzztime 30s github.com/xataio/pgstream/cmd/config
 	@echo "Fuzzing YAML Config Structure"
-	@go test -fuzz=FuzzYAMLConfigStructure --fuzztime 5s github.com/xataio/pgstream/cmd/config
+	@go test -fuzz=FuzzYAMLConfigStructure --fuzztime 30s github.com/xataio/pgstream/cmd/config
 	@echo "Fuzzing YAML Config Properties"
-	@go test -fuzz=FuzzYAMLConfigProperties --fuzztime 5s github.com/xataio/pgstream/cmd/config
+	@go test -fuzz=FuzzYAMLConfigProperties --fuzztime 30s github.com/xataio/pgstream/cmd/config
 
 .PHONY: license-check
 license-check:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,15 @@ test:
 integration-test:
 	@PGSTREAM_INTEGRATION_TESTS=true go test -timeout 180s github.com/xataio/pgstream/pkg/stream/integration
 
+.PHONY: fuzz
+fuzz:
+	@echo "Fuzzing YAML to Stream Config"
+	@go test -fuzz=FuzzYAMLToStreamConfig --fuzztime 5s github.com/xataio/pgstream/cmd/config
+	@echo "Fuzzing YAML Config Structure"
+	@go test -fuzz=FuzzYAMLConfigStructure --fuzztime 5s github.com/xataio/pgstream/cmd/config
+	@echo "Fuzzing YAML Config Properties"
+	@go test -fuzz=FuzzYAMLConfigProperties --fuzztime 5s github.com/xataio/pgstream/cmd/config
+
 .PHONY: license-check
 license-check:
 	@curl -s https://raw.githubusercontent.com/lluissm/license-header-checker/master/install.sh | bash

--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -472,13 +472,7 @@ func (c *YAMLConfig) parseSnapshotConfig() (*snapshotbuilder.SnapshotListenerCon
 	}
 
 	if snapshotConfig.Mode == fullSnapshotMode || snapshotConfig.Mode == dataSnapshotMode {
-		streamCfg.Generator = pgsnapshotgenerator.Config{
-			URL:             c.Source.Postgres.URL,
-			BatchBytes:      snapshotConfig.Data.BatchBytes,
-			SchemaWorkers:   uint(snapshotConfig.Data.SchemaWorkers),
-			TableWorkers:    uint(snapshotConfig.Data.TableWorkers),
-			SnapshotWorkers: uint(snapshotConfig.SnapshotWorkers),
-		}
+		streamCfg.Generator = c.parseDataSnapshotConfig()
 	}
 
 	if snapshotConfig.Mode == fullSnapshotMode || snapshotConfig.Mode == schemaSnapshotMode {
@@ -490,6 +484,22 @@ func (c *YAMLConfig) parseSnapshotConfig() (*snapshotbuilder.SnapshotListenerCon
 	}
 
 	return streamCfg, nil
+}
+
+func (c *YAMLConfig) parseDataSnapshotConfig() pgsnapshotgenerator.Config {
+	snapshotCfg := c.Source.Postgres.Snapshot
+	cfg := pgsnapshotgenerator.Config{
+		URL:             c.Source.Postgres.URL,
+		SnapshotWorkers: uint(snapshotCfg.SnapshotWorkers),
+	}
+
+	if snapshotCfg.Data != nil {
+		cfg.BatchBytes = snapshotCfg.Data.BatchBytes
+		cfg.SchemaWorkers = uint(snapshotCfg.Data.SchemaWorkers)
+		cfg.TableWorkers = uint(snapshotCfg.Data.TableWorkers)
+	}
+
+	return cfg
 }
 
 func (c *YAMLConfig) parseSchemaSnapshotConfig() (snapshotbuilder.SchemaSnapshotConfig, error) {

--- a/cmd/config/config_yaml_fuzz_test.go
+++ b/cmd/config/config_yaml_fuzz_test.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+var config, _ = os.ReadFile("test/test_config.yaml")
+
+func FuzzToStreamConfig(f *testing.F) {
+	f.Add(config)
+	// Seed with edge cases
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`source: {}`))
+	f.Add([]byte(`target: {}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var yamlConfig YAMLConfig
+		if err := yaml.Unmarshal(data, &yamlConfig); err != nil {
+			return
+		}
+
+		_, err := yamlConfig.toStreamConfig()
+		if err != nil {
+			t.Logf("Expected error: %v", err)
+		}
+	})
+}
+
+func FuzzYAMLConfigStructure(f *testing.F) {
+	// Test various YAML structures that could break parsing
+	malformedInputs := []string{
+		`source: !!str invalid_source_type`,
+		`source: !!int 12345`,
+		`source: !!float 123.45`,
+		`source: !!bool true`,
+		`source: [1, 2, 3]`,
+		`target: !!seq ["invalid", "target"]`,
+		`modifiers: !!null`,
+		`source: {postgres: {url: !!binary "SGVsbG8="}}`,
+		`source: {postgres: {mode: !!null}}`,
+		`target: {postgres: {batch: {size: !!str "not_a_number"}}}`,
+	}
+
+	for _, input := range malformedInputs {
+		f.Add([]byte(input))
+	}
+
+	f.Fuzz(func(t *testing.T, yamlInput []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("YAML structure fuzzing panicked: %v", r)
+			}
+		}()
+
+		var yamlConfig YAMLConfig
+		err := yaml.Unmarshal(yamlInput, &yamlConfig)
+		if err != nil {
+			// YAML parsing errors are fine
+			return
+		}
+
+		// Try to convert to stream config
+		_, err = yamlConfig.toStreamConfig()
+		// Conversion errors are acceptable, panics are not
+		_ = err
+	})
+}
+
+func FuzzConfigProperties(f *testing.F) {
+	f.Fuzz(func(t *testing.T,
+		sourceMode uint8,
+		snapshotMode uint8,
+		targetMode uint8,
+		searchEngine uint8,
+		modifiersMode uint8,
+		batchSize uint16,
+		timeout uint32,
+	) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Property-based fuzzing panicked: %v", r)
+			}
+		}()
+
+		cfg := generateYAMLConfigFromProperties(
+			sourceMode, snapshotMode, targetMode, searchEngine, modifiersMode, batchSize, timeout)
+
+		// Test marshaling/unmarshaling
+		data, err := yaml.Marshal(cfg)
+		if err != nil {
+			return
+		}
+
+		var parsed YAMLConfig
+		if err := yaml.Unmarshal(data, &parsed); err != nil {
+			return
+		}
+
+		// Test conversion to stream config
+		_, err = parsed.toStreamConfig()
+		// Errors are acceptable for invalid combinations
+		_ = err
+	})
+}
+
+// Helper functions
+
+func generateYAMLConfigFromProperties(
+	sourceMode, snapshotMode, targetMode, searchEngine, modifiersMode uint8,
+	batchSize uint16,
+	timeout uint32,
+) *YAMLConfig {
+	cfg := &YAMLConfig{}
+
+	// Generate source config
+	switch sourceMode % 2 {
+	case 0:
+		mode := []string{"replication", "snapshot", "snapshot_and_replication"}[sourceMode%3]
+		cfg.Source.Postgres = &PostgresConfig{
+			URL:  "postgresql://test:test@localhost:5432/test",
+			Mode: mode,
+		}
+		if mode == "snapshot" || mode == "snapshot_and_replication" {
+			snapshotModeStr := []string{"full", "data", "schema"}[snapshotMode%3]
+			cfg.Source.Postgres.Snapshot = &SnapshotConfig{
+				Mode: snapshotModeStr,
+			}
+		}
+	case 1:
+		cfg.Source.Kafka = &KafkaConfig{
+			Servers: []string{"localhost:9092"},
+			Topic:   TopicConfig{Name: "test"},
+		}
+	}
+
+	// Generate target config
+	switch targetMode % 4 {
+	case 0:
+		cfg.Target.Postgres = &PostgresTargetConfig{
+			URL: "postgresql://test:test@localhost:5432/test",
+			Batch: &BatchConfig{
+				Size:    int(batchSize),
+				Timeout: int(timeout),
+			},
+		}
+	case 1:
+		cfg.Target.Kafka = &KafkaTargetConfig{
+			Servers: []string{"localhost:9092"},
+			Topic:   KafkaTopicConfig{Name: "test"},
+			Batch: &BatchConfig{
+				Size:    int(batchSize),
+				Timeout: int(timeout),
+			},
+		}
+	case 2:
+		engine := []string{"elasticsearch", "opensearch"}[searchEngine%2]
+		cfg.Target.Search = &SearchConfig{
+			Engine: engine,
+			URL:    "http://localhost:9200",
+			Batch: &BatchConfig{
+				Size:    int(batchSize),
+				Timeout: int(timeout),
+			},
+		}
+	case 3:
+		cfg.Target.Webhooks = &WebhooksConfig{
+			Subscriptions: WebhookSubscriptionsConfig{
+				Store: WebhookStoreConfig{URL: "postgresql://test:test@localhost:5432/test"},
+			},
+			Notifier: WebhookNotifierConfig{
+				ClientTimeout: int(timeout),
+			},
+		}
+	}
+
+	// Generate modifiers config
+	switch modifiersMode % 4 {
+	case 0:
+		// no modifiers
+	case 1:
+		cfg.Modifiers.Injector = &InjectorConfig{Enabled: true}
+	case 2:
+		cfg.Modifiers.Filter = &FilterConfig{
+			IncludeTables: []string{"test.*"},
+		}
+	case 3:
+		validationModes := []string{"strict", "relaxed", "table_level"}
+		cfg.Modifiers.Transformations = &TransformationsConfig{
+			ValidationMode: validationModes[modifiersMode%3],
+			TransformerRules: []TableTransformersConfig{
+				{
+					ValidationMode: validationModes[modifiersMode%3],
+					Schema:         "public",
+					Table:          "test",
+					ColumnRules: map[string]ColumnTransformersConfig{
+						"name": {Name: "test_transformer"},
+					},
+				},
+			},
+		}
+	}
+
+	return cfg
+}
+
+// Benchmark to catch performance regressions
+func BenchmarkToStreamConfig(b *testing.B) {
+	var yamlConfig YAMLConfig
+	yaml.Unmarshal(config, &yamlConfig)
+
+	for b.Loop() {
+		_, _ = yamlConfig.toStreamConfig()
+	}
+}

--- a/cmd/config/config_yaml_fuzz_test.go
+++ b/cmd/config/config_yaml_fuzz_test.go
@@ -6,12 +6,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
 
-var config, _ = os.ReadFile("test/test_config.yaml")
-
 func FuzzYAMLToStreamConfig(f *testing.F) {
+	config, err := os.ReadFile("test/test_config.yaml")
+	require.NoError(f, err)
+
 	f.Add(config)
 	// Seed with edge cases
 	f.Add([]byte(`{}`))
@@ -210,6 +212,9 @@ func generateYAMLConfigFromProperties(
 
 // Benchmark to catch performance regressions
 func BenchmarkToStreamConfig(b *testing.B) {
+	config, err := os.ReadFile("test/test_config.yaml")
+	require.NoError(b, err)
+
 	var yamlConfig YAMLConfig
 	yaml.Unmarshal(config, &yamlConfig)
 

--- a/cmd/config/config_yaml_fuzz_test.go
+++ b/cmd/config/config_yaml_fuzz_test.go
@@ -11,7 +11,7 @@ import (
 
 var config, _ = os.ReadFile("test/test_config.yaml")
 
-func FuzzToStreamConfig(f *testing.F) {
+func FuzzYAMLToStreamConfig(f *testing.F) {
 	f.Add(config)
 	// Seed with edge cases
 	f.Add([]byte(`{}`))
@@ -71,7 +71,7 @@ func FuzzYAMLConfigStructure(f *testing.F) {
 	})
 }
 
-func FuzzConfigProperties(f *testing.F) {
+func FuzzYAMLConfigProperties(f *testing.F) {
 	f.Fuzz(func(t *testing.T,
 		sourceMode uint8,
 		snapshotMode uint8,


### PR DESCRIPTION
This PR fixes the issue where having the snapshot mode set to `full`/`data` would expect the `data` section of the yaml configuration to be present, or would crash otherwise. 

A check is added to make sure that if the data section is not provided, defaults will apply instead. 
Fuzzing has also been introduced, for local use for now, to identify crash paths for the yaml configuration parsing.