### PR TITLE
Add TCP keepalives to the postgres connections

### DIFF
--- a/internal/postgres/pg_conn.go
+++ b/internal/postgres/pg_conn.go
@@ -19,6 +19,8 @@ func NewConn(ctx context.Context, url string) (*Conn, error) {
 		return nil, fmt.Errorf("failed parsing postgres connection string: %w", mapError(err))
 	}
 
+	configureTCPKeepalive(pgCfg)
+
 	conn, err := pgx.ConnectConfig(ctx, pgCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to postgres: %w", mapError(err))

--- a/internal/postgres/pg_conn_pool.go
+++ b/internal/postgres/pg_conn_pool.go
@@ -28,6 +28,8 @@ func NewConnPool(ctx context.Context, url string) (*Pool, error) {
 	pgCfg.MaxConns = maxConns
 	pgCfg.AfterConnect = registerTypesToConnMap
 
+	configureTCPKeepalive(pgCfg.ConnConfig)
+
 	pool, err := pgxpool.NewWithConfig(ctx, pgCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a postgres connection pool: %w", mapError(err))

--- a/internal/postgres/pg_replication_conn.go
+++ b/internal/postgres/pg_replication_conn.go
@@ -43,6 +43,8 @@ func NewReplicationConn(ctx context.Context, url string) (*ReplicationConn, erro
 
 	pgCfg.RuntimeParams["replication"] = "database"
 
+	configureTCPKeepalive(pgCfg)
+
 	conn, err := pgconn.ConnectConfig(context.Background(), &pgCfg.Config)
 	if err != nil {
 		return nil, fmt.Errorf("create postgres replication client: %w", mapError(err))


### PR DESCRIPTION
#### Description

This enables TCP keepalive configuration (with the Go defaults) in order to detect and break on stuck connections.

##### Related Issue(s)

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup


#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

#### Checklist

- [ ] Code follows project style guidelines
- [x] Self-review completed
- [ ] Code is well-commented
- [ ] Documentation updated where necessary


#### Additional Notes

<!-- Any context or special instructions for reviewers -->
