### PR TITLE
docs(xata): add cnpg_pooler_pgbouncer to Xata-managed roles

### DIFF
--- a/docs/xata.md
+++ b/docs/xata.md
@@ -81,7 +81,7 @@ This guide explains how to use **pgstream** with **Xata databases**, covering **
              no_privileges: true
    ```
 
-ℹ️ Xata-managed roles (`xata`, `xata_superuser`) will not be snapshotted.
+ℹ️ Xata-managed roles (`xata`, `xata_superuser`, `cnpg_pooler_pgbouncer`) will not be snapshotted.
 
 ### To Xata Database (Snapshots)
 


### PR DESCRIPTION
## Summary

Adds `cnpg_pooler_pgbouncer` to the list of Xata-managed roles in `docs/xata.md` that are excluded from pgstream snapshots.

## Context

`cnpg_pooler_pgbouncer` is the CloudNativePG PgBouncer service account. It was added to `xatautils.reserved_roles` in `xataio/maki` and is now managed by Xata alongside `xata` and `xata_superuser`. The doc on this side was lagging.

A mirror change was previously made downstream in `xataio/documentation` (#214); landing it upstream removes the drift and lets the next docs sync no-op on this file.