### PR TITLE
Surface error even if we cannot parse ERROR lines in the output of restore

### DIFF
--- a/internal/postgres/pg_restore.go
+++ b/internal/postgres/pg_restore.go
@@ -92,16 +92,24 @@ func RunPGRestore(ctx context.Context, opts PGRestoreOptions, dump []byte) (stri
 
 	// TODO: add streaming support when large data output is required
 	out, err := cmd.CombinedOutput()
-	if err != nil || strings.Contains(string(out), "ERROR") {
-		if parseErr := parsePgRestoreOutputErrs(out); parseErr != nil {
-			return "", fmt.Errorf("error restoring dump: %w", parseErr)
-		}
-		if err != nil {
-			return "", fmt.Errorf("error restoring dump: %w", err)
-		}
+	if restoreErr := buildRestoreError(out, err); restoreErr != nil {
+		return "", restoreErr
 	}
 
 	return string(out), nil
+}
+
+func buildRestoreError(out []byte, execErr error) error {
+	if execErr == nil && !strings.Contains(string(out), "ERROR") {
+		return nil
+	}
+	if parseErr := parsePgRestoreOutputErrs(out); parseErr != nil {
+		return fmt.Errorf("error restoring dump: %w", parseErr)
+	}
+	if execErr != nil {
+		return fmt.Errorf("error restoring dump: %w", execErr)
+	}
+	return nil
 }
 
 func removeDatabaseFromConnectionString(url string) (string, error) {

--- a/internal/postgres/pg_restore_test.go
+++ b/internal/postgres/pg_restore_test.go
@@ -149,6 +149,67 @@ pg_restore: finished`,
 	}
 }
 
+func TestBuildRestoreError(t *testing.T) {
+	t.Parallel()
+
+	execErr := errors.New("exit status 1")
+
+	tests := []struct {
+		name    string
+		output  []byte
+		execErr error
+
+		wantNil     bool
+		wantContain string
+	}{
+		{
+			name:    "no error - success",
+			output:  []byte("pg_restore: finished\n"),
+			execErr: nil,
+			wantNil: true,
+		},
+		{
+			name:        "exec error with no parseable output",
+			output:      []byte("some unexpected output\n"),
+			execErr:     execErr,
+			wantContain: "exit status 1",
+		},
+		{
+			name:        "exec error with empty output",
+			output:      []byte{},
+			execErr:     execErr,
+			wantContain: "exit status 1",
+		},
+		{
+			name:        "exec error with parseable ERROR lines",
+			output:      []byte("pg_restore: error: could not execute query: ERROR:  relation \"users\" already exists\n"),
+			execErr:     execErr,
+			wantContain: "already exists",
+		},
+		{
+			name:        "no exec error but output contains ERROR",
+			output:      []byte("ERROR:  relation \"users\" already exists\n"),
+			execErr:     nil,
+			wantContain: "already exists",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := buildRestoreError(tc.output, tc.execErr)
+			if tc.wantNil {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantContain)
+			assert.NotContains(t, err.Error(), "%!w(<nil>)")
+		})
+	}
+}
+
 func TestIsErrorLine(t *testing.T) {
 	tests := []struct {
 		line     string


### PR DESCRIPTION
#### Description

Fix `RunPGRestore` producing `error restoring dump: %!w(<nil>)` when the command fails with a non-zero exit code but the output contains no parseable ERROR lines. Now falls back to the exec error instead of wrapping nil.

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Extract error-handling logic into `buildRestoreError` for testability and add tests covering all combinations of exec error and output parsing

#### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary


#### Additional Notes

<!-- Any context or special instructions for reviewers -->
