### PR TITLE
docs: sync snapshot command description and examples with cobra

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -150,7 +150,7 @@ pgstream run --config config.env
 
 ### snapshot
 
-Snapshot performs a snapshot of the configured source Postgres database into the configured target.
+Snapshot performs a one-time data snapshot of a PostgreSQL database. For continuous replication or combined snapshot+replication, use the `run` command with `--snapshot-tables` flag.
 
 ```bash
 pgstream snapshot [flags]
@@ -184,8 +184,11 @@ The `snapshot` command creates a point-in-time copy of database tables. It:
 **Examples:**
 
 ```bash
+# Snapshot specific tables from a PostgreSQL database to a target PostgreSQL database
 pgstream snapshot --postgres-url <postgres-url> --target postgres --target-url <target-url> --tables <schema.table> --reset
+# Snapshot using a YAML configuration file (requires source.postgres.mode: 'snapshot')
 pgstream snapshot --config config.yaml --log-level info
+# Snapshot using an environment configuration file
 pgstream snapshot --config config.env
 ```
 


### PR DESCRIPTION
## Summary

Updates `docs/cli.md`'s `snapshot` section to match the current cobra command definitions in `cmd/snapshot_cmd.go`:

- Short description (`Snapshot performs a one-time data snapshot of a PostgreSQL database...`)
- Annotated examples for the inline-flags, YAML config, and env config invocations

## Context

The cobra `Short` and `Example` text was tightened up earlier without a corresponding doc update. Bringing the source-of-truth doc in line with the code removes the drift surfaced via the Xata docs sync.