### PR TITLE
Exclude `pgstream` schema when cleaning up target database

### DIFF
--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/pg_options_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/pg_options_generator.go
@@ -26,6 +26,7 @@ type optionGenerator struct {
 const (
 	roleSnapshotDisabled    = "disabled"
 	roleSnapshotNoPasswords = "no_passwords"
+	pgstreamSchema          = "pgstream"
 )
 
 func newOptionGenerator(querier pglib.Querier, cfg *Config) *optionGenerator {
@@ -101,6 +102,7 @@ func (o *optionGenerator) pgdumpOptions(ctx context.Context, schemaTables map[st
 	case hasWildcardSchema(schemaTables):
 		// no need to filter schemas, since we are including all of them
 		opts.Schemas = nil
+		opts.ExcludeSchemas = []string{pglib.QuoteIdentifier(pgstreamSchema)}
 	case o.includeGlobalDBObjects:
 		// instead of using the schema filter, we use the exclude schemas filter
 		// to make sure extensions and other database global objects are

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/pg_options_generator_test.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/pg_options_generator_test.go
@@ -286,7 +286,7 @@ func TestOptionsGenerator_pgdumpOptions(t *testing.T) {
 			wantOpts: &pglib.PGDumpOptions{
 				ConnectionString: "source-url",
 				Format:           "p",
-				ExcludeSchemas:   []string{`"excluded_schema"`},
+				ExcludeSchemas:   []string{`"pgstream"`, `"excluded_schema"`},
 				SchemaOnly:       true,
 			},
 			wantErr: nil,
@@ -323,7 +323,7 @@ func TestOptionsGenerator_pgdumpOptions(t *testing.T) {
 			wantOpts: &pglib.PGDumpOptions{
 				ConnectionString: "source-url",
 				Format:           "p",
-				ExcludeSchemas:   nil,
+				ExcludeSchemas:   []string{`"pgstream"`},
 				SchemaOnly:       true,
 				ExcludeTables:    []string{`"public"."table3"`},
 			},
@@ -345,7 +345,7 @@ func TestOptionsGenerator_pgdumpOptions(t *testing.T) {
 			wantOpts: &pglib.PGDumpOptions{
 				ConnectionString: "source-url",
 				Format:           "p",
-				ExcludeSchemas:   nil,
+				ExcludeSchemas:   []string{`"pgstream"`},
 				SchemaOnly:       true,
 			},
 			wantErr: nil,

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
@@ -460,6 +460,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 						ConnectionString: "source-url",
 						Format:           "p",
 						SchemaOnly:       true,
+						ExcludeSchemas:   []string{`"pgstream"`},
 						ExcludeTables:    []string{pglib.QuoteQualifiedIdentifier(excludedSchema, excludedTable), pglib.QuoteQualifiedIdentifier(excludedSchema, excludedTable2)},
 					}, po)
 					return schemaDump, nil
@@ -506,6 +507,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 						ConnectionString: "source-url",
 						Format:           "p",
 						SchemaOnly:       true,
+						ExcludeSchemas:   []string{`"pgstream"`},
 					}, po)
 					return schemaDump, nil
 				case 2:
@@ -667,6 +669,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 						Format:           "p",
 						SchemaOnly:       true,
 						Clean:            false,
+						ExcludeSchemas:   []string{`"pgstream"`},
 					}, po)
 					return schemaDump, nil
 				case 2:
@@ -675,6 +678,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 						Format:           "p",
 						SchemaOnly:       true,
 						Clean:            true,
+						ExcludeSchemas:   []string{`"pgstream"`},
 					}, po)
 					return append(cleanupDump, schemaDump...), nil
 				case 3:


### PR DESCRIPTION
#### Description

This PR excludes the schema `pgstream` from dropped objects when `clean_target_db` is set and `pgstream` schema is in the target database.

##### Related Issue(s)

- Fixes #736

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- `DROP SCHEMA pgstream` is filtered out when `clean_target_db` is set and `pgstream` is in the target db

#### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary


#### Additional Notes

Needs manual verification
