### PR TITLE
Fix ddl adapter nil panic

### DIFF
--- a/pkg/wal/processor/postgres/postgres_wal_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_adapter.go
@@ -51,7 +51,7 @@ func newAdapter(ctx context.Context, schemaQuerier schemalogQuerier, logger logl
 		return nil, err
 	}
 
-	var ddl *ddlAdapter
+	var ddl ddlQueryAdapter
 	if schemaQuerier != nil {
 		ddl = newDDLAdapter(schemaQuerier)
 	}


### PR DESCRIPTION
#### Description

Prevents a panic on DDL WAL events by avoiding a typed-nil interface for the DDL adapter.

#### Type of Change

Please select the relevant option(s):

- [x ] 🐛 Bug fix (non-breaking change that fixes an issue)

#### Changes Made

Initialize the DDL adapter as an interface so the nil check works and avoids the nil-pointer panic in the batch writer.

#### Testing

- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
