### PR TITLE
Fix improper formatting variable in tests

### DIFF
--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_test.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_test.go
@@ -85,7 +85,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 	validMaxPageQueryFn := func(args ...any) error {
 		require.Len(t, args, 1)
 		ctid, ok := args[0].(*pgtype.TID)
-		require.True(t, ok, fmt.Sprintf("ctid, expected *pgtype.TID, got %t", args[0]))
+		require.True(t, ok, fmt.Sprintf("ctid, expected *pgtype.TID, got %T", args[0]))
 		*ctid = testMaxCTID
 		return nil
 	}


### PR DESCRIPTION
#### Description
We want it to print the type not the boolean value.

Fixing this as I introduced it in #713 and didn't notice until copilot brought it up.

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [x] 🧹 Code cleanup

#### Changes Made

- Changed the string formatting variable to print the type instead of a bool 
-
-

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

#### Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Code is well-commented
- [ ] Documentation updated where necessary


#### Additional Notes

<!-- Any context or special instructions for reviewers -->
