### PR TITLE
Add support for human readable byte size settings

### DIFF
--- a/cmd/config/bytesize.go
+++ b/cmd/config/bytesize.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	units "github.com/docker/go-units"
+	mapstructure "github.com/go-viper/mapstructure/v2"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+// byteSize represents a size in bytes that can be configured either as a plain
+// integer or as a human-readable string with a unit suffix (e.g. "64MiB" or
+// "1GiB"). Units are case-insensitive and interpreted as binary multiples
+// (1MiB = 1024*1024 bytes).
+type byteSize int64
+
+func parseByteSize(s string) (int64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+	n, err := units.RAMInBytes(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid byte size %q: %w", s, err)
+	}
+	return n, nil
+}
+
+func getByteSize(key string) (int64, error) {
+	n, err := parseByteSize(viper.GetString(key))
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", key, err)
+	}
+	return n, nil
+}
+
+// byteSizeDecodeHook builds the mapstructure hook used to decode the YAML
+// config. viper.DecodeHook replaces viper's default hook rather than appending
+// to it, so the duration and slice hooks are re-included here alongside the
+// text unmarshaller hook that decodes byteSize fields.
+func byteSizeDecodeHook() mapstructure.DecodeHookFunc {
+	return mapstructure.ComposeDecodeHookFunc(
+		mapstructure.StringToTimeDurationHookFunc(),
+		mapstructure.StringToSliceHookFunc(","),
+		mapstructure.TextUnmarshallerHookFunc(),
+	)
+}
+
+func (b *byteSize) UnmarshalText(text []byte) error {
+	n, err := parseByteSize(string(text))
+	if err != nil {
+		return err
+	}
+	*b = byteSize(n)
+	return nil
+}
+
+func (b *byteSize) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.ScalarNode {
+		return fmt.Errorf("invalid byte size %q: expected a scalar value", value.Value)
+	}
+	n, err := parseByteSize(value.Value)
+	if err != nil {
+		return err
+	}
+	*b = byteSize(n)
+	return nil
+}

--- a/cmd/config/bytesize_test.go
+++ b/cmd/config/bytesize_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseByteSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: 0},
+		{name: "whitespace only", input: "   ", want: 0},
+		{name: "zero", input: "0", want: 0},
+		{name: "plain integer", input: "1572864", want: 1572864},
+		{name: "plain integer large", input: "104857600", want: 104857600},
+		{name: "MiB suffix", input: "64MiB", want: 67108864},
+		{name: "GiB suffix", input: "1GiB", want: 1073741824},
+		{name: "fractional MiB", input: "1.5MiB", want: 1572864},
+		{name: "MiB with space", input: "64 MiB", want: 67108864},
+		{name: "lowercase mb treated as binary", input: "64mb", want: 67108864},
+		{name: "surrounding whitespace", input: "  256MiB  ", want: 268435456},
+		{name: "invalid - non-numeric", input: "abc", wantErr: true},
+		{name: "invalid - bad suffix", input: "6yMiB", wantErr: true},
+		{name: "invalid - too long suffix", input: "64MiBB", wantErr: true},
+		{name: "invalid - negative", input: "-5", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseByteSize(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestByteSize_UnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	var b byteSize
+	require.NoError(t, b.UnmarshalText([]byte("64MiB")))
+	assert.Equal(t, byteSize(67108864), b)
+
+	require.Error(t, b.UnmarshalText([]byte("6yMiB")))
+}
+
+func TestGetByteSize_EnvVar(t *testing.T) {
+	t.Setenv("PGSTREAM_POSTGRES_WRITER_BATCH_BYTES", "64MiB")
+	got, err := getByteSize("PGSTREAM_POSTGRES_WRITER_BATCH_BYTES")
+	require.NoError(t, err)
+	assert.Equal(t, int64(67108864), got)
+
+	t.Setenv("PGSTREAM_POSTGRES_WRITER_BATCH_BYTES", "6yMiB")
+	_, err = getByteSize("PGSTREAM_POSTGRES_WRITER_BATCH_BYTES")
+	require.Error(t, err)
+}
+
+func TestParsePostgresProcessorConfig_ByteSizeSuffixes(t *testing.T) {
+	t.Setenv("PGSTREAM_POSTGRES_WRITER_TARGET_URL", "postgresql://user:password@localhost:5432/mytargetdatabase")
+	t.Setenv("PGSTREAM_POSTGRES_WRITER_BATCH_BYTES", "64MiB")
+	t.Setenv("PGSTREAM_POSTGRES_WRITER_MAX_QUEUE_BYTES", "256MiB")
+
+	cfg, err := parsePostgresProcessorConfig()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, int64(67108864), cfg.BatchWriter.BatchConfig.MaxBatchBytes)
+	assert.Equal(t, int64(268435456), cfg.BatchWriter.BatchConfig.MaxQueueBytes)
+
+	t.Setenv("PGSTREAM_POSTGRES_WRITER_BATCH_BYTES", "not-a-size")
+	_, err = parsePostgresProcessorConfig()
+	require.Error(t, err)
+}
+
+func TestParseStreamConfig_YAMLByteSizeSuffixes(t *testing.T) {
+	yamlCfg := `source:
+  postgres:
+    url: postgresql://user:password@localhost:5432/mydatabase
+    mode: replication
+target:
+  postgres:
+    url: postgresql://user:password@localhost:5432/mytargetdatabase
+    batch:
+      max_bytes: 64MiB
+      max_queue_bytes: 256MiB
+`
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(yamlCfg), 0o600))
+	require.NoError(t, LoadFile(path))
+
+	streamConfig, err := ParseStreamConfig()
+	require.NoError(t, err)
+	require.NotNil(t, streamConfig.Processor.Postgres)
+	assert.Equal(t, int64(67108864), streamConfig.Processor.Postgres.BatchWriter.BatchConfig.MaxBatchBytes)
+	assert.Equal(t, int64(268435456), streamConfig.Processor.Postgres.BatchWriter.BatchConfig.MaxQueueBytes)
+}
+
+func TestParseStreamConfig_YAMLInvalidByteSize(t *testing.T) {
+	yamlCfg := `source:
+  postgres:
+    url: postgresql://user:password@localhost:5432/mydatabase
+    mode: replication
+target:
+  postgres:
+    url: postgresql://user:password@localhost:5432/mytargetdatabase
+    batch:
+      max_bytes: 6yMiB
+`
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(yamlCfg), 0o600))
+	require.NoError(t, LoadFile(path))
+
+	_, err := ParseStreamConfig()
+	require.Error(t, err)
+}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -74,7 +74,7 @@ func ParseStreamConfig() (*stream.Config, error) {
 	switch ext := filepath.Ext(cfgFile); ext {
 	case ".yml", ".yaml":
 		yamlCfg := YAMLConfig{}
-		if err := viper.Unmarshal(&yamlCfg); err != nil {
+		if err := viper.Unmarshal(&yamlCfg, viper.DecodeHook(byteSizeDecodeHook())); err != nil {
 			return nil, fmt.Errorf("invalid format in config file %q: %w", cfgFile, err)
 		}
 

--- a/cmd/config/config_env.go
+++ b/cmd/config/config_env.go
@@ -264,9 +264,13 @@ func parseSnapshotConfig(pgURL string) (*snapshotbuilder.SnapshotListenerConfig,
 
 	var dataSnapshotCfg *pgsnapshotgenerator.Config
 	if snapshotMode == fullSnapshotMode || snapshotMode == dataSnapshotMode {
+		batchBytes, err := getByteSize("PGSTREAM_POSTGRES_SNAPSHOT_BATCH_BYTES")
+		if err != nil {
+			return nil, err
+		}
 		dataSnapshotCfg = &pgsnapshotgenerator.Config{
 			URL:             pgURL,
-			BatchBytes:      viper.GetUint64("PGSTREAM_POSTGRES_SNAPSHOT_BATCH_BYTES"),
+			BatchBytes:      uint64(batchBytes),
 			SchemaWorkers:   viper.GetUint("PGSTREAM_POSTGRES_SNAPSHOT_SCHEMA_WORKERS"),
 			TableWorkers:    viper.GetUint("PGSTREAM_POSTGRES_SNAPSHOT_TABLE_WORKERS"),
 			SnapshotWorkers: viper.GetUint("PGSTREAM_POSTGRES_SNAPSHOT_WORKERS"),
@@ -360,30 +364,63 @@ func parseProcessorConfig() (stream.ProcessorConfig, error) {
 	if err != nil {
 		return stream.ProcessorConfig{}, err
 	}
+
+	kafkaCfg, err := parseKafkaProcessorConfig()
+	if err != nil {
+		return stream.ProcessorConfig{}, err
+	}
+
+	searchCfg, err := parseSearchProcessorConfig()
+	if err != nil {
+		return stream.ProcessorConfig{}, err
+	}
+
+	webhookCfg, err := parseWebhookProcessorConfig()
+	if err != nil {
+		return stream.ProcessorConfig{}, err
+	}
+
+	postgresCfg, err := parsePostgresProcessorConfig()
+	if err != nil {
+		return stream.ProcessorConfig{}, err
+	}
+
 	return stream.ProcessorConfig{
-		Kafka:       parseKafkaProcessorConfig(),
-		Search:      parseSearchProcessorConfig(),
-		Webhook:     parseWebhookProcessorConfig(),
-		Postgres:    parsePostgresProcessorConfig(),
+		Kafka:       kafkaCfg,
+		Search:      searchCfg,
+		Webhook:     webhookCfg,
+		Postgres:    postgresCfg,
 		Injector:    parseInjectorConfig(),
 		Transformer: transformerCfg,
 		Filter:      parseFilterConfig(),
 	}, nil
 }
 
-func parseKafkaProcessorConfig() *stream.KafkaProcessorConfig {
+func parseKafkaProcessorConfig() (*stream.KafkaProcessorConfig, error) {
 	kafkaTopic := viper.GetString("PGSTREAM_KAFKA_TOPIC_NAME")
 	kafkaServers := viper.GetStringSlice("PGSTREAM_KAFKA_WRITER_SERVERS")
 	if len(kafkaServers) == 0 || kafkaTopic == "" {
-		return nil
+		return nil, nil
 	}
 
-	return &stream.KafkaProcessorConfig{
-		Writer: parseKafkaWriterConfig(kafkaServers, kafkaTopic),
+	writerCfg, err := parseKafkaWriterConfig(kafkaServers, kafkaTopic)
+	if err != nil {
+		return nil, err
 	}
+	return &stream.KafkaProcessorConfig{
+		Writer: writerCfg,
+	}, nil
 }
 
-func parseKafkaWriterConfig(kafkaServers []string, kafkaTopic string) *kafkaprocessor.Config {
+func parseKafkaWriterConfig(kafkaServers []string, kafkaTopic string) (*kafkaprocessor.Config, error) {
+	maxBatchBytes, err := getByteSize("PGSTREAM_KAFKA_WRITER_BATCH_BYTES")
+	if err != nil {
+		return nil, err
+	}
+	maxQueueBytes, err := getByteSize("PGSTREAM_KAFKA_WRITER_MAX_QUEUE_BYTES")
+	if err != nil {
+		return nil, err
+	}
 	return &kafkaprocessor.Config{
 		Kafka: kafka.ConnConfig{
 			Servers: kafkaServers,
@@ -397,28 +434,36 @@ func parseKafkaWriterConfig(kafkaServers []string, kafkaTopic string) *kafkaproc
 		},
 		Batch: batch.Config{
 			BatchTimeout:     viper.GetDuration("PGSTREAM_KAFKA_WRITER_BATCH_TIMEOUT"),
-			MaxBatchBytes:    viper.GetInt64("PGSTREAM_KAFKA_WRITER_BATCH_BYTES"),
+			MaxBatchBytes:    maxBatchBytes,
 			MaxBatchSize:     viper.GetInt64("PGSTREAM_KAFKA_WRITER_BATCH_SIZE"),
-			MaxQueueBytes:    viper.GetInt64("PGSTREAM_KAFKA_WRITER_MAX_QUEUE_BYTES"),
+			MaxQueueBytes:    maxQueueBytes,
 			IgnoreSendErrors: viper.GetBool("PGSTREAM_KAFKA_WRITER_BATCH_IGNORE_SEND_ERRORS"),
 		},
-	}
+	}, nil
 }
 
-func parseSearchProcessorConfig() *stream.SearchProcessorConfig {
+func parseSearchProcessorConfig() (*stream.SearchProcessorConfig, error) {
 	opensearchStore := viper.GetString("PGSTREAM_OPENSEARCH_STORE_URL")
 	elasticsearchStore := viper.GetString("PGSTREAM_ELASTICSEARCH_STORE_URL")
 	if opensearchStore == "" && elasticsearchStore == "" {
-		return nil
+		return nil, nil
 	}
 
+	maxQueueBytes, err := getByteSize("PGSTREAM_SEARCH_INDEXER_MAX_QUEUE_BYTES")
+	if err != nil {
+		return nil, err
+	}
+	maxBatchBytes, err := getByteSize("PGSTREAM_SEARCH_INDEXER_BATCH_BYTES")
+	if err != nil {
+		return nil, err
+	}
 	return &stream.SearchProcessorConfig{
 		Indexer: search.IndexerConfig{
 			Batch: batch.Config{
 				MaxBatchSize:     viper.GetInt64("PGSTREAM_SEARCH_INDEXER_BATCH_SIZE"),
 				BatchTimeout:     viper.GetDuration("PGSTREAM_SEARCH_INDEXER_BATCH_TIMEOUT"),
-				MaxQueueBytes:    viper.GetInt64("PGSTREAM_SEARCH_INDEXER_MAX_QUEUE_BYTES"),
-				MaxBatchBytes:    viper.GetInt64("PGSTREAM_SEARCH_INDEXER_BATCH_BYTES"),
+				MaxQueueBytes:    maxQueueBytes,
+				MaxBatchBytes:    maxBatchBytes,
 				IgnoreSendErrors: viper.GetBool("PGSTREAM_SEARCH_INDEXER_BATCH_IGNORE_SEND_ERRORS"),
 			},
 			HashDocIDs: viper.GetBool("PGSTREAM_SEARCH_INDEXER_HASH_DOC_IDS"),
@@ -430,15 +475,19 @@ func parseSearchProcessorConfig() *stream.SearchProcessorConfig {
 		Retrier: search.StoreRetryConfig{
 			Backoff: parseBackoffConfig("PGSTREAM_SEARCH_STORE"),
 		},
-	}
+	}, nil
 }
 
-func parseWebhookProcessorConfig() *stream.WebhookProcessorConfig {
+func parseWebhookProcessorConfig() (*stream.WebhookProcessorConfig, error) {
 	subscriptionStore := viper.GetString("PGSTREAM_WEBHOOK_SUBSCRIPTION_STORE_URL")
 	if subscriptionStore == "" {
-		return nil
+		return nil, nil
 	}
 
+	maxQueueBytes, err := getByteSize("PGSTREAM_WEBHOOK_NOTIFIER_MAX_QUEUE_BYTES")
+	if err != nil {
+		return nil, err
+	}
 	return &stream.WebhookProcessorConfig{
 		SubscriptionStore: stream.WebhookSubscriptionStoreConfig{
 			URL:                  subscriptionStore,
@@ -446,7 +495,7 @@ func parseWebhookProcessorConfig() *stream.WebhookProcessorConfig {
 			CacheRefreshInterval: viper.GetDuration("PGSTREAM_WEBHOOK_SUBSCRIPTION_STORE_CACHE_REFRESH_INTERVAL"),
 		},
 		Notifier: notifier.Config{
-			MaxQueueBytes:  viper.GetInt64("PGSTREAM_WEBHOOK_NOTIFIER_MAX_QUEUE_BYTES"),
+			MaxQueueBytes:  maxQueueBytes,
 			URLWorkerCount: viper.GetUint("PGSTREAM_WEBHOOK_NOTIFIER_WORKER_COUNT"),
 			ClientTimeout:  viper.GetDuration("PGSTREAM_WEBHOOK_NOTIFIER_CLIENT_TIMEOUT"),
 		},
@@ -455,13 +504,30 @@ func parseWebhookProcessorConfig() *stream.WebhookProcessorConfig {
 			ReadTimeout:  viper.GetDuration("PGSTREAM_WEBHOOK_SUBSCRIPTION_SERVER_READ_TIMEOUT"),
 			WriteTimeout: viper.GetDuration("PGSTREAM_WEBHOOK_SUBSCRIPTION_SERVER_WRITE_TIMEOUT"),
 		},
-	}
+	}, nil
 }
 
-func parsePostgresProcessorConfig() *stream.PostgresProcessorConfig {
+func parsePostgresProcessorConfig() (*stream.PostgresProcessorConfig, error) {
 	targetPostgresURL := viper.GetString("PGSTREAM_POSTGRES_WRITER_TARGET_URL")
 	if targetPostgresURL == "" {
-		return nil
+		return nil, nil
+	}
+
+	maxBatchBytes, err := getByteSize("PGSTREAM_POSTGRES_WRITER_BATCH_BYTES")
+	if err != nil {
+		return nil, err
+	}
+	maxQueueBytes, err := getByteSize("PGSTREAM_POSTGRES_WRITER_MAX_QUEUE_BYTES")
+	if err != nil {
+		return nil, err
+	}
+	autoTuneMinBytes, err := getByteSize("PGSTREAM_POSTGRES_WRITER_BATCH_AUTO_TUNE_MIN_BYTES")
+	if err != nil {
+		return nil, err
+	}
+	autoTuneMaxBytes, err := getByteSize("PGSTREAM_POSTGRES_WRITER_BATCH_AUTO_TUNE_MAX_BYTES")
+	if err != nil {
+		return nil, err
 	}
 
 	bulkIngestEnabled := viper.GetBool("PGSTREAM_POSTGRES_WRITER_BULK_INGEST_ENABLED")
@@ -470,14 +536,14 @@ func parsePostgresProcessorConfig() *stream.PostgresProcessorConfig {
 			URL: targetPostgresURL,
 			BatchConfig: batch.Config{
 				BatchTimeout:     viper.GetDuration("PGSTREAM_POSTGRES_WRITER_BATCH_TIMEOUT"),
-				MaxBatchBytes:    viper.GetInt64("PGSTREAM_POSTGRES_WRITER_BATCH_BYTES"),
+				MaxBatchBytes:    maxBatchBytes,
 				MaxBatchSize:     viper.GetInt64("PGSTREAM_POSTGRES_WRITER_BATCH_SIZE"),
-				MaxQueueBytes:    viper.GetInt64("PGSTREAM_POSTGRES_WRITER_MAX_QUEUE_BYTES"),
+				MaxQueueBytes:    maxQueueBytes,
 				IgnoreSendErrors: viper.GetBool("PGSTREAM_POSTGRES_WRITER_BATCH_IGNORE_SEND_ERRORS"),
 				AutoTune: batch.AutoTuneConfig{
 					Enabled:              viper.GetBool("PGSTREAM_POSTGRES_WRITER_BATCH_AUTO_TUNE_ENABLE"),
-					MinBatchBytes:        viper.GetInt64("PGSTREAM_POSTGRES_WRITER_BATCH_AUTO_TUNE_MIN_BYTES"),
-					MaxBatchBytes:        viper.GetInt64("PGSTREAM_POSTGRES_WRITER_BATCH_AUTO_TUNE_MAX_BYTES"),
+					MinBatchBytes:        autoTuneMinBytes,
+					MaxBatchBytes:        autoTuneMaxBytes,
 					ConvergenceThreshold: viper.GetFloat64("PGSTREAM_POSTGRES_WRITER_BATCH_AUTO_TUNE_CONVERGENCE_THRESHOLD"),
 				},
 			},
@@ -493,7 +559,7 @@ func parsePostgresProcessorConfig() *stream.PostgresProcessorConfig {
 		applyPostgresBulkBatchDefaults(&cfg.BatchWriter.BatchConfig)
 	}
 
-	return cfg
+	return cfg, nil
 }
 
 func parseBackoffConfig(prefix string) backoff.Config {

--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -88,10 +88,10 @@ type SnapshotRecorderConfig struct {
 }
 
 type SnapshotDataConfig struct {
-	SchemaWorkers  int    `mapstructure:"schema_workers" yaml:"schema_workers"`
-	TableWorkers   int    `mapstructure:"table_workers" yaml:"table_workers"`
-	BatchBytes     uint64 `mapstructure:"batch_bytes" yaml:"batch_bytes"`
-	MaxConnections uint   `mapstructure:"max_connections" yaml:"max_connections"`
+	SchemaWorkers  int      `mapstructure:"schema_workers" yaml:"schema_workers"`
+	TableWorkers   int      `mapstructure:"table_workers" yaml:"table_workers"`
+	BatchBytes     byteSize `mapstructure:"batch_bytes" yaml:"batch_bytes"`
+	MaxConnections uint     `mapstructure:"max_connections" yaml:"max_connections"`
 }
 
 type SnapshotSchemaConfig struct {
@@ -199,17 +199,17 @@ type SearchConfig struct {
 type BatchConfig struct {
 	Timeout          int                  `mapstructure:"timeout" yaml:"timeout"`
 	Size             int                  `mapstructure:"size" yaml:"size"`
-	MaxBytes         int                  `mapstructure:"max_bytes" yaml:"max_bytes"`
-	MaxQueueBytes    int                  `mapstructure:"max_queue_bytes" yaml:"max_queue_bytes"`
+	MaxBytes         byteSize             `mapstructure:"max_bytes" yaml:"max_bytes"`
+	MaxQueueBytes    byteSize             `mapstructure:"max_queue_bytes" yaml:"max_queue_bytes"`
 	IgnoreSendErrors bool                 `mapstructure:"ignore_send_errors" yaml:"ignore_send_errors"`
 	AutoTune         *BatchAutoTuneConfig `mapstructure:"auto_tune" yaml:"auto_tune"`
 }
 
 type BatchAutoTuneConfig struct {
-	Enabled              bool    `mapstructure:"enabled" yaml:"enabled"`
-	MaxBatchBytes        int64   `mapstructure:"max_batch_bytes" yaml:"max_batch_bytes"`
-	MinBatchBytes        int64   `mapstructure:"min_batch_bytes" yaml:"min_batch_bytes"`
-	ConvergenceThreshold float64 `mapstructure:"convergence_threshold" yaml:"convergence_threshold"`
+	Enabled              bool     `mapstructure:"enabled" yaml:"enabled"`
+	MaxBatchBytes        byteSize `mapstructure:"max_batch_bytes" yaml:"max_batch_bytes"`
+	MinBatchBytes        byteSize `mapstructure:"min_batch_bytes" yaml:"min_batch_bytes"`
+	ConvergenceThreshold float64  `mapstructure:"convergence_threshold" yaml:"convergence_threshold"`
 }
 
 type BulkIngestConfig struct {
@@ -520,7 +520,7 @@ func (c *YAMLConfig) parseDataSnapshotConfig() *pgsnapshotgenerator.Config {
 	}
 
 	if snapshotCfg.Data != nil {
-		streamCfg.BatchBytes = snapshotCfg.Data.BatchBytes
+		streamCfg.BatchBytes = uint64(snapshotCfg.Data.BatchBytes)
 		streamCfg.SchemaWorkers = uint(snapshotCfg.Data.SchemaWorkers)
 		streamCfg.TableWorkers = uint(snapshotCfg.Data.TableWorkers)
 		streamCfg.MaxConnections = snapshotCfg.Data.MaxConnections
@@ -866,8 +866,8 @@ func (bc *BatchConfig) parseBatchConfig() batch.Config {
 	if bc.AutoTune != nil {
 		cfg.AutoTune = batch.AutoTuneConfig{
 			Enabled:              bc.AutoTune.Enabled,
-			MinBatchBytes:        bc.AutoTune.MinBatchBytes,
-			MaxBatchBytes:        bc.AutoTune.MaxBatchBytes,
+			MinBatchBytes:        int64(bc.AutoTune.MinBatchBytes),
+			MaxBatchBytes:        int64(bc.AutoTune.MaxBatchBytes),
 			ConvergenceThreshold: bc.AutoTune.ConvergenceThreshold,
 		}
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,6 +187,8 @@ modifiers:
 
 Here's a list of all the environment variables that can be used to configure the individual modules, along with their descriptions and default values.
 
+> Byte-size variables (those ending in `_BYTES`) accept either a plain integer or a human-readable size such as `64MiB` or `1GiB`. Units are case-insensitive and interpreted as binary multiples (`1MiB` = 1048576 bytes). The same applies to the equivalent fields in the YAML configuration.
+
 ### Sources
 
 <details>
@@ -274,7 +276,7 @@ One of exponential/constant backoff policies can be provided for the Kafka commi
 | PGSTREAM_KAFKA_WRITER_BATCH_BYTES              | 1572864 | No               | Max size in bytes for a given batch. When this size is reached, the batch is sent to Kafka.         |
 | PGSTREAM_KAFKA_WRITER_BATCH_SIZE               | 100     | No               | Max number of messages to be sent per batch. When this size is reached, the batch is sent to Kafka. |
 | PGSTREAM_KAFKA_WRITER_BATCH_IGNORE_SEND_ERRORS | False   | No               | Whether to ignore errors encountered while sending batches to the target.                           |
-| PGSTREAM_KAFKA_WRITER_MAX_QUEUE_BYTES          | 100MiB  | No               | Max memory used by the Kafka batch writer for inflight batches.                                     |
+| PGSTREAM_KAFKA_WRITER_MAX_QUEUE_BYTES          | 104857600 (100MiB) | No               | Max memory used by the Kafka batch writer for inflight batches.                                     |
 
 </details>
 
@@ -289,7 +291,7 @@ One of exponential/constant backoff policies can be provided for the Kafka commi
 | PGSTREAM_SEARCH_INDEXER_BATCH_TIMEOUT              | 1s      | No       | Max time interval at which the batch sending to the search store is triggered.                                 |
 | PGSTREAM_SEARCH_INDEXER_BATCH_SIZE                 | 100     | No       | Max number of messages to be sent per batch. When this size is reached, the batch is sent to the search store. |
 | PGSTREAM_SEARCH_INDEXER_BATCH_IGNORE_SEND_ERRORS   | False   | No       | Whether to ignore errors encountered while sending batches to the target.                                      |
-| PGSTREAM_SEARCH_INDEXER_MAX_QUEUE_BYTES            | 100MiB  | No       | Max memory used by the search batch indexer for inflight batches.                                              |
+| PGSTREAM_SEARCH_INDEXER_MAX_QUEUE_BYTES            | 104857600 (100MiB) | No       | Max memory used by the search batch indexer for inflight batches.                                              |
 | PGSTREAM_SEARCH_STORE_EXP_BACKOFF_INITIAL_INTERVAL | 1s      | No       | Initial interval for the exponential backoff policy to be applied to the search store operation retries.       |
 | PGSTREAM_SEARCH_STORE_EXP_BACKOFF_MAX_INTERVAL     | 1min    | No       | Max interval for the exponential backoff policy to be applied to the search store operation retries.           |
 | PGSTREAM_SEARCH_STORE_EXP_BACKOFF_MAX_RETRIES      | 0       | No       | Max retries for the exponential backoff policy to be applied to the search store operation retries.            |
@@ -311,7 +313,7 @@ One of exponential/constant/disable retries backoff policies can be provided for
 | PGSTREAM_WEBHOOK_SUBSCRIPTION_STORE_URL                    | N/A     | Yes                | URL for the webhook subscription store to connect to.                                                       |
 | PGSTREAM_WEBHOOK_SUBSCRIPTION_STORE_CACHE_ENABLED          | False   | No                 | Caching applied to the subscription store retrieval queries.                                                |
 | PGSTREAM_WEBHOOK_SUBSCRIPTION_STORE_CACHE_REFRESH_INTERVAL | 60s     | When cache enabled | Interval at which the subscription store cache will be refreshed. Indicates max cache staleness.            |
-| PGSTREAM_WEBHOOK_NOTIFIER_MAX_QUEUE_BYTES                  | 100MiB  | No                 | Max memory used by the webhook notifier for inflight notifications.                                         |
+| PGSTREAM_WEBHOOK_NOTIFIER_MAX_QUEUE_BYTES                  | 104857600 (100MiB) | No                 | Max memory used by the webhook notifier for inflight notifications.                                         |
 | PGSTREAM_WEBHOOK_NOTIFIER_WORKER_COUNT                     | 10      | No                 | Max number of concurrent workers that will send webhook notifications for a given WAL event.                |
 | PGSTREAM_WEBHOOK_NOTIFIER_CLIENT_TIMEOUT                   | 10s     | No                 | Max time the notifier will wait for a response from a webhook URL before timing out.                        |
 | PGSTREAM_WEBHOOK_SUBSCRIPTION_SERVER_ADDRESS               | ":9900" | No                 | Address for the subscription server to listen on.                                                           |
@@ -328,8 +330,8 @@ One of exponential/constant/disable retries backoff policies can be provided for
 | PGSTREAM_POSTGRES_WRITER_TARGET_URL                            | N/A                             | Yes      | URL for the PostgreSQL store to connect to                                                                                                                                                                     |
 | PGSTREAM_POSTGRES_WRITER_BATCH_TIMEOUT                         | 30s                             | No       | Max time interval at which the batch sending to PostgreSQL is triggered.                                                                                                                                       |
 | PGSTREAM_POSTGRES_WRITER_BATCH_SIZE                            | 20000                           | No       | Max number of messages to be sent per batch. When this size is reached, the batch is sent to PostgreSQL.                                                                                                       |
-| PGSTREAM_POSTGRES_WRITER_MAX_QUEUE_BYTES                       | 100MiB                          | No       | Max memory used by the postgres batch writer for inflight batches.                                                                                                                                             |
-| PGSTREAM_POSTGRES_WRITER_BATCH_BYTES                           | 1.5MiB, 80MiB with bulk enabled | No       | Max size in bytes for a given batch. When this size is reached, the batch is sent to PostgreSQL.                                                                                                               |
+| PGSTREAM_POSTGRES_WRITER_MAX_QUEUE_BYTES                       | 104857600 (100MiB)              | No       | Max memory used by the postgres batch writer for inflight batches.                                                                                                                                             |
+| PGSTREAM_POSTGRES_WRITER_BATCH_BYTES                           | 1572864 (1.5MiB), 83886080 (80MiB) with bulk enabled | No       | Max size in bytes for a given batch. When this size is reached, the batch is sent to PostgreSQL.                                                                                                               |
 | PGSTREAM_POSTGRES_WRITER_BATCH_IGNORE_SEND_ERRORS              | False                           | No       | Whether to ignore errors encountered while sending events to the target.                                                                                                                                       |
 | PGSTREAM_POSTGRES_WRITER_DISABLE_TRIGGERS                      | False(run), True(snapshot)      | No       | Option to disable triggers on the target PostgreSQL database while performing the snaphot/replication streaming. It defaults to false when using the run command, and to true when using the snapshot command. |
 | PGSTREAM_POSTGRES_WRITER_ON_CONFLICT_ACTION                    | error                           | No       | Action to apply to inserts on conflict. Options are `nothing`, `update` or `error`.                                                                                                                            |

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,12 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/bytedance/sonic v1.15.1
 	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/docker/go-units v0.5.0
 	github.com/elastic/go-elasticsearch/v8 v8.19.3
 	github.com/eminano/greenmask v0.0.0-20250718112128-2fb5fa726c02
 	github.com/ggwhite/go-masker v1.1.0
 	github.com/go-logr/zerologr v1.2.3
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
@@ -82,7 +84,6 @@ require (
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v28.5.1+incompatible // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.8.0 // indirect
 	github.com/expr-lang/expr v1.17.7 // indirect
@@ -93,7 +94,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gofrs/uuid/v5 v5.3.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/mock v1.7.0-rc.1 // indirect


### PR DESCRIPTION
#### Description

Config values that set bytes (`_BYTES` suffix) both in env variables and YAML configuration accept human readable suffixes. In the past, the documentation said that we support it. However, we did not. So `pgstream` silently used the defaults instead of the configured values.

From now on, `pgstream` parses values like `15MiB`.

Another behaviour change is that now the value cannot be parsed, `pgstream` fails to start. Previously, in case of errors, `pgstream` started with the defaults.

Unset values continue to work the same as before.

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Indirect dependencies became direct dependencies
- Stricter configuration check

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
