### PR TITLE
[Snapshots] Use repeatable snapshot default only when recorder provided

### DIFF
--- a/cmd/snapshot_cmd.go
+++ b/cmd/snapshot_cmd.go
@@ -51,8 +51,10 @@ func snapshotFlagBinding(cmd *cobra.Command, args []string) error {
 	viper.BindPFlag("source.postgres.snapshot.tables", cmd.Flags().Lookup("tables"))
 	viper.BindPFlag("source.postgres.snapshot.schema.pgdump_pgrestore.clean_target_db", cmd.Flags().Lookup("reset"))
 	viper.BindPFlag("source.postgres.snapshot.schema.pgdump_pgrestore.dump_file", cmd.Flags().Lookup("dump-file"))
-	// if not explicitly set, default to repeatable for snapshot command
-	if viper.GetString("source.postgres.snapshot.recorder.repeatable_snapshots") == "" {
+	// if not explicitly set, default to repeatable for snapshot command if the
+	// snapshot recorder is provided
+	if viper.IsSet("source.postgres.snapshot.recorder") &&
+		viper.GetString("source.postgres.snapshot.recorder.repeatable_snapshots") == "" {
 		viper.Set("source.postgres.snapshot.recorder.repeatable_snapshots", true)
 	}
 
@@ -67,8 +69,10 @@ func snapshotFlagBinding(cmd *cobra.Command, args []string) error {
 	viper.BindPFlag("PGSTREAM_POSTGRES_SNAPSHOT_TABLES", cmd.Flags().Lookup("tables"))
 	viper.BindPFlag("PGSTREAM_POSTGRES_SNAPSHOT_CLEAN_TARGET_DB", cmd.Flags().Lookup("reset"))
 	viper.BindPFlag("PGSTREAM_POSTGRES_SNAPSHOT_SCHEMA_DUMP_FILE", cmd.Flags().Lookup("dump-file"))
-	// if not explicitly set, default to repeatable for snapshot command
-	if viper.GetString("PGSTREAM_POSTGRES_SNAPSHOT_STORE_REPEATABLE") == "" {
+	// if not explicitly set, default to repeatable for snapshot command if the
+	// snapshot recorder is provided
+	if viper.GetString("PGSTREAM_POSTGRES_SNAPSHOT_STORE_URL") != "" &&
+		viper.GetString("PGSTREAM_POSTGRES_SNAPSHOT_STORE_REPEATABLE") == "" {
 		viper.Set("PGSTREAM_POSTGRES_SNAPSHOT_STORE_REPEATABLE", true)
 	}
 


### PR DESCRIPTION
#### Description

This PR updates the snapshot command to only apply a default to the repeatable snapshots configuration when the snapshot recorder is provided. Otherwise it makes the recorder section required, when it should be optional.

##### Related Issue(s)

- Fixes #(issue number)
- Closes #(issue number)
- Related to #(issue number)

#### Type of Change

Please select the relevant option(s):

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

-
-
-

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Code is well-commented
- [ ] Documentation updated where necessary


#### Additional Notes

<!-- Any context or special instructions for reviewers -->
