### PR TITLE
docs: document --data-only flag for pgstream run

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -130,6 +130,7 @@ The `run` command is the main operation mode for pgstream. It:
 - `--profile` - Whether to expose a /debug/pprof endpoint on localhost:6060
 - `--init` - Whether to initialize pgstream before starting replication
 - `--dump-file` - File where the pg_dump output will be written if initial snapshot is enabled when using pgdump/restore
+- `--data-only` - When used with `--snapshot-tables`, skip schema restore and only snapshot data. Use this when the schema is already present on the target. Defaults to `false`
 - `--with-injector` - Whether to enable the injection of pgstream metadata to the WAL events. Required for search targets (OpenSearch/Elasticsearch)
 
 **Examples:**


### PR DESCRIPTION
## Summary

Adds the `--data-only` flag to the `pgstream run` flags list in `docs/cli.md`. The flag is already implemented in `cmd/root_cmd.go:89` and consumed in `cmd/run_cmd.go:96` — only the documentation was lagging.

## Context

Surfaced while reviewing the Xata documentation sync (`xataio/documentation`), where a downstream fix was added to mirror the flag's existence in the rendered docs. Bringing the source-of-truth doc in line removes the drift.