### PR TITLE
Use qualified sequence name when querying from pg

### DIFF
--- a/pkg/wal/processor/postgres/postgres_schema_observer.go
+++ b/pkg/wal/processor/postgres/postgres_schema_observer.go
@@ -238,7 +238,7 @@ func (o *pgSchemaObserver) queryTableSequences(ctx context.Context, conn pglib.Q
 		if err := rows.Scan(&columnName, &sequenceName); err != nil {
 			return nil, fmt.Errorf("scanning sequence column mapping: %w", err)
 		}
-		seqColMap[pglib.QuoteIdentifier(columnName)] = sequenceName
+		seqColMap[pglib.QuoteIdentifier(columnName)] = pglib.QuoteQualifiedIdentifier(schemaName, sequenceName)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/pkg/wal/processor/postgres/postgres_schema_observer_test.go
+++ b/pkg/wal/processor/postgres/postgres_schema_observer_test.go
@@ -381,6 +381,9 @@ func TestPGSchemaObserver_getSequenceColumns(t *testing.T) {
 	createdAtColumn := `"created_at"`
 	idSequenceName := "id_seq"
 	createdAtSequenceName := "created_at_seq"
+	quoteQualifiedSequenceName := func(seq string) string {
+		return pglib.QuoteQualifiedIdentifier("test_schema", seq)
+	}
 
 	tests := []struct {
 		name                 string
@@ -418,7 +421,7 @@ func TestPGSchemaObserver_getSequenceColumns(t *testing.T) {
 
 			wantColumns: []string{idColumn},
 			wantColumnTableSequences: map[string]map[string]string{
-				quotedQualifiedTableName: {idColumn: idSequenceName},
+				quotedQualifiedTableName: {idColumn: quoteQualifiedSequenceName(idSequenceName)},
 			},
 			wantErr: nil,
 		},
@@ -459,8 +462,8 @@ func TestPGSchemaObserver_getSequenceColumns(t *testing.T) {
 			wantColumns: []string{idColumn, createdAtColumn},
 			wantColumnTableSequences: map[string]map[string]string{
 				quotedQualifiedTableName: {
-					idColumn:        idSequenceName,
-					createdAtColumn: createdAtSequenceName,
+					idColumn:        quoteQualifiedSequenceName(idSequenceName),
+					createdAtColumn: quoteQualifiedSequenceName(createdAtSequenceName),
 				},
 			},
 			wantErr: nil,
@@ -468,7 +471,7 @@ func TestPGSchemaObserver_getSequenceColumns(t *testing.T) {
 		{
 			name: "ok - existing table in cache",
 			columnTableSequences: map[string]map[string]string{
-				quotedQualifiedTableName: {idColumn: idSequenceName},
+				quotedQualifiedTableName: {idColumn: quoteQualifiedSequenceName(idSequenceName)},
 			},
 			pgConn: &pgmocks.Querier{
 				QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
@@ -478,7 +481,7 @@ func TestPGSchemaObserver_getSequenceColumns(t *testing.T) {
 
 			wantColumns: []string{idColumn},
 			wantColumnTableSequences: map[string]map[string]string{
-				quotedQualifiedTableName: {idColumn: idSequenceName},
+				quotedQualifiedTableName: {idColumn: quoteQualifiedSequenceName(idSequenceName)},
 			},
 			wantErr: nil,
 		},
@@ -779,7 +782,7 @@ func TestPGSchemaObserver_queryTableSequences(t *testing.T) {
 					}, nil
 				},
 			},
-			wantSeqCols: map[string]string{`"id"`: "id_seq"},
+			wantSeqCols: map[string]string{`"id"`: `"test_schema"."id_seq"`},
 			wantErr:     nil,
 		},
 		{
@@ -819,9 +822,9 @@ func TestPGSchemaObserver_queryTableSequences(t *testing.T) {
 				},
 			},
 			wantSeqCols: map[string]string{
-				`"id"`:         "id_seq",
-				`"order_id"`:   "order_id_seq",
-				`"created_at"`: "created_at_seq",
+				`"id"`:         `"test_schema"."id_seq"`,
+				`"order_id"`:   `"test_schema"."order_id_seq"`,
+				`"created_at"`: `"test_schema"."created_at_seq"`,
 			},
 			wantErr: nil,
 		},


### PR DESCRIPTION
#### Description

This PR updates the schema observer used by the postgres query adapter to use the qualified name of the sequence name (including schema) when building the column sequence map from postgres. The schema log map was built correctly, but the results from the postgres query were not adding the schema. 

This could lead to not found errors when setting the value for a sequence within a custom schema instead of public.

##### Related Issue(s)

- Fixes https://github.com/xataio/pgstream/issues/669

#### Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)

#### Testing

- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [X] All existing tests pass
