### PR TITLE
Fix tstzrange with nil upper or lower value

### DIFF
--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
@@ -353,10 +353,13 @@ func getTypedTSTZRange(value any) any {
 	}
 
 	lower, lowerOk := v.Lower.(time.Time)
-	upper, upperOk := v.Upper.(time.Time)
+	if !lowerOk {
+		lower = time.Time{}
+	}
 
-	if !lowerOk || !upperOk {
-		return value
+	upper, upperOk := v.Upper.(time.Time)
+	if !upperOk {
+		upper = time.Time{}
 	}
 
 	return pgtype.Range[time.Time]{


### PR DESCRIPTION
#### Description

The previous change to add support for tstzrange in snapshots did not take into account the upper or lower bounds being able to be empty/null making them "infinity" values.

This change sets any nil upper or lower value to an empty `time.Time` struct which pgx evaluates correctly as being empty.

##### Related Issue(s)

- Related to #692 

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Checks upper and lower value of range to see if it is nil, if it is sets a zero value time.Time
-
-

#### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

#### Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Code is well-commented
- [ ] Documentation updated where necessary


#### Additional Notes

<!-- Any context or special instructions for reviewers -->
