### PR TITLE
Fix schemalog snapshot syncing for wildcard schemas

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -48,6 +48,11 @@
       "example": "\n\tpgstream run --source postgres --source-url <source-postgres-url> --target postgres --target-url <target-postgres-url> --init\n\tpgstream run --source postgres --source-url <source-postgres-url> --target postgres --target-url <target-postgres-url> --snapshot-tables <schema.table> --reset\n\tpgstream run --source kafka --source-url <kafka-url> --target elasticsearch --target-url <elasticsearch-url>\n\tpgstream run --source postgres --source-url <postgres-url> --target kafka --target-url <kafka-url>\n\tpgstream run --config config.yaml --log-level info\n\tpgstream run --config config.env",
       "flags": [
         {
+          "name": "dump-file",
+          "description": "File where the pg_dump output will be written if initial snapshot is enabled",
+          "default": ""
+        },
+        {
           "name": "init",
           "description": "Whether to initialize pgstream before starting replication",
           "default": "false"

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -77,6 +77,7 @@ func Prepare() *cobra.Command {
 	runCmd.Flags().Bool("reset", false, "Whether to reset the target before snapshotting (only for postgres target)")
 	runCmd.Flags().Bool("profile", false, "Whether to expose a /debug/pprof endpoint on localhost:6060")
 	runCmd.Flags().BoolVar(&initFlag, "init", false, "Whether to initialize pgstream before starting replication")
+	runCmd.Flags().String("dump-file", "", "File where the pg_dump output will be written if initial snapshot is enabled")
 
 	// status cmd
 	statusCmd.Flags().String("postgres-url", "", "Source postgres URL where pgstream has been initialised")

--- a/cmd/run_cmd.go
+++ b/cmd/run_cmd.go
@@ -89,6 +89,8 @@ func initialSnapshotFlagBinding(cmd *cobra.Command) {
 		}
 	}
 
+	viper.BindPFlag("source.postgres.snapshot.schema.pgdump_pgrestore.dump_file", cmd.Flags().Lookup("dump-file"))
+
 	// if the source and target are postgres, and snapshot and replication mode
 	// is enabled, default to using bulk ingest if not set
 	if viper.GetString("source.postgres.url") != "" && viper.GetString("target.postgres.url") != "" &&
@@ -101,6 +103,8 @@ func initialSnapshotFlagBinding(cmd *cobra.Command) {
 	// provided or when no configuration is provided
 	viper.BindPFlag("PGSTREAM_POSTGRES_SNAPSHOT_TABLES", cmd.Flags().Lookup("snapshot-tables"))
 	viper.BindPFlag("PGSTREAM_POSTGRES_SNAPSHOT_CLEAN_TARGET_DB", cmd.Flags().Lookup("reset"))
+
+	viper.BindPFlag("PGSTREAM_POSTGRES_SNAPSHOT_SCHEMA_DUMP_FILE", cmd.Flags().Lookup("dump-file"))
 
 	// if the source and target are postgres, with replication + initial snapshot
 	// enabled, default to using bulk ingest if not set

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
@@ -1549,4 +1549,3 @@ func TestSnapshotGenerator_syncSchemaLog(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
@@ -1151,7 +1151,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 				},
 			},
 
-			wantErr: fmt.Errorf("inserting schemalog entry after schema snapshot: %w", errTest),
+			wantErr: fmt.Errorf("inserting schemalog entry for schema %q after schema snapshot: %w", testSchema, errTest),
 		},
 	}
 
@@ -1371,3 +1371,182 @@ func TestGetDumpsDiff(t *testing.T) {
 		})
 	}
 }
+
+func TestSnapshotGenerator_syncSchemaLog(t *testing.T) {
+	t.Parallel()
+
+	testSchema := "test_schema"
+	testSchema2 := "test_schema_2"
+	excludedSchema := "excluded_schema"
+	errTest := errors.New("oh noes")
+
+	tests := []struct {
+		name                string
+		schemalogStore      schemalog.Store
+		connBuilder         pglib.QuerierBuilder
+		schemaTables        map[string][]string
+		excludeSchemaTables map[string][]string
+		wantErr             error
+	}{
+		{
+			name:           "ok - no schemalog store",
+			schemalogStore: nil,
+			schemaTables: map[string][]string{
+				testSchema: {"table1"},
+			},
+			excludeSchemaTables: map[string][]string{},
+			wantErr:             nil,
+		},
+		{
+			name: "ok - single schema",
+			schemalogStore: &schemalogmocks.Store{
+				InsertFn: func(ctx context.Context, schemaName string) (*schemalog.LogEntry, error) {
+					require.Equal(t, testSchema, schemaName)
+					return &schemalog.LogEntry{SchemaName: schemaName}, nil
+				},
+			},
+			connBuilder: func(ctx context.Context, s string) (pglib.Querier, error) {
+				return &mocks.Querier{}, nil
+			},
+			schemaTables: map[string][]string{
+				testSchema: {"table1"},
+			},
+			excludeSchemaTables: map[string][]string{},
+			wantErr:             nil,
+		},
+		{
+			name: "ok - wildcard schema",
+			schemalogStore: &schemalogmocks.Store{
+				InsertFn: func(ctx context.Context, schemaName string) (*schemalog.LogEntry, error) {
+					if schemaName != testSchema && schemaName != testSchema2 {
+						return nil, fmt.Errorf("unexpected schema name: %s", schemaName)
+					}
+					return &schemalog.LogEntry{SchemaName: schemaName}, nil
+				},
+			},
+			connBuilder: func(ctx context.Context, s string) (pglib.Querier, error) {
+				return &mocks.Querier{
+					QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
+						require.Contains(t, query, pglib.DiscoverAllSchemasQuery)
+						return &mocks.Rows{
+							CloseFn: func() {},
+							NextFn: func(i uint) bool {
+								return i < 2
+							},
+							ScanFn: func(dest ...any) error {
+								schema, ok := dest[0].(*string)
+								require.True(t, ok)
+								if *schema == "" {
+									*schema = testSchema
+								} else {
+									*schema = testSchema2
+								}
+								return nil
+							},
+							ErrFn: func() error { return nil },
+						}, nil
+					},
+				}, nil
+			},
+			schemaTables: map[string][]string{
+				wildcard: {"table1"},
+			},
+			excludeSchemaTables: map[string][]string{},
+			wantErr:             nil,
+		},
+		{
+			name: "ok - excluded schema skipped",
+			schemalogStore: &schemalogmocks.Store{
+				InsertFn: func(ctx context.Context, schemaName string) (*schemalog.LogEntry, error) {
+					require.NotEqual(t, excludedSchema, schemaName)
+					return &schemalog.LogEntry{SchemaName: schemaName}, nil
+				},
+			},
+			connBuilder: func(ctx context.Context, s string) (pglib.Querier, error) {
+				return &mocks.Querier{}, nil
+			},
+			schemaTables: map[string][]string{
+				testSchema:     {"table1"},
+				excludedSchema: {"table2"},
+			},
+			excludeSchemaTables: map[string][]string{
+				excludedSchema: {"table2"},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "error - schema log insert fails",
+			schemalogStore: &schemalogmocks.Store{
+				InsertFn: func(ctx context.Context, schemaName string) (*schemalog.LogEntry, error) {
+					return nil, errTest
+				},
+			},
+			connBuilder: func(ctx context.Context, s string) (pglib.Querier, error) {
+				return &mocks.Querier{}, nil
+			},
+			schemaTables: map[string][]string{
+				testSchema: {"table1"},
+			},
+			excludeSchemaTables: map[string][]string{},
+			wantErr:             errTest,
+		},
+		{
+			name:           "error - getting source connection",
+			schemalogStore: &schemalogmocks.Store{},
+			connBuilder: func(ctx context.Context, s string) (pglib.Querier, error) {
+				return nil, errTest
+			},
+			schemaTables: map[string][]string{
+				testSchema: {"table1"},
+			},
+			excludeSchemaTables: map[string][]string{},
+			wantErr:             errTest,
+		},
+		{
+			name: "error - discovering schemas",
+			schemalogStore: &schemalogmocks.Store{
+				InsertFn: func(ctx context.Context, schemaName string) (*schemalog.LogEntry, error) {
+					if schemaName != testSchema && schemaName != testSchema2 {
+						return nil, fmt.Errorf("unexpected schema name: %s", schemaName)
+					}
+					return &schemalog.LogEntry{SchemaName: schemaName}, nil
+				},
+			},
+			connBuilder: func(ctx context.Context, s string) (pglib.Querier, error) {
+				return &mocks.Querier{
+					QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
+						require.Contains(t, query, pglib.DiscoverAllSchemasQuery)
+						return &mocks.Rows{
+							CloseFn: func() {},
+							NextFn: func(i uint) bool {
+								return i < 2
+							},
+							ScanFn: func(dest ...any) error {
+								return errTest
+							},
+							ErrFn: func() error { return nil },
+						}, nil
+					},
+				}, nil
+			},
+			schemaTables: map[string][]string{
+				wildcard: {"table1"},
+			},
+			excludeSchemaTables: map[string][]string{},
+			wantErr:             errTest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sg := &SnapshotGenerator{
+				schemalogStore: tc.schemalogStore,
+				connBuilder:    tc.connBuilder,
+				logger:         log.NewNoopLogger(),
+			}
+			err := sg.syncSchemaLog(context.Background(), tc.schemaTables, tc.excludeSchemaTables)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+

--- a/pkg/snapshot/generator/postgres/tablefinder/pg_snapshot_table_finder_test.go
+++ b/pkg/snapshot/generator/postgres/tablefinder/pg_snapshot_table_finder_test.go
@@ -332,8 +332,8 @@ func TestSnapshotTableFinder_CreateSnapshot(t *testing.T) {
 			tableFinder := SnapshotSchemaTableFinder{
 				conn:              tc.conn,
 				wrapped:           tc.generator,
-				schemaDiscoveryFn: discoverAllSchemas,
-				tableDiscoveryFn:  discoverAllSchemaTables,
+				schemaDiscoveryFn: pglib.DiscoverAllSchemas,
+				tableDiscoveryFn:  pglib.DiscoverAllSchemaTables,
 			}
 			err := tableFinder.CreateSnapshot(context.Background(), tc.snapshot)
 			if tc.wantErr != nil {


### PR DESCRIPTION
This PR updates the syncing of the schemalog table to properly handle wildcard schemas. Currently it was creating a "*" schema since it didn't explode it into the relevant ones. 
Since the schemalog table wasn't recording the right schemas, this was affecting DDL replication as well when using the `*.*` filter on snapshots.

Schema/table discovery utilities have been extracted into the postgres library, since they were used in multiple places. The `dump-file` flag has been added to the run command (already supported in the snapshot cmd), to allow for easier debugging when using the run command with initial snapshot enabled.


Fixes https://github.com/xataio/pgstream/issues/504