### PR TITLE
Fix ordering of DROP TRIGGER statements in the filtered schema

### DIFF
--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -470,6 +470,7 @@ func (s *SnapshotGenerator) parseDump(d []byte) *dump {
 			strings.HasPrefix(line, "CREATE UNIQUE INDEX"),
 			strings.HasPrefix(line, "CREATE CONSTRAINT"),
 			strings.HasPrefix(line, "CREATE TRIGGER"),
+			strings.HasPrefix(line, "DROP TRIGGER"),
 			strings.HasPrefix(line, "COMMENT ON CONSTRAINT"),
 			strings.HasPrefix(line, "COMMENT ON INDEX"),
 			strings.HasPrefix(line, "COMMENT ON TRIGGER"):

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump_constraints.sql
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump_constraints.sql
@@ -1,5 +1,9 @@
 \connect test
 
+DROP TRIGGER IF EXISTS a_del_alternative_release ON musicbrainz.alternative_release;
+
+DROP TRIGGER IF EXISTS a_del_alternative_medium_track ON musicbrainz.alternative_medium_track;
+
 ALTER TABLE ONLY musicbrainz.alternative_medium
     ADD CONSTRAINT alternative_medium_pkey PRIMARY KEY (id);
 

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump_filtered.sql
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump_filtered.sql
@@ -21,8 +21,6 @@ SET row_security = off;
 
 ALTER TABLE IF EXISTS ONLY musicbrainz.alternative_medium DROP CONSTRAINT IF EXISTS alternative_medium_fk_medium;
 ALTER TABLE IF EXISTS ONLY musicbrainz.alternative_medium DROP CONSTRAINT IF EXISTS alternative_medium_fk_alternative_release;
-DROP TRIGGER IF EXISTS a_del_alternative_release ON musicbrainz.alternative_release;
-DROP TRIGGER IF EXISTS a_del_alternative_medium_track ON musicbrainz.alternative_medium_track;
 DROP INDEX IF EXISTS musicbrainz.alternative_release_idx_artist_credit;
 DROP INDEX IF EXISTS musicbrainz.alternative_medium_idx_alternative_release;
 ALTER TABLE IF EXISTS ONLY musicbrainz.alternative_medium_track DROP CONSTRAINT IF EXISTS alternative_medium_track_pkey;


### PR DESCRIPTION
#### Description

In a similar issue with https://github.com/xataio/pgstream/pull/573 we're seeing error of this form:

```
ERROR: relation "public.table" does not exist
```

Which seem to come from DROP TRIGGER statmenets in the filtered schema like:

```
DROP TRIGGER IF EXISTS trigger_name ON public.table;
```

because it's called before `public.table` is created.

##### Related Issue(s)

- Fixes #(issue number)
- Closes #(issue number)
- Related to #(issue number)

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

-
-
-

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

#### Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Code is well-commented
- [ ] Documentation updated where necessary


#### Additional Notes

<!-- Any context or special instructions for reviewers -->
