### PR TITLE
[Snapshots] Split restore for improved progress tracking

### DIFF
--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -164,6 +164,8 @@ func (s *SnapshotGenerator) CreateSnapshot(ctx context.Context, ss *snapshot.Sna
 		return nil
 	}
 
+	// DUMP
+
 	dump, err := s.dumpSchema(ctx, dumpSchemas, ss.SchemaExcludedTables)
 	if err != nil {
 		return err
@@ -185,38 +187,47 @@ func (s *SnapshotGenerator) CreateSnapshot(ctx context.Context, ss *snapshot.Sna
 		return err
 	}
 
-	// the cleanup part will drop all the objects before we execute the roles dump,
-	// and this will allow us to drop the roles safely, in case `clean_target_db` is enabled.
-	preDataDump := dump.cleanupPart
-	preDataDump = append(preDataDump, rolesDump...)
-	preDataDump = append(preDataDump, dump.filtered...)
+	// RESTORE
 
-	postDataDump := sequenceDump
-	postDataDump = append(postDataDump, dump.indicesAndConstraints...)
-
-	// if there's no further snapshotting happening, we can apply the full dump,
-	// no need to wait to apply the constraints/indices.
-	if s.generator == nil {
-		dumpsToRestore := preDataDump
-		dumpsToRestore = append(dumpsToRestore, postDataDump...)
-		return s.restoreDump(ctx, dumpSchemas, dumpsToRestore)
-	}
-
-	// otherwise, we need to apply the roles dump along with the filtered schema dump first,
-	// then call the wrapped snapshot generator, and apply the indices and constraints last.
-	// This will make the data snapshot faster, since there will be no
-	// constraints to be updated/checked on each insert.
-	if err := s.restoreDump(ctx, dumpSchemas, preDataDump); err != nil {
+	if err := s.restoreSchemas(ctx, dumpSchemas); err != nil {
 		return err
 	}
 
-	if err := s.generator.CreateSnapshot(ctx, ss); err != nil {
+	if s.optionGenerator.cleanTargetDB {
+		s.logger.Info("restoring cleanup")
+		if err := s.restoreDump(ctx, dump.cleanupPart); err != nil {
+			return err
+		}
+	}
+
+	if rolesDump != nil {
+		s.logger.Info("restoring roles")
+		if err := s.restoreDump(ctx, rolesDump); err != nil {
+			return err
+		}
+	}
+
+	s.logger.Info("restoring schema")
+	if err := s.restoreDump(ctx, dump.filtered); err != nil {
+		return err
+	}
+
+	// call the wrapped snapshot generator if any before restoring sequences,
+	// indices and constraints to improve performance.
+	if s.generator != nil {
+		if err := s.generator.CreateSnapshot(ctx, ss); err != nil {
+			return err
+		}
+	}
+
+	// apply the sequences, indices and constraints when the wrapped generator has finished
+	s.logger.Info("restoring sequence data", loglib.Fields{"schemaTables": ss.SchemaTables})
+	if err := s.restoreDump(ctx, sequenceDump); err != nil {
 		return err
 	}
 
 	s.logger.Info("restoring schema indices and constraints", loglib.Fields{"schemaTables": ss.SchemaTables})
-	// apply the indices and constraints when the wrapped generator has finished
-	return s.restoreDump(ctx, dumpSchemas, postDataDump)
+	return s.restoreDump(ctx, dump.indicesAndConstraints)
 }
 
 func (s *SnapshotGenerator) Close() error {
@@ -320,10 +331,10 @@ func (s *SnapshotGenerator) dumpRoles(ctx context.Context, rolesInSchemaDump map
 	return filteredRolesDump, nil
 }
 
-func (s *SnapshotGenerator) restoreDump(ctx context.Context, schemaTables map[string][]string, dump []byte) error {
-	// if we use table filtering in the pg_dump command, the schema creation
-	// will not be dumped, so it needs to be created explicitly (except for
-	// public schema)
+// if we use table filtering in the pg_dump command, the schema creation will
+// not be dumped, so it needs to be created explicitly (except for public
+// schema)
+func (s *SnapshotGenerator) restoreSchemas(ctx context.Context, schemaTables map[string][]string) error {
 	for schema, tables := range schemaTables {
 		if len(tables) > 0 && schema != publicSchema && schema != wildcard {
 			if err := s.createSchemaIfNotExists(ctx, schema); err != nil {
@@ -331,7 +342,13 @@ func (s *SnapshotGenerator) restoreDump(ctx context.Context, schemaTables map[st
 			}
 		}
 	}
+	return nil
+}
 
+func (s *SnapshotGenerator) restoreDump(ctx context.Context, dump []byte) error {
+	if len(dump) == 0 {
+		return nil
+	}
 	_, err := s.pgRestoreFn(ctx, s.optionGenerator.pgrestoreOptions(), dump)
 	pgrestoreErr := &pglib.PGRestoreErrors{}
 	if err != nil {

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
@@ -25,14 +25,14 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 	t.Parallel()
 
 	schemaDump := []byte("schema dump\nCREATE SEQUENCE test.test_sequence\nALTER TABLE public.test_table OWNER TO test_role;\nGRANT ALL ON TABLE public.test_table TO test_role2;\nCREATE INDEX a;\n")
-	schemaDumpNoSequences := []byte("schema dump\n")
+	schemaDumpNoSequences := []byte("schema dump\nALTER TABLE public.test_table OWNER TO test_role;\nGRANT ALL ON TABLE public.test_table TO test_role2;\nCREATE INDEX a;\n")
+	filteredDumpNoSequences := []byte("schema dump\nALTER TABLE public.test_table OWNER TO test_role;\nGRANT ALL ON TABLE public.test_table TO test_role2;\n")
 	filteredDump := []byte("schema dump\nCREATE SEQUENCE test.test_sequence\nALTER TABLE public.test_table OWNER TO test_role;\nGRANT ALL ON TABLE public.test_table TO test_role2;\n")
 	sequenceDump := []byte("sequence dump\n")
 	indexDump := []byte("CREATE INDEX a;\n\n")
 	rolesDumpOriginal := []byte("roles dump\nCREATE ROLE postgres\nCREATE ROLE test_role\nCREATE ROLE test_role2\nALTER ROLE test_role3 INHERIT FROM test_role;\n")
 	rolesDumpFiltered := []byte("roles dump\nCREATE ROLE test_role\nCREATE ROLE test_role2\nGRANT \"test_role\" TO CURRENT_USER;\nGRANT ALL ON SCHEMA \"public\" TO \"test_role\";\n")
 	rolesDumpFilteredWithCleanup := []byte("REVOKE ALL ON SCHEMA \"public\" FROM \"test_role\";\nroles dump\nCREATE ROLE test_role\nCREATE ROLE test_role2\nGRANT \"test_role\" TO CURRENT_USER;\nGRANT ALL ON SCHEMA \"public\" TO \"test_role\";\n")
-	roleDumpEmpty := []byte("roles dump\n")
 	cleanupDump := []byte("cleanup dump\n")
 	testSchema := "test_schema"
 	testTable := "test_table"
@@ -43,10 +43,25 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 	testSequence := pglib.QuoteQualifiedIdentifier("test", "test_sequence")
 	testRole := "test_role"
 
-	restoreFullDump := rolesDumpFiltered
-	restoreFullDump = append(restoreFullDump, filteredDump...)
-	restoreFullDump = append(restoreFullDump, sequenceDump...)
-	restoreFullDump = append(restoreFullDump, indexDump...)
+	fullDumpRestoreFn := func(_ context.Context, i uint, po pglib.PGRestoreOptions, dump []byte) (string, error) {
+		require.Equal(t, pglib.PGRestoreOptions{
+			ConnectionString: "target-url",
+			Format:           "p",
+		}, po)
+		switch i {
+		case 1:
+			require.Equal(t, string(rolesDumpFiltered), string(dump))
+		case 2:
+			require.Equal(t, string(filteredDump), string(dump))
+		case 3:
+			require.Equal(t, string(sequenceDump), string(dump))
+		case 4:
+			require.Equal(t, string(indexDump), string(dump))
+		default:
+			return "", fmt.Errorf("unexpected call to pgrestoreFn: %d", i)
+		}
+		return "", nil
+	}
 
 	validQuerier := func() *mocks.Querier {
 		return &mocks.Querier{
@@ -179,14 +194,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 					return nil, fmt.Errorf("unexpected call to pgdumpallFn: %d", i)
 				}
 			}),
-			pgrestoreFn: func(_ context.Context, po pglib.PGRestoreOptions, dump []byte) (string, error) {
-				require.Equal(t, pglib.PGRestoreOptions{
-					ConnectionString: "target-url",
-					Format:           "p",
-				}, po)
-				require.Equal(t, string(restoreFullDump), string(dump))
-				return "", nil
-			},
+			pgrestoreFn:  newMockPgrestore(fullDumpRestoreFn),
 			role:         testRole,
 			noOwner:      true,
 			noPrivileges: true,
@@ -228,14 +236,23 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 					return nil, fmt.Errorf("unexpected call to pgdumpallFn: %d", i)
 				}
 			}),
-			pgrestoreFn: func(_ context.Context, po pglib.PGRestoreOptions, dump []byte) (string, error) {
+			pgrestoreFn: newMockPgrestore(func(_ context.Context, i uint, po pglib.PGRestoreOptions, dump []byte) (string, error) {
 				require.Equal(t, pglib.PGRestoreOptions{
 					ConnectionString: "target-url",
 					Format:           "p",
 				}, po)
-				require.Equal(t, string(append(roleDumpEmpty, schemaDumpNoSequences...)), string(dump))
+				switch i {
+				case 1:
+					require.Equal(t, string(rolesDumpFiltered), string(dump))
+				case 2:
+					require.Equal(t, string(filteredDumpNoSequences), string(dump))
+				case 3:
+					require.Equal(t, string(indexDump), string(dump))
+				default:
+					return "", fmt.Errorf("unexpected call to pgrestoreFn: %d", i)
+				}
 				return "", nil
-			},
+			}),
 
 			wantErr: nil,
 		},
@@ -282,21 +299,8 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 					return nil, fmt.Errorf("unexpected call to pgdumpallFn: %d", i)
 				}
 			}),
-			pgrestoreFn: newMockPgrestore(func(_ context.Context, i uint, po pglib.PGRestoreOptions, dump []byte) (string, error) {
-				require.Equal(t, pglib.PGRestoreOptions{
-					ConnectionString: "target-url",
-					Format:           "p",
-				}, po)
-				switch i {
-				case 1:
-					require.Equal(t, string(append(rolesDumpFiltered, filteredDump...)), string(dump))
-				case 2:
-					require.Equal(t, string(append(sequenceDump, indexDump...)), string(dump))
-				default:
-					return "", fmt.Errorf("unexpected call to pgrestoreFn: %d", i)
-				}
-				return "", nil
-			}),
+			pgrestoreFn: newMockPgrestore(fullDumpRestoreFn),
+
 			generator: &generatormocks.Generator{
 				CreateSnapshotFn: func(ctx context.Context, ss *snapshot.Snapshot) error {
 					require.Equal(t, &snapshot.Snapshot{
@@ -352,14 +356,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 					return nil, fmt.Errorf("unexpected call to pgdumpallFn: %d", i)
 				}
 			}),
-			pgrestoreFn: func(_ context.Context, po pglib.PGRestoreOptions, dump []byte) (string, error) {
-				require.Equal(t, pglib.PGRestoreOptions{
-					ConnectionString: "target-url",
-					Format:           "p",
-				}, po)
-				require.Equal(t, string(restoreFullDump), string(dump))
-				return "", nil
-			},
+			pgrestoreFn: newMockPgrestore(fullDumpRestoreFn),
 
 			wantErr: nil,
 		},
@@ -408,14 +405,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 					return nil, fmt.Errorf("unexpected call to pgdumpallFn: %d", i)
 				}
 			}),
-			pgrestoreFn: func(_ context.Context, po pglib.PGRestoreOptions, dump []byte) (string, error) {
-				require.Equal(t, pglib.PGRestoreOptions{
-					ConnectionString: "target-url",
-					Format:           "p",
-				}, po)
-				require.Equal(t, string(restoreFullDump), string(dump))
-				return "", nil
-			},
+			pgrestoreFn: newMockPgrestore(fullDumpRestoreFn),
 
 			wantErr: nil,
 		},
@@ -460,15 +450,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 					return nil, fmt.Errorf("unexpected call to pgdumpallFn: %d", i)
 				}
 			}),
-			pgrestoreFn: func(_ context.Context, po pglib.PGRestoreOptions, dump []byte) (string, error) {
-				require.Equal(t, pglib.PGRestoreOptions{
-					ConnectionString: "target-url",
-					Format:           "p",
-				}, po)
-
-				require.Equal(t, string(restoreFullDump), string(dump))
-				return "", nil
-			},
+			pgrestoreFn: newMockPgrestore(fullDumpRestoreFn),
 
 			wantErr: nil,
 		},
@@ -516,14 +498,23 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 					return nil, fmt.Errorf("unexpected call to pgdumpallFn: %d", i)
 				}
 			}),
-			pgrestoreFn: func(_ context.Context, po pglib.PGRestoreOptions, dump []byte) (string, error) {
+			pgrestoreFn: newMockPgrestore(func(_ context.Context, i uint, po pglib.PGRestoreOptions, dump []byte) (string, error) {
 				require.Equal(t, pglib.PGRestoreOptions{
 					ConnectionString: "target-url",
 					Format:           "p",
 				}, po)
-				require.Equal(t, append(filteredDump, append(sequenceDump, indexDump...)...), dump)
+				switch i {
+				case 1:
+					require.Equal(t, string(filteredDump), string(dump))
+				case 2:
+					require.Equal(t, string(sequenceDump), string(dump))
+				case 3:
+					require.Equal(t, string(indexDump), string(dump))
+				default:
+					return "", fmt.Errorf("unexpected call to pgrestoreFn: %d", i)
+				}
 				return "", nil
-			},
+			}),
 
 			wantErr: nil,
 		},
@@ -571,14 +562,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 					return nil, fmt.Errorf("unexpected call to pgdumpallFn: %d", i)
 				}
 			}),
-			pgrestoreFn: func(_ context.Context, po pglib.PGRestoreOptions, dump []byte) (string, error) {
-				require.Equal(t, pglib.PGRestoreOptions{
-					ConnectionString: "target-url",
-					Format:           "p",
-				}, po)
-				require.Equal(t, string(restoreFullDump), string(dump))
-				return "", nil
-			},
+			pgrestoreFn: newMockPgrestore(fullDumpRestoreFn),
 
 			wantErr: nil,
 		},
@@ -634,21 +618,29 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 					return nil, fmt.Errorf("unexpected call to pgdumpallFn: %d", i)
 				}
 			}),
-			pgrestoreFn: func(_ context.Context, po pglib.PGRestoreOptions, dump []byte) (string, error) {
+			pgrestoreFn: newMockPgrestore(func(_ context.Context, i uint, po pglib.PGRestoreOptions, dump []byte) (string, error) {
 				require.Equal(t, pglib.PGRestoreOptions{
 					ConnectionString: "target-url",
 					Format:           "p",
 					Clean:            true,
 				}, po)
-				expectedDump := cleanupDump
-				expectedDump = append(expectedDump, rolesDumpFilteredWithCleanup...)
-				expectedDump = append(expectedDump, cleanupDump...) // because we're not removing the duplicate cleanup dump for now
-				expectedDump = append(expectedDump, filteredDump...)
-				expectedDump = append(expectedDump, sequenceDump...)
-				expectedDump = append(expectedDump, indexDump...)
-				require.Equal(t, string(expectedDump), string(dump))
+				switch i {
+				case 1:
+					require.Equal(t, string(cleanupDump), string(dump))
+				case 2:
+					require.Equal(t, string(rolesDumpFilteredWithCleanup), string(dump))
+				case 3:
+					// because we're not removing the duplicate cleanup dump for now
+					require.Equal(t, string(append(cleanupDump, filteredDump...)), string(dump))
+				case 4:
+					require.Equal(t, string(sequenceDump), string(dump))
+				case 5:
+					require.Equal(t, string(indexDump), string(dump))
+				default:
+					return "", fmt.Errorf("unexpected call to pgrestoreFn: %d", i)
+				}
 				return "", nil
-			},
+			}),
 
 			wantErr: nil,
 		},
@@ -1156,10 +1148,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 					return nil, fmt.Errorf("unexpected call to pgdumpallFn: %d", i)
 				}
 			}),
-			pgrestoreFn: func(_ context.Context, po pglib.PGRestoreOptions, dump []byte) (string, error) {
-				require.Equal(t, string(restoreFullDump), string(dump))
-				return "", nil
-			},
+			pgrestoreFn: newMockPgrestore(fullDumpRestoreFn),
 			schemalogStore: &schemalogmocks.Store{
 				InsertFn: func(ctx context.Context, schemaName string) (*schemalog.LogEntry, error) {
 					return nil, errTest


### PR DESCRIPTION
#### Description

This PR splits the restore operations so that each individual step is logged and tracked separately. This should help with progress tracking for schema snapshots. 

##### Related Issue(s)

- Related to #607 

#### Type of Change

- [X] 🔧 Refactoring (no functional changes)

#### Testing

- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [X] All existing tests pass

#### Additional context

Logging before:
```
2025-11-13T14:47:02.951799+01:00 INF logger.go:43 > creating schema snapshot module=postgres_schema_snapshot_generator schemaTables={"public":["aka_title"]}
2025-11-13T14:47:03.253904+01:00 INF logger.go:43 > creating data snapshot module=postgres_data_snapshot_generator schema=public tables=["aka_title"]
[public] Snapshotting data... 100% [====================] (51/51 MB, 11 MB/s) [4s]
2025-11-13T14:47:07.968183+01:00 INF logger.go:43 > restoring schema indices and constraints module=postgres_schema_snapshot_generator schemaTables={"public":["aka_title"]}
```

Logging after:
```
2025-11-13T14:02:43.224559+01:00 INF logger.go:43 > creating schema snapshot module=postgres_schema_snapshot_generator schemaTables={"public":["aka_title"]}
2025-11-13T14:02:43.452025+01:00 INF logger.go:43 > restoring cleanup module=postgres_schema_snapshot_generator
2025-11-13T14:02:43.491369+01:00 INF logger.go:43 > restoring roles module=postgres_schema_snapshot_generator
2025-11-13T14:02:43.515093+01:00 INF logger.go:43 > restoring schema module=postgres_schema_snapshot_generator
2025-11-13T14:02:43.548185+01:00 INF logger.go:43 > creating data snapshot module=postgres_data_snapshot_generator schema=public tables=["aka_title"]
[public] Snapshotting data... 100% [====================] (51/51 MB, 12 MB/s) [4s]
2025-11-13T14:02:47.902153+01:00 INF logger.go:43 > restoring sequence data module=postgres_schema_snapshot_generator schemaTables={"public":["aka_title"]}
2025-11-13T14:02:47.902226+01:00 INF logger.go:43 > restoring schema indices and constraints module=postgres_schema_snapshot_generator schemaTables={"public":["aka_title"]}
```

