### PR TITLE
Automate PR backports using backport-0.9.x label

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,36 @@
+name: Backport
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Backport to v0.9.x
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'backport-0.9.x')) ||
+        (github.event.action == 'labeled' && github.event.label.name == 'backport-0.9.x')
+      )
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create backport PR
+        uses: korthout/backport-action@v3
+        with:
+          github_token: ${{ secrets.GIT_TOKEN }}
+          target_branches: v0.9.x
+          pull_title: '[Backport v0.9.x] ${pull_title}'
+          pull_description: |-
+            Automated backport of #${pull_number} to `v0.9.x`.
+
+            ---
+
+            ${pull_description}


### PR DESCRIPTION
#### Description

This PR adds a new Github action to automate backporting of pull requests to v0.9.x branch using the new `backport-0.9.x` label.

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [x] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup
