### PR TITLE
[Snapshots] Set concurrency limit on snapshot recorder

### DIFF
--- a/cmd/config/config_env.go
+++ b/cmd/config/config_env.go
@@ -286,7 +286,7 @@ func parseSnapshotConfig(pgURL string) (*snapshotbuilder.SnapshotListenerConfig,
 		cfg.Recorder = &snapshotbuilder.SnapshotRecorderConfig{
 			RepeatableSnapshots: viper.GetBool("PGSTREAM_POSTGRES_SNAPSHOT_STORE_REPEATABLE"),
 			SnapshotStoreURL:    storeURL,
-			SchemaWorkers:       viper.GetUint("PGSTREAM_POSTGRES_SNAPSHOT_WORKERS"),
+			SnapshotWorkers:     viper.GetUint("PGSTREAM_POSTGRES_SNAPSHOT_WORKERS"),
 		}
 	}
 

--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -478,7 +478,7 @@ func (c *YAMLConfig) parseSnapshotConfig() (*snapshotbuilder.SnapshotListenerCon
 		streamCfg.Recorder = &snapshotbuilder.SnapshotRecorderConfig{
 			RepeatableSnapshots: snapshotConfig.Recorder.RepeatableSnapshots,
 			SnapshotStoreURL:    snapshotConfig.Recorder.PostgresURL,
-			SchemaWorkers:       uint(snapshotConfig.SnapshotWorkers),
+			SnapshotWorkers:     uint(snapshotConfig.SnapshotWorkers),
 		}
 	}
 

--- a/cmd/config/helper_test.go
+++ b/cmd/config/helper_test.go
@@ -85,7 +85,7 @@ func validateTestStreamConfig(t *testing.T, streamConfig *stream.Config) {
 					Recorder: &builder.SnapshotRecorderConfig{
 						SnapshotStoreURL:    "postgresql://user:password@localhost:5432/mytargetdatabase",
 						RepeatableSnapshots: true,
-						SchemaWorkers:       4,
+						SnapshotWorkers:     4,
 					},
 					DisableProgressTracking: true,
 				},

--- a/pkg/snapshot/generator/snapshot_generator_recorder.go
+++ b/pkg/snapshot/generator/snapshot_generator_recorder.go
@@ -24,12 +24,12 @@ type SnapshotRecorder struct {
 
 type Config struct {
 	RepeatableSnapshots bool
-	SchemaWorkers       uint
+	SnapshotWorkers     uint
 }
 
 const (
-	defaultSchemaWorkers = 1
-	updateTimeout        = time.Minute
+	defaultSnapshotWorkers = 1
+	updateTimeout          = time.Minute
 )
 
 // NewSnapshotRecorder will return the generator on input wrapped with an
@@ -40,7 +40,7 @@ func NewSnapshotRecorder(cfg *Config, store snapshotstore.Store, generator Snaps
 		wrapped:             generator,
 		store:               store,
 		repeatableSnapshots: cfg.RepeatableSnapshots,
-		schemaWorkers:       cfg.schemaWorkers(),
+		schemaWorkers:       cfg.snapshotWorkers(),
 	}
 }
 
@@ -206,9 +206,9 @@ func (s *SnapshotRecorder) filterOutExistingSchemaTables(ctx context.Context, sc
 	return filteredTables, nil
 }
 
-func (c *Config) schemaWorkers() uint {
-	if c.SchemaWorkers <= 0 {
-		return defaultSchemaWorkers
+func (c *Config) snapshotWorkers() uint {
+	if c.SnapshotWorkers <= 0 {
+		return defaultSnapshotWorkers
 	}
-	return c.SchemaWorkers
+	return c.SnapshotWorkers
 }

--- a/pkg/snapshot/generator/snapshot_generator_recorder_test.go
+++ b/pkg/snapshot/generator/snapshot_generator_recorder_test.go
@@ -386,7 +386,7 @@ func TestSnapshotRecorder_CreateSnapshot(t *testing.T) {
 
 			sr := NewSnapshotRecorder(&Config{
 				RepeatableSnapshots: false,
-				SchemaWorkers:       1,
+				SnapshotWorkers:     1,
 			}, tc.store, tc.generator)
 			defer sr.Close()
 

--- a/pkg/wal/listener/snapshot/builder/config.go
+++ b/pkg/wal/listener/snapshot/builder/config.go
@@ -22,6 +22,6 @@ type SchemaSnapshotConfig struct {
 
 type SnapshotRecorderConfig struct {
 	RepeatableSnapshots bool
-	SchemaWorkers       uint
+	SnapshotWorkers     uint
 	SnapshotStoreURL    string
 }

--- a/pkg/wal/listener/snapshot/builder/wal_listener_snapshot_generator_builder.go
+++ b/pkg/wal/listener/snapshot/builder/wal_listener_snapshot_generator_builder.go
@@ -92,7 +92,7 @@ func NewSnapshotGenerator(ctx context.Context, cfg *SnapshotListenerConfig, p li
 		}
 		g = generator.NewSnapshotRecorder(&generator.Config{
 			RepeatableSnapshots: cfg.Recorder.RepeatableSnapshots,
-			SchemaWorkers:       cfg.Recorder.SchemaWorkers,
+			SnapshotWorkers:     cfg.Recorder.SnapshotWorkers,
 		}, snapshotStore, g)
 	}
 


### PR DESCRIPTION
#### Description

This PR sets a limit to the concurrency of the snapshot recorder, preventing unbounded go routines to be started (one per schema), and potentially exhausting the connection pool resources from the source database. It uses the existing snapshot workers configuration which is already applied to the data snapshot. 

This can be a problem when there are many schemas being snapshotted in parallel.

##### Related Issue(s)

- Related to #729 

#### Type of Change

Please select the relevant option(s):

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [X] All existing tests pass

