### PR TITLE
Fix views order in the pg_dump restore

### DIFF
--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -79,6 +79,7 @@ type dump struct {
 	filtered              []byte
 	cleanupPart           []byte
 	indicesAndConstraints []byte
+	views                 []byte
 	sequences             []string
 	roles                 map[string]role
 	eventTriggers         []byte
@@ -247,9 +248,15 @@ func (s *SnapshotGenerator) CreateSnapshot(ctx context.Context, ss *snapshot.Sna
 
 	s.logger.Info("restoring schema indices and constraints", loglib.Fields{"schemaTables": ss.SchemaTables})
 	if s.snapshotTracker != nil {
-		return s.restoreIndicesWithTracking(ctx, dump.indicesAndConstraints)
+		if err := s.restoreIndicesWithTracking(ctx, dump.indicesAndConstraints); err != nil {
+			return err
+		}
+	} else if err := s.restoreDump(ctx, dump.indicesAndConstraints); err != nil {
+		return err
 	}
-	return s.restoreDump(ctx, dump.indicesAndConstraints)
+
+	s.logger.Info("restoring views")
+	return s.restoreDump(ctx, dump.views)
 }
 
 func (s *SnapshotGenerator) Close() error {
@@ -297,6 +304,7 @@ func (s *SnapshotGenerator) dumpSchema(ctx context.Context, schemaTables map[str
 
 	s.dumpToFile(s.getDumpFileName("-filtered"), pgdumpOpts, parsedDump.filtered)
 	s.dumpToFile(s.getDumpFileName("-indices-constraints"), pgdumpOpts, parsedDump.indicesAndConstraints)
+	s.dumpToFile(s.getDumpFileName("-views"), pgdumpOpts, parsedDump.views)
 
 	// only if clean is enabled, produce the clean up part of the dump
 	if s.optionGenerator.cleanTargetDB {
@@ -495,10 +503,12 @@ func (s *SnapshotGenerator) parseDump(d []byte) *dump {
 	indicesAndConstraints := strings.Builder{}
 	filteredDump := strings.Builder{}
 	eventTriggersDump := strings.Builder{}
+	viewsDump := strings.Builder{}
 	sequenceNames := []string{}
 	dumpRoles := make(map[string]role)
 	alterTable := ""
 	createEventTrigger := ""
+	createView := ""
 	for scanner.Scan() {
 		line := scanner.Text()
 		switch {
@@ -535,11 +545,27 @@ func (s *SnapshotGenerator) parseDump(d []byte) *dump {
 			eventTriggersDump.WriteString(line)
 			eventTriggersDump.WriteString("\n")
 
+		case strings.HasPrefix(line, "CREATE VIEW"),
+			strings.HasPrefix(line, "CREATE MATERIALIZED VIEW"):
+			createView = line
+			fallthrough
+		case createView != "":
+			if strings.HasSuffix(line, ";") {
+				viewsDump.WriteString(line)
+				viewsDump.WriteString("\n\n")
+				createView = ""
+				continue
+			}
+			viewsDump.WriteString(line)
+			viewsDump.WriteString("\n")
+
 		case strings.Contains(line, `\connect`):
 			indicesAndConstraints.WriteString(line)
 			indicesAndConstraints.WriteString("\n\n")
 			filteredDump.WriteString(line)
 			filteredDump.WriteString("\n")
+			viewsDump.WriteString(line)
+			viewsDump.WriteString("\n\n")
 		case strings.HasPrefix(line, "CREATE INDEX"),
 			strings.HasPrefix(line, "CREATE UNIQUE INDEX"),
 			strings.HasPrefix(line, "CREATE CONSTRAINT"),
@@ -604,6 +630,7 @@ func (s *SnapshotGenerator) parseDump(d []byte) *dump {
 		full:                  d,
 		filtered:              []byte(filteredDump.String()),
 		indicesAndConstraints: []byte(indicesAndConstraints.String()),
+		views:                 []byte(viewsDump.String()),
 		sequences:             sequenceNames,
 		roles:                 dumpRoles,
 		eventTriggers:         []byte(eventTriggersDump.String()),

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
@@ -25,11 +25,13 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 	t.Parallel()
 
 	schemaDump := []byte("schema dump\nCREATE SEQUENCE test.test_sequence\nALTER TABLE public.test_table OWNER TO test_role;\nGRANT ALL ON TABLE public.test_table TO test_role2;\nCREATE INDEX a;\n")
+	schemaDumpWithViews := []byte("schema dump\nCREATE SEQUENCE test.test_sequence\nALTER TABLE public.test_table OWNER TO test_role;\nGRANT ALL ON TABLE public.test_table TO test_role2;\nCREATE VIEW public.test_view AS\n SELECT 1;\nCREATE INDEX a;\n")
 	schemaDumpNoSequences := []byte("schema dump\nALTER TABLE public.test_table OWNER TO test_role;\nGRANT ALL ON TABLE public.test_table TO test_role2;\nCREATE INDEX a;\n")
 	filteredDumpNoSequences := []byte("schema dump\nGRANT ALL ON SCHEMA \"public\" TO \"test_role\";\nALTER TABLE public.test_table OWNER TO test_role;\nGRANT ALL ON TABLE public.test_table TO test_role2;\n")
 	filteredDump := []byte("schema dump\nCREATE SEQUENCE test.test_sequence\nGRANT ALL ON SCHEMA \"public\" TO \"test_role\";\nALTER TABLE public.test_table OWNER TO test_role;\nGRANT ALL ON TABLE public.test_table TO test_role2;\n")
 	sequenceDump := []byte("sequence dump\n")
 	indexDump := []byte("CREATE INDEX a;\n\n")
+	testViewsDump := []byte("CREATE VIEW public.test_view AS\n SELECT 1;\n\n")
 	rolesDumpOriginal := []byte("roles dump\nCREATE ROLE postgres\nCREATE ROLE test_role\nCREATE ROLE test_role2\nALTER ROLE test_role3 INHERIT FROM test_role;\n")
 	rolesDumpFiltered := []byte("roles dump\nCREATE ROLE test_role\nCREATE ROLE test_role2\nGRANT \"test_role\" TO CURRENT_USER;\n")
 	cleanupDump := []byte("cleanup dump\n")
@@ -258,6 +260,52 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 			snapshotTracker: &mockSnapshotTracker{
 				trackIndexesCreationFn: func(ctx context.Context) {},
 			},
+
+			wantErr: nil,
+		},
+		{
+			name: "ok - with views",
+			snapshot: &snapshot.Snapshot{
+				SchemaTables: map[string][]string{
+					testSchema: {testTable},
+				},
+			},
+			conn: validQuerier(),
+			pgdumpFn: newMockPgdump(func(_ context.Context, i uint, po pglib.PGDumpOptions) ([]byte, error) {
+				switch i {
+				case 1:
+					return schemaDumpWithViews, nil
+				case 2:
+					return sequenceDump, nil
+				default:
+					return nil, fmt.Errorf("unexpected call to pgdumpFn: %d", i)
+				}
+			}),
+			pgdumpallFn: newMockPgdumpall(func(_ context.Context, i uint, po pglib.PGDumpAllOptions) ([]byte, error) {
+				switch i {
+				case 1:
+					return rolesDumpOriginal, nil
+				default:
+					return nil, fmt.Errorf("unexpected call to pgdumpallFn: %d", i)
+				}
+			}),
+			pgrestoreFn: newMockPgrestore(func(_ context.Context, i uint, po pglib.PGRestoreOptions, dump []byte) (string, error) {
+				switch i {
+				case 1:
+					require.Equal(t, string(rolesDumpFiltered), string(dump))
+				case 2:
+					require.Equal(t, string(filteredDump), string(dump))
+				case 3:
+					require.Equal(t, string(sequenceDump), string(dump))
+				case 4:
+					require.Equal(t, string(indexDump), string(dump))
+				case 5:
+					require.Equal(t, string(testViewsDump), string(dump))
+				default:
+					return "", fmt.Errorf("unexpected call to pgrestoreFn: %d", i)
+				}
+				return "", nil
+			}),
 
 			wantErr: nil,
 		},
@@ -1370,6 +1418,9 @@ func TestSnapshotGenerator_parseDump(t *testing.T) {
 	wantEventTriggersBytes, err := os.ReadFile("test/test_dump_event_triggers.sql")
 	require.NoError(t, err)
 
+	wantViewsBytes, err := os.ReadFile("test/test_dump_views.sql")
+	require.NoError(t, err)
+
 	sg := &SnapshotGenerator{
 		excludedSecurityLabels: []string{"anon"},
 	}
@@ -1381,12 +1432,15 @@ func TestSnapshotGenerator_parseDump(t *testing.T) {
 	wantConstraintsStr := strings.Trim(string(wantConstraintsBytes), "\n")
 	eventTriggersStr := strings.Trim(string(dump.eventTriggers), "\n")
 	wantEventTriggersStr := strings.Trim(string(wantEventTriggersBytes), "\n")
+	viewsStr := strings.Trim(string(dump.views), "\n")
+	wantViewsStr := strings.Trim(string(wantViewsBytes), "\n")
 	wantSequences := []string{`"musicbrainz"."alternative_medium_id_seq"`, `"musicbrainz"."Alternative_medium_id_seq"`}
 
 	require.Equal(t, wantFilteredStr, filteredStr)
 	require.Equal(t, wantConstraintsStr, constraintsStr)
 	require.Equal(t, wantSequences, dump.sequences)
 	require.Equal(t, wantEventTriggersStr, eventTriggersStr)
+	require.Equal(t, wantViewsStr, viewsStr)
 }
 
 func TestGetDumpsDiff(t *testing.T) {

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump.sql
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump.sql
@@ -252,6 +252,37 @@ ALTER TABLE ONLY musicbrainz.alternative_release ALTER COLUMN id SET DEFAULT nex
 
 
 --
+-- Name: edit_summary; Type: VIEW; Schema: musicbrainz; Owner: postgres
+--
+
+CREATE VIEW musicbrainz.edit_summary AS
+ SELECT e.id,
+    e.editor,
+    e.type,
+    e.status
+   FROM musicbrainz.edit e
+  GROUP BY e.id;
+
+
+ALTER VIEW musicbrainz.edit_summary OWNER TO postgres;
+
+--
+-- Name: medium_summary; Type: MATERIALIZED VIEW; Schema: musicbrainz; Owner: postgres
+--
+
+CREATE MATERIALIZED VIEW musicbrainz.medium_summary AS
+ SELECT am.id,
+    am.medium,
+    am.alternative_release,
+    am.name
+   FROM musicbrainz.alternative_medium am
+  GROUP BY am.id
+  WITH NO DATA;
+
+
+ALTER MATERIALIZED VIEW musicbrainz.medium_summary OWNER TO postgres;
+
+--
 -- Name: alternative_medium alternative_medium_pkey; Type: CONSTRAINT; Schema: musicbrainz; Owner: postgres
 --
 

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump_filtered.sql
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump_filtered.sql
@@ -241,6 +241,20 @@ ALTER TABLE ONLY musicbrainz.alternative_release ALTER COLUMN id SET DEFAULT nex
 
 
 --
+-- Name: edit_summary; Type: VIEW; Schema: musicbrainz; Owner: postgres
+--
+
+
+
+
+--
+-- Name: medium_summary; Type: MATERIALIZED VIEW; Schema: musicbrainz; Owner: postgres
+--
+
+
+
+
+--
 -- Name: alternative_medium alternative_medium_pkey; Type: CONSTRAINT; Schema: musicbrainz; Owner: postgres
 --
 

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump_views.sql
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/test/test_dump_views.sql
@@ -1,0 +1,18 @@
+\connect test
+
+CREATE VIEW musicbrainz.edit_summary AS
+ SELECT e.id,
+    e.editor,
+    e.type,
+    e.status
+   FROM musicbrainz.edit e
+  GROUP BY e.id;
+
+CREATE MATERIALIZED VIEW musicbrainz.medium_summary AS
+ SELECT am.id,
+    am.medium,
+    am.alternative_release,
+    am.name
+   FROM musicbrainz.alternative_medium am
+  GROUP BY am.id
+  WITH NO DATA;


### PR DESCRIPTION
#### Description

See #757, the statements for creating views were done before index creation and that's a problem for views that use GROUP BY. This moves them after the index creation.

##### Related Issue(s)

- Fixes #757 

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Used the same pattern as for indexes and constraints to move views at the end.
- Added tets
-

#### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

