### PR TITLE
Fix JSONB string scalar serialization

### DIFF
--- a/pkg/wal/processor/postgres/jsonb_serialization_test.go
+++ b/pkg/wal/processor/postgres/jsonb_serialization_test.go
@@ -83,6 +83,41 @@ func TestFilterRowColumnsJSONBArrayHandling(t *testing.T) {
 	require.Equal(t, "🎉", emoji)
 }
 
+func TestFilterRowColumnsJSONBScalarStringSerialization(t *testing.T) {
+	t.Parallel()
+
+	// Simulates pgx rows.Values() returning a JSON scalar string for a jsonb
+	// column (e.g. rollup_operator storing "FIRST"). The Go string "FIRST" is
+	// not valid JSON and must be serialized (quoted) before being sent to
+	// PostgreSQL via COPY or parameterized queries.
+	cols := []wal.Column{
+		{Name: "id", Type: "integer", Value: 1},
+		{Name: "rollup_operator", Type: "jsonb", Value: "FIRST"},
+	}
+
+	_, values := (&dmlAdapter{}).filterRowColumns(cols, schemaInfo{})
+
+	jsonbResult, ok := values[1].([]byte)
+	require.True(t, ok, "JSONB scalar string should be serialized to []byte, got %T", values[1])
+	require.Equal(t, `"FIRST"`, string(jsonbResult))
+}
+
+func TestFilterRowColumnsJSONScalarStringSerialization(t *testing.T) {
+	t.Parallel()
+
+	// Same as above but for json type (not jsonb)
+	cols := []wal.Column{
+		{Name: "id", Type: "integer", Value: 1},
+		{Name: "operator", Type: "json", Value: "COUNT DISTINCT"},
+	}
+
+	_, values := (&dmlAdapter{}).filterRowColumns(cols, schemaInfo{})
+
+	jsonbResult, ok := values[1].([]byte)
+	require.True(t, ok, "JSON scalar string should be serialized to []byte, got %T", values[1])
+	require.Equal(t, `"COUNT DISTINCT"`, string(jsonbResult))
+}
+
 func TestBuildWhereQueryJSONBHandling(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
@@ -3,6 +3,7 @@
 package postgres
 
 import (
+	stdjson "encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -388,15 +389,24 @@ func isArray(colType string) bool {
 		(len(colType) > 1 && colType[0] == '_')
 }
 
-// serializeJSONBValue pre-serializes JSONB/JSON map/slice values with Sonic to
-// ensure consistent encoding between Sonic (wal2json parsing) and pgx (encoding/json).
-// String values pass through unchanged to avoid double-encoding.
+// serializeJSONBValue pre-serializes JSONB/JSON values to ensure consistent
+// encoding between Sonic (wal2json parsing) and pgx (encoding/json).
+// Map and slice values are always serialized. String values are serialized
+// only if they are not already valid JSON (e.g. JSON scalar strings like
+// "FIRST" from pgx rows.Values()), to avoid double-encoding pre-built JSON
+// documents passed as strings (e.g. from the schemalog snapshot generator).
 func serializeJSONBValue(colType string, val any) any {
 	if (colType == "jsonb" || colType == "json") && val != nil {
-		switch val.(type) {
+		switch v := val.(type) {
 		case map[string]any, []any:
 			if jsonBytes, err := json.Marshal(val); err == nil {
 				return jsonBytes
+			}
+		case string:
+			if !stdjson.Valid([]byte(v)) {
+				if jsonBytes, err := json.Marshal(v); err == nil {
+					return jsonBytes
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#### Description

 serializeJSONBValue did not handle Go string values for jsonb/json columns. When pgx unmarshals a JSON string scalar like "FIRST", it returns a bare Go string without JSON quotes. This was passed through to CopyFrom unchanged, causing PostgreSQL to reject it as invalid JSON.

Add a string case that JSON-encodes values not already valid JSON, while preserving passthrough for pre-built JSON documents.

NOTE: opened against 0.9.x, we need to merge 0.9.x into `main` after releasing.
  
##### Related Issue(s)

- Fixes #743 

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

