### PR TITLE
Fix double encoding in postgres password

### DIFF
--- a/internal/postgres/pg_utils.go
+++ b/internal/postgres/pg_utils.go
@@ -237,8 +237,17 @@ func escapeConnectionURL(rawURL string) (string, error) {
 	if username == "" {
 		return "", errInvalidURL
 	}
+
+	// Decode any percent-encoded characters in the password before re-encoding
+	// to avoid double-encoding that would break authentication
+	decodedPassword := password
+	if strings.Contains(password, "%") {
+		if unescapedPwd, err := url.PathUnescape(password); err == nil {
+			decodedPassword = unescapedPwd
+		}
+	}
 	// URL encode the password
-	encodedPassword := url.QueryEscape(password)
+	encodedPassword := url.QueryEscape(decodedPassword)
 
 	return fmt.Sprintf("%s%s:%s@%s", scheme, username, encodedPassword, hostAndPath), nil
 }

--- a/internal/postgres/pg_utils_test.go
+++ b/internal/postgres/pg_utils_test.go
@@ -325,6 +325,12 @@ func Test_escapeConnectionURL(t *testing.T) {
 			expected: "",
 			wantErr:  errInvalidURL,
 		},
+		{
+			name:     "postgres url escaped password",
+			rawURL:   "postgres://user:p%5Essword@localhost:5432/mydb",
+			expected: "postgres://user:p%5Essword@localhost:5432/mydb",
+			wantErr:  nil,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
#### Description

This PR updates the password escaping logic to handle passwords that are already escaped, and prevent double encoding.

##### Related Issue(s)

- Fixes #680 

#### Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)

#### Testing

- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [X] All existing tests pass

