### PR TITLE
Automerge dependabot PRs on minor and patch releases

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'xataio/pgstream'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Description

Adds a GitHub Actions workflow that auto-approves and enables auto-merge on
Dependabot PRs for patch and minor version bumps. Major-version updates are
skipped and continue to require human review.

##### Related Issue(s)

- N/A

#### Type of Change

- [x] 🔨 Build/CI changes

#### Changes Made

- Add `.github/workflows/dependabot-auto-merge.yml` triggered on `pull_request`,
  scoped to PRs authored by `dependabot[bot]` on `xataio/pgstream`.
- Approve + enable auto-merge only when update type is `semver-patch` or
  `semver-minor`; major bumps fall through to manual review.

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All existing tests pass

CI workflows aren't unit-testable; behavior will be observable on the next
Dependabot PR.

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
