### PR TITLE
Add support for cube data type

### DIFF
--- a/internal/postgres/instrumentation/instrumented_tx.go
+++ b/internal/postgres/instrumentation/instrumented_tx.go
@@ -52,3 +52,9 @@ func (i *Tx) CopyFrom(ctx context.Context, tableName string, columnNames []strin
 	defer otel.CloseSpan(span, err)
 	return i.inner.CopyFrom(ctx, tableName, columnNames, srcRows)
 }
+
+func (i *Tx) CopyFromText(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (rowCount int64, err error) {
+	ctx, span := otel.StartSpan(ctx, i.tracer, "tx.CopyFromText")
+	defer otel.CloseSpan(span, err)
+	return i.inner.CopyFromText(ctx, tableName, columnNames, srcRows)
+}

--- a/internal/postgres/mocks/mock_tx.go
+++ b/internal/postgres/mocks/mock_tx.go
@@ -9,11 +9,12 @@ import (
 )
 
 type Tx struct {
-	QueryRowFn    func(ctx context.Context, dest []any, query string, args ...any) error
-	QueryFn       func(ctx context.Context, query string, args ...any) (postgres.Rows, error)
-	ExecFn        func(ctx context.Context, i uint, query string, args ...any) (postgres.CommandTag, error)
-	CopyFromFn    func(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (int64, error)
-	execCallCount uint
+	QueryRowFn     func(ctx context.Context, dest []any, query string, args ...any) error
+	QueryFn        func(ctx context.Context, query string, args ...any) (postgres.Rows, error)
+	ExecFn         func(ctx context.Context, i uint, query string, args ...any) (postgres.CommandTag, error)
+	CopyFromFn     func(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (int64, error)
+	CopyFromTextFn func(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (int64, error)
+	execCallCount  uint
 }
 
 func (m *Tx) QueryRow(ctx context.Context, dest []any, query string, args ...any) error {
@@ -30,5 +31,12 @@ func (m *Tx) Exec(ctx context.Context, query string, args ...any) (postgres.Comm
 }
 
 func (m *Tx) CopyFrom(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (rowCount int64, err error) {
+	return m.CopyFromFn(ctx, tableName, columnNames, srcRows)
+}
+
+func (m *Tx) CopyFromText(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (rowCount int64, err error) {
+	if m.CopyFromTextFn != nil {
+		return m.CopyFromTextFn(ctx, tableName, columnNames, srcRows)
+	}
 	return m.CopyFromFn(ctx, tableName, columnNames, srcRows)
 }

--- a/internal/postgres/pg_tx.go
+++ b/internal/postgres/pg_tx.go
@@ -3,9 +3,13 @@
 package postgres
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type Tx interface {
@@ -13,6 +17,7 @@ type Tx interface {
 	QueryRow(ctx context.Context, dest []any, query string, args ...any) error
 	Exec(ctx context.Context, query string, args ...any) (CommandTag, error)
 	CopyFrom(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (int64, error)
+	CopyFromText(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (int64, error)
 }
 
 type TxIsolationLevel string
@@ -55,19 +60,161 @@ func (t *Txn) Exec(ctx context.Context, query string, args ...any) (CommandTag, 
 	return CommandTag{tag}, MapError(err)
 }
 
+// CopyFrom uses pgx's binary-format COPY, which is the fast path for any
+// column type pgx has a binary codec for. Callers must use CopyFromText
+// instead when the target table contains extension columns whose binary
+// representation pgx cannot produce.
 func (t *Txn) CopyFrom(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (int64, error) {
 	identifier, err := newIdentifier(tableName)
 	if err != nil {
 		return -1, err
 	}
+	for i, c := range columnNames {
+		columnNames[i] = removeQuotes(c)
+	}
+	return t.Tx.CopyFrom(ctx, identifier, columnNames, pgx.CopyFromRows(srcRows))
+}
 
-	// sanitize the input, removing any added quotes. The CopyFrom will sanitize
-	// them and double quotes will cause errors.
+// CopyFromText runs the postgres COPY protocol in text format, rather than
+// the binary format pgx defaults to. Text format makes the destination
+// Postgres parse each value through the per-type input function.
+// This matches pg_dump/pg_restore behaviour at the cost of a
+// modest serialisation/wire-size overhead vs. binary COPY.
+func (t *Txn) CopyFromText(ctx context.Context, tableName string, columnNames []string, srcRows [][]any) (int64, error) {
+	if len(srcRows) == 0 {
+		return 0, nil
+	}
+
 	for i, c := range columnNames {
 		columnNames[i] = removeQuotes(c)
 	}
 
-	return t.Tx.CopyFrom(ctx, identifier, columnNames, pgx.CopyFromRows(srcRows))
+	identifier, err := newIdentifier(tableName)
+	if err != nil {
+		return -1, err
+	}
+
+	conn := t.Tx.Conn()
+	tm := conn.TypeMap()
+
+	// Look up the column OIDs once via a prepared statement description so
+	// each value can be encoded with the right text codec.
+	quotedCols := make([]string, len(columnNames))
+	for i, c := range columnNames {
+		quotedCols[i] = pgx.Identifier{c}.Sanitize()
+	}
+	sd, err := conn.Prepare(ctx, "",
+		fmt.Sprintf("SELECT %s FROM %s", strings.Join(quotedCols, ", "), identifier.Sanitize()))
+	if err != nil {
+		return -1, fmt.Errorf("describing copy target: %w", err)
+	}
+	if len(sd.Fields) != len(columnNames) {
+		return -1, fmt.Errorf("copy target returned %d fields, expected %d", len(sd.Fields), len(columnNames))
+	}
+
+	// Bulk batches are bounded by maxParamsPerQuery/numCols upstream
+	// so we can serialise the COPY payload into a single buffer up front.
+	buf := bytes.NewBuffer(make([]byte, 0, estimateCopyTextSize(srcRows)))
+	for _, row := range srcRows {
+		if len(row) != len(columnNames) {
+			return -1, fmt.Errorf("row has %d values, expected %d", len(row), len(columnNames))
+		}
+		for i, val := range row {
+			if i > 0 {
+				buf.WriteByte('\t')
+			}
+			if err := writeCopyTextValue(buf, tm, sd.Fields[i].DataTypeOID, val); err != nil {
+				return -1, fmt.Errorf("encoding column %s: %w", columnNames[i], err)
+			}
+		}
+		buf.WriteByte('\n')
+	}
+
+	sql := fmt.Sprintf("COPY %s ( %s ) FROM STDIN", identifier.Sanitize(), strings.Join(quotedCols, ", "))
+	tag, err := conn.PgConn().CopyFrom(ctx, bytes.NewReader(buf.Bytes()), sql)
+	if err != nil {
+		return -1, err
+	}
+	return tag.RowsAffected(), nil
+}
+
+// estimateCopyTextSize returns a rough byte budget for the buffer that will
+// hold the entire COPY text payload. Slightly over-estimating avoids slice
+// regrowth while keeping the upfront allocation bounded.
+func estimateCopyTextSize(rows [][]any) int {
+	if len(rows) == 0 {
+		return 0
+	}
+	const perValueOverhead = 16 // delimiter + escape headroom
+	var perRow int
+	for _, v := range rows[0] {
+		switch val := v.(type) {
+		case string:
+			perRow += len(val) + perValueOverhead
+		case []byte:
+			perRow += len(val) + perValueOverhead
+		default:
+			_ = val
+			perRow += 24 // numeric/timestamp text form fits well under this
+		}
+	}
+	return perRow * len(rows)
+}
+
+// writeCopyTextValue appends the COPY-text-format encoding of v to buf,
+// looking up the encoder for oid in the type map. NULL is emitted as `\N`.
+// Special characters in the text encoding are escaped per the rules in
+// https://www.postgresql.org/docs/current/sql-copy.html (Text Format).
+func writeCopyTextValue(buf *bytes.Buffer, tm *pgtype.Map, oid uint32, v any) error {
+	if v == nil {
+		buf.WriteString(`\N`)
+		return nil
+	}
+	encoded, err := tm.Encode(oid, pgtype.TextFormatCode, v, nil)
+	if err != nil {
+		return err
+	}
+	if encoded == nil {
+		buf.WriteString(`\N`)
+		return nil
+	}
+	writeCopyTextEscaped(buf, encoded)
+	return nil
+}
+
+// copyTextEscapes maps each byte that needs escaping in COPY text format to
+// its replacement. A 256-entry table is faster than a switch and lets us
+// detect whether a byte needs escaping with a single index + len check.
+var copyTextEscapes = func() [256]string {
+	var t [256]string
+	t['\b'] = `\b`
+	t['\f'] = `\f`
+	t['\n'] = `\n`
+	t['\r'] = `\r`
+	t['\t'] = `\t`
+	t['\v'] = `\v`
+	t['\\'] = `\\`
+	return t
+}()
+
+// writeCopyTextEscaped writes b to buf escaping the byte values that have a
+// special meaning in COPY text format: \b \f \n \r \t \v \\. Runs of bytes
+// that do not need escaping are emitted in a single Write to keep the hot
+// path cheap for typical (escape-free) strings.
+func writeCopyTextEscaped(buf *bytes.Buffer, b []byte) {
+	start := 0
+	for i, c := range b {
+		if esc := copyTextEscapes[c]; esc != "" {
+			if i > start {
+				buf.Write(b[start:i])
+			}
+			buf.WriteString(esc)
+			start = i + 1
+		}
+	}
+	if start < len(b) {
+		buf.Write(b[start:])
+	}
 }
 
 func toTxOptions(opts TxOptions) pgx.TxOptions {

--- a/internal/postgres/pg_tx.go
+++ b/internal/postgres/pg_tx.go
@@ -94,7 +94,7 @@ func (t *Txn) CopyFromText(ctx context.Context, tableName string, columnNames []
 		return -1, err
 	}
 
-	conn := t.Tx.Conn()
+	conn := t.Conn()
 	tm := conn.TypeMap()
 
 	// Look up the column OIDs once via a prepared statement description so

--- a/internal/postgres/pg_tx_bench_test.go
+++ b/internal/postgres/pg_tx_bench_test.go
@@ -104,7 +104,6 @@ func BenchmarkCopyFrom(b *testing.B) {
 	}
 
 	for _, shape := range shapes {
-		shape := shape
 		// reset table once per shape so benchmarks share state
 		_, err := pool.Exec(ctx, "DROP TABLE IF EXISTS bench_numeric, bench_text")
 		require.NoError(b, err)

--- a/internal/postgres/pg_tx_bench_test.go
+++ b/internal/postgres/pg_tx_bench_test.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/testcontainers"
+)
+
+// BenchmarkCopyFrom compares pgx's binary-format COPY (Txn.CopyFrom) against
+// the text-format implementation (Txn.CopyFromText) on the same row payload.
+//
+// Two table shapes:
+//   - numeric: int8/timestamp/uuid columns — binary's strongest case (smaller
+//     wire payload, no per-type input function on the destination).
+//   - text:    text/varchar/jsonb columns — the gap shrinks because both
+//     modes ultimately route through text-like decoding.
+//
+// Each benchmark runs one COPY of `rows` rows per iteration. The container
+// is spun up once for the whole run and reused.
+//
+// Gated on PGSTREAM_INTEGRATION_TESTS so `go test ./...` doesn't pay the
+// container cost.
+//
+// Usage:
+//
+//	PGSTREAM_INTEGRATION_TESTS=true go test -bench=BenchmarkCopyFrom \
+//	    -benchtime=10x -run=^$ ./internal/postgres/
+func BenchmarkCopyFrom(b *testing.B) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		b.Skip("set PGSTREAM_INTEGRATION_TESTS=true to run")
+	}
+
+	ctx := context.Background()
+
+	var pgURL string
+	cleanup, err := testcontainers.SetupPostgresContainer(ctx, &pgURL, testcontainers.Postgres17)
+	require.NoError(b, err)
+	defer func() { _ = cleanup() }()
+
+	pool, err := pglib.NewConnPool(ctx, pgURL)
+	require.NoError(b, err)
+	defer pool.Close(ctx)
+
+	// the text path encodes citext through cube_in / citext_in / ltree_in,
+	// so install the extension on the bench db too — even though the
+	// numeric/text benchmark shapes below don't use them, the codec map
+	// is shared with the rest of the repo.
+	for _, ext := range []string{"cube", "citext", "ltree"} {
+		_, err := pool.Exec(ctx, "CREATE EXTENSION IF NOT EXISTS "+ext)
+		require.NoError(b, err)
+	}
+
+	shapes := []struct {
+		name    string
+		create  string
+		columns []string
+		row     func(int) []any
+	}{
+		{
+			name: "numeric_heavy",
+			create: `CREATE TABLE bench_numeric (
+				id          bigint PRIMARY KEY,
+				amount      bigint NOT NULL,
+				created_at  timestamptz NOT NULL,
+				external_id uuid NOT NULL
+			)`,
+			columns: []string{"id", "amount", "created_at", "external_id"},
+			row: func(i int) []any {
+				return []any{
+					int64(i),
+					int64(i * 1000),
+					time.Unix(int64(1_700_000_000+i), 0).UTC(),
+					uuid.New().String(),
+				}
+			},
+		},
+		{
+			name: "text_heavy",
+			create: `CREATE TABLE bench_text (
+				id     bigint PRIMARY KEY,
+				name   text   NOT NULL,
+				bio    text   NOT NULL,
+				doc    jsonb  NOT NULL
+			)`,
+			columns: []string{"id", "name", "bio", "doc"},
+			row: func(i int) []any {
+				return []any{
+					int64(i),
+					fmt.Sprintf("user-%d", i),
+					"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eu congue arcu.",
+					fmt.Sprintf(`{"i":%d,"tags":["a","b","c"],"nested":{"x":1.5,"y":"z"}}`, i),
+				}
+			},
+		},
+	}
+
+	for _, shape := range shapes {
+		shape := shape
+		// reset table once per shape so benchmarks share state
+		_, err := pool.Exec(ctx, "DROP TABLE IF EXISTS bench_numeric, bench_text")
+		require.NoError(b, err)
+		_, err = pool.Exec(ctx, shape.create)
+		require.NoError(b, err)
+
+		for _, rows := range []int{1_000, 10_000} {
+			payload := make([][]any, rows)
+			for i := range payload {
+				payload[i] = shape.row(i)
+			}
+
+			tableName := "bench_numeric"
+			if shape.name == "text_heavy" {
+				tableName = "bench_text"
+			}
+
+			b.Run(fmt.Sprintf("%s/binary/n=%d", shape.name, rows), func(b *testing.B) {
+				runCopyBench(ctx, b, pool, tableName, shape.columns, payload, false)
+			})
+			b.Run(fmt.Sprintf("%s/text/n=%d", shape.name, rows), func(b *testing.B) {
+				runCopyBench(ctx, b, pool, tableName, shape.columns, payload, true)
+			})
+		}
+	}
+}
+
+func runCopyBench(ctx context.Context, b *testing.B, pool *pglib.Pool, table string, cols []string, rows [][]any, useText bool) {
+	b.Helper()
+	b.ReportAllocs()
+	b.SetBytes(approxRowBytes(rows))
+	for b.Loop() {
+		err := pool.ExecInTx(ctx, func(tx pglib.Tx) error {
+			// TRUNCATE keeps every iteration writing into an empty table
+			// without paying ALTER / VACUUM overhead between runs.
+			if _, err := tx.Exec(ctx, "TRUNCATE "+table); err != nil {
+				return err
+			}
+			if useText {
+				_, err := tx.CopyFromText(ctx, table, cols, rows)
+				return err
+			}
+			_, err := tx.CopyFrom(ctx, table, cols, rows)
+			return err
+		})
+		require.NoError(b, err)
+	}
+}
+
+// approxRowBytes returns a rough byte count for the payload so b.SetBytes
+// produces a meaningful MB/s figure. We only need an order-of-magnitude
+// approximation, hence the rough sizing of non-string values.
+func approxRowBytes(rows [][]any) int64 {
+	if len(rows) == 0 {
+		return 0
+	}
+	const inlineNumericBytes = 8
+	var perRow int64
+	for _, v := range rows[0] {
+		switch val := v.(type) {
+		case string:
+			perRow += int64(len(val))
+		case []byte:
+			perRow += int64(len(val))
+		default:
+			_ = val
+			perRow += inlineNumericBytes
+		}
+	}
+	return perRow * int64(len(rows))
+}

--- a/internal/postgres/pg_utils.go
+++ b/internal/postgres/pg_utils.go
@@ -151,25 +151,75 @@ func extractDatabase(url string) (string, error) {
 	return pgCfg.Database, nil
 }
 
-func registerTypesToConnMap(ctx context.Context, conn *pgx.Conn) error {
-	var hstoreOID uint32
-	err := conn.QueryRow(ctx, "SELECT oid FROM pg_type WHERE typname = 'hstore'").Scan(&hstoreOID)
-	if err == nil && hstoreOID != 0 {
-		conn.TypeMap().RegisterType(&pgtype.Type{
-			Codec: pgtype.HstoreCodec{},
-			Name:  "hstore",
-			OID:   hstoreOID,
-		})
-	}
+// extensionType describes a postgres extension type that pgx does not know
+// about out of the box and how to make pgx encode/decode it correctly.
+type extensionType struct {
+	// name is the unqualified type name as it appears to `to_regtype`
+	name string
+	// register is invoked with the resolved OID once the type has been found
+	// in pg_type. Implementations are free to register additional related types.
+	register func(ctx context.Context, conn *pgx.Conn, oid uint32) error
+}
 
-	var vectorOID uint32
-	if err := conn.QueryRow(ctx, "SELECT to_regtype('vector')::oid").Scan(&vectorOID); err == nil && vectorOID != 0 {
+// extensionTypes lists the postgres extension types pgstream teaches pgx
+// about on every connection.
+var extensionTypes = []extensionType{
+	{name: "hstore", register: registerWithCodec("hstore", pgtype.HstoreCodec{})},
+	{name: "vector", register: func(ctx context.Context, conn *pgx.Conn, _ uint32) error {
+		// pgxvec registers vector, halfvec and sparsevec in one call —
+		// the OID lookup above is just a gate to skip when pgvector is
+		// not installed.
 		if err := pgxvec.RegisterTypes(ctx, conn); err != nil {
 			return fmt.Errorf("registering pgvector types: %w", err)
 		}
-	}
+		return nil
+	}},
+	{name: "cube", register: registerWithCodec("cube", pgtype.TextCodec{})},
+}
 
+// registerTypesToConnMap teaches pgx about the postgres extension types
+// listed in extensionTypes for every new connection.
+//
+// To add a new extension type, append one entry to extensionTypes above:
+//   - Simple case (one OID, one codec): use registerWithCodec("name", codec).
+//     For COPY-safe text round-trip, pass pgtype.TextCodec{}.
+//   - Complex case (extension exposes several related types, or needs
+//     library-side setup): inline a register func; see the "vector" entry,
+//     which delegates to pgxvec.RegisterTypes.
+//
+// Entries are no-ops when the extension is not installed on the target.
+func registerTypesToConnMap(ctx context.Context, conn *pgx.Conn) error {
+	for _, ext := range extensionTypes {
+		if err := registerExtensionType(ctx, conn, ext); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// registerExtensionType resolves the OID for ext.name via `to_regtype` and,
+// if the type exists, hands it to ext.register. A missing extension is not
+// an error.
+func registerExtensionType(ctx context.Context, conn *pgx.Conn, ext extensionType) error {
+	var oid uint32
+	if err := conn.QueryRow(ctx, "SELECT to_regtype($1)::oid", ext.name).Scan(&oid); err != nil || oid == 0 {
+		return nil
+	}
+	return ext.register(ctx, conn, oid)
+}
+
+// registerWithCodec builds a register function that binds the given codec to
+// the (name, OID) pair on the connection's type map. Used for extensions
+// where one OID maps to one codec.
+func registerWithCodec(name string, codec pgtype.Codec) func(ctx context.Context, conn *pgx.Conn, oid uint32) error {
+	return func(_ context.Context, conn *pgx.Conn, oid uint32) error {
+		conn.TypeMap().RegisterType(&pgtype.Type{
+			Codec: codec,
+			Name:  name,
+			OID:   oid,
+		})
+		return nil
+	}
 }
 
 const DiscoverAllSchemasQuery = "SELECT nspname FROM pg_catalog.pg_namespace WHERE nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast', 'pgstream')"

--- a/internal/postgres/pg_utils_integration_test.go
+++ b/internal/postgres/pg_utils_integration_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/pgvector/pgvector-go"
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/internal/testcontainers"
+)
+
+func Test_registerTypesToConnMap_pgvector(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx := context.Background()
+
+	t.Run("extension installed - vector round-trips through pgx", func(t *testing.T) {
+		var pgURL string
+		cleanup, err := testcontainers.SetupPostgresContainer(ctx, &pgURL, testcontainers.PgvectorPostgres17)
+		require.NoError(t, err)
+		defer cleanup()
+
+		bootstrap, err := NewConn(ctx, pgURL)
+		require.NoError(t, err)
+		_, err = bootstrap.Exec(ctx, "CREATE EXTENSION vector")
+		require.NoError(t, err)
+		bootstrap.Close(ctx)
+
+		// New connection after the extension is installed: registerTypesToConnMap
+		// should see vectorOID != 0 and call pgxvec.RegisterTypes successfully.
+		conn, err := NewConn(ctx, pgURL)
+		require.NoError(t, err)
+		defer conn.Close(ctx)
+
+		_, err = conn.Exec(ctx, "CREATE TABLE items (id serial primary key, embedding vector(3))")
+		require.NoError(t, err)
+
+		want := pgvector.NewVector([]float32{1, 2, 3})
+		_, err = conn.Exec(ctx, "INSERT INTO items (embedding) VALUES ($1)", want)
+		require.NoError(t, err)
+
+		var got pgvector.Vector
+		err = conn.QueryRow(ctx, []any{&got}, "SELECT embedding FROM items LIMIT 1")
+		require.NoError(t, err)
+		require.Equal(t, want.Slice(), got.Slice())
+	})
+
+	t.Run("extension not installed - connection still succeeds", func(t *testing.T) {
+		var pgURL string
+		cleanup, err := testcontainers.SetupPostgresContainer(ctx, &pgURL, testcontainers.Postgres17)
+		require.NoError(t, err)
+		defer cleanup()
+
+		// registerTypesToConnMap should see vectorOID == 0 and skip RegisterTypes
+		// entirely. Connection setup must not fail.
+		conn, err := NewConn(ctx, pgURL)
+		require.NoError(t, err)
+		defer conn.Close(ctx)
+
+		var one int
+		err = conn.QueryRow(ctx, []any{&one}, "SELECT 1")
+		require.NoError(t, err)
+		require.Equal(t, 1, one)
+	})
+}

--- a/internal/testcontainers/test_postgres_container.go
+++ b/internal/testcontainers/test_postgres_container.go
@@ -17,8 +17,9 @@ type cleanup func() error
 type PostgresImage string
 
 const (
-	Postgres14 PostgresImage = "debezium/postgres:14-alpine"
-	Postgres17 PostgresImage = "debezium/postgres:17-alpine"
+	Postgres14         PostgresImage = "debezium/postgres:14-alpine"
+	Postgres17         PostgresImage = "debezium/postgres:17-alpine"
+	PgvectorPostgres17 PostgresImage = "pgvector/pgvector:pg17"
 )
 
 func SetupPostgresContainer(ctx context.Context, url *string, image PostgresImage, configFile ...string) (cleanup, error) {

--- a/pkg/stream/integration/snapshot_pg_integration_test.go
+++ b/pkg/stream/integration/snapshot_pg_integration_test.go
@@ -205,6 +205,125 @@ func Test_SnapshotToPostgres_IdentityOnlyTable(t *testing.T) {
 	})
 }
 
+// Test_SnapshotToPostgres_CubeColumns verifies that snapshot/restore
+// preserves cube column values end-to-end.
+//
+// Regression for #801: pgx's CopyFrom serialised cube values in binary
+// format and the destination COPY rejected the rows with "cube dimension
+// is too large" because the leading bytes of the text representation
+// were interpreted as the binary header.
+func Test_SnapshotToPostgres_CubeColumns(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	var snapshotPGURL string
+	pgcleanup, err := testcontainers.SetupPostgresContainer(context.Background(), &snapshotPGURL, testcontainers.Postgres14, "config/postgresql.conf")
+	require.NoError(t, err)
+	defer pgcleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	run := func(suffix string, opts ...option) {
+		testTable := fmt.Sprintf("cube_columns_%s", suffix)
+
+		// install cube on both source and target; the test row uses a
+		// 5-D cube and a 3-D box to exercise the binary-header failure
+		// mode.
+		for _, url := range []string{snapshotPGURL, targetPGURL} {
+			execQueryWithURL(t, ctx, url, "CREATE EXTENSION IF NOT EXISTS cube")
+		}
+
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+			`CREATE TABLE %s(
+				id  INTEGER PRIMARY KEY,
+				vec cube NOT NULL
+			)`, testTable))
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+			`INSERT INTO %s(id, vec) VALUES
+				(1, cube(ARRAY[1.0, 2.0, 3.0, 4.0, 5.0])),
+				(2, cube(ARRAY[0.5])),
+				(3, cube('(10, 20, 30),(40, 50, 60)'))`,
+			testTable))
+
+		cfg := &stream.Config{
+			Listener:  testPostgresListenerCfgWithSnapshot(snapshotPGURL, targetPGURL, []string{"*.*"}),
+			Processor: testPostgresProcessorCfg(opts...),
+		}
+		initStream(t, ctx, snapshotPGURL)
+		runSnapshot(t, ctx, cfg)
+
+		targetConn, err := pglib.NewConn(ctx, targetPGURL)
+		require.NoError(t, err)
+		sourceConn, err := pglib.NewConn(ctx, snapshotPGURL)
+		require.NoError(t, err)
+
+		timer := time.NewTimer(20 * time.Second)
+		defer timer.Stop()
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		type row struct {
+			id  int
+			vec string
+		}
+		// Pull the canonical text form from the source so the assertion
+		// doesn't bake in cube output formatting quirks.
+		query := fmt.Sprintf("SELECT id, vec::text FROM %s ORDER BY id", testTable)
+		fetch := func(conn pglib.Querier) ([]row, error) {
+			rows, err := conn.Query(ctx, query)
+			if err != nil {
+				return nil, err
+			}
+			defer rows.Close()
+
+			out := []row{}
+			for rows.Next() {
+				var r row
+				if err := rows.Scan(&r.id, &r.vec); err != nil {
+					return nil, err
+				}
+				out = append(out, r)
+			}
+			return out, rows.Err()
+		}
+
+		want, err := fetch(sourceConn)
+		require.NoError(t, err)
+		require.Len(t, want, 3)
+
+		validation := func() bool {
+			got, err := fetch(targetConn)
+			if err != nil || len(got) != len(want) {
+				return false
+			}
+			require.Equal(t, want, got)
+			return true
+		}
+
+		for {
+			select {
+			case <-timer.C:
+				cancel()
+				t.Error("timeout waiting for postgres snapshot sync of cube columns")
+				return
+			case <-ticker.C:
+				if validation() {
+					return
+				}
+			}
+		}
+	}
+
+	t.Run("bulk ingest", func(t *testing.T) {
+		run("bulk", withBulkIngestionEnabled())
+	})
+	t.Run("batch writer", func(t *testing.T) {
+		run("batch")
+	})
+}
+
 // Test_SnapshotToPostgres_IdentityAndGeneratedColumns verifies that identity
 // columns have their values preserved while generated (stored) columns are
 // correctly excluded from inserts and recomputed by the target database.

--- a/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
+++ b/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
@@ -168,12 +168,26 @@ func (w *BulkIngestWriter) copyFromInsertQueries(ctx context.Context, inserts []
 		rows = append(rows, q.args)
 	}
 
+	// Tables with extension types pgx has no binary codec for
+	// must round-trip through text-format COPY, otherwise
+	// the destination misreads the raw text bytes as the binary
+	// representation of the type.
+	// The dml adapter precomputes the needsTextCopy flag
+	// from the column type list when building the query.
+	copyFn := func(tx pglib.Tx) (int64, error) {
+		target := pglib.QuoteQualifiedIdentifier(query.schema, query.table)
+		if query.needsTextCopy {
+			return tx.CopyFromText(ctx, target, query.columnNames, rows)
+		}
+		return tx.CopyFrom(ctx, target, query.columnNames, rows)
+	}
+
 	err := w.pgConn.ExecInTx(ctx, func(tx pglib.Tx) error {
 		if err := w.setReplicationRoleToReplica(ctx, tx); err != nil {
 			return err
 		}
 
-		rowsCopied, err := tx.CopyFrom(ctx, pglib.QuoteQualifiedIdentifier(query.schema, query.table), query.columnNames, rows)
+		rowsCopied, err := copyFn(tx)
 		if err != nil {
 			return err
 		}

--- a/pkg/wal/processor/postgres/postgres_query_msg.go
+++ b/pkg/wal/processor/postgres/postgres_query_msg.go
@@ -9,6 +9,7 @@ type query struct {
 	columnNames []string
 	args        []any
 	isDDL       bool
+	needsTextCopy bool
 }
 
 const (

--- a/pkg/wal/processor/postgres/postgres_query_msg.go
+++ b/pkg/wal/processor/postgres/postgres_query_msg.go
@@ -3,12 +3,12 @@
 package postgres
 
 type query struct {
-	schema      string
-	table       string
-	sql         string
-	columnNames []string
-	args        []any
-	isDDL       bool
+	schema        string
+	table         string
+	sql           string
+	columnNames   []string
+	args          []any
+	isDDL         bool
 	needsTextCopy bool
 }
 

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
@@ -95,7 +95,7 @@ func (a *dmlAdapter) buildDeleteQuery(d *wal.Data) (*query, error) {
 }
 
 func (a *dmlAdapter) buildInsertQueries(d *wal.Data, schemaInfo schemaInfo) []*query {
-	names, values := a.filterRowColumns(d.Columns, schemaInfo)
+	names, types, values := a.filterRowColumnsWithTypes(d.Columns, schemaInfo)
 	// if there are no columns after filtering generated ones, no query to run
 	if len(names) == 0 {
 		return []*query{}
@@ -108,9 +108,10 @@ func (a *dmlAdapter) buildInsertQueries(d *wal.Data, schemaInfo schemaInfo) []*q
 
 	qs := []*query{
 		{
-			table:       d.Table,
-			schema:      d.Schema,
-			columnNames: names,
+			table:         d.Table,
+			schema:        d.Schema,
+			columnNames:   names,
+			needsTextCopy: needsTextCopy(types),
 			sql: fmt.Sprintf("INSERT INTO %s(%s) OVERRIDING SYSTEM VALUE VALUES(%s)%s",
 				quotedTableName(d.Schema, d.Table), strings.Join(names, ", "),
 				strings.Join(placeholders, ", "),
@@ -147,7 +148,7 @@ func (a *dmlAdapter) buildInsertQueries(d *wal.Data, schemaInfo schemaInfo) []*q
 }
 
 func (a *dmlAdapter) buildUpdateQuery(d *wal.Data, schemaInfo schemaInfo) (*query, error) {
-	rowColumns, rowValues := a.filterRowColumnsForAction(d.Columns, schemaInfo, true)
+	rowColumns, _, rowValues := a.filterRowColumnsForAction(d.Columns, schemaInfo, true)
 	// if there are no columns after filtering generated ones, no query to run
 	if len(rowColumns) == 0 {
 		return &query{}, nil
@@ -269,6 +270,14 @@ func (a *dmlAdapter) extractPrimaryKeyColumnNames(colIDs []string, cols []wal.Co
 }
 
 func (a *dmlAdapter) filterRowColumns(cols []wal.Column, schemaInfo schemaInfo) ([]string, []any) {
+	names, _, vals := a.filterRowColumnsForAction(cols, schemaInfo, false)
+	return names, vals
+}
+
+// filterRowColumnsWithTypes is the variant used on the bulk-COPY path: it
+// also returns the postgres type name for each kept column so the writer
+// can decide between binary and text-format COPY.
+func (a *dmlAdapter) filterRowColumnsWithTypes(cols []wal.Column, schemaInfo schemaInfo) ([]string, []string, []any) {
 	return a.filterRowColumnsForAction(cols, schemaInfo, false)
 }
 
@@ -276,9 +285,10 @@ func (a *dmlAdapter) filterRowColumns(cols []wal.Column, schemaInfo schemaInfo) 
 // true — also drops GENERATED ALWAYS AS IDENTITY columns. INSERTs use
 // OVERRIDING SYSTEM VALUE so always-identity values are accepted, but no such
 // clause exists for UPDATE and Postgres rejects explicit values in SET.
-func (a *dmlAdapter) filterRowColumnsForAction(cols []wal.Column, schemaInfo schemaInfo, forUpdate bool) ([]string, []any) {
+func (a *dmlAdapter) filterRowColumnsForAction(cols []wal.Column, schemaInfo schemaInfo, forUpdate bool) ([]string, []string, []any) {
 	rowValues := make([]any, 0, len(cols))
 	rowColumns := make([]string, 0, len(cols))
+	rowTypes := make([]string, 0, len(cols))
 	for _, c := range cols {
 		quoted := pglib.QuoteIdentifier(c.Name)
 		if _, found := schemaInfo.generatedColumns[quoted]; found {
@@ -290,6 +300,7 @@ func (a *dmlAdapter) filterRowColumnsForAction(cols []wal.Column, schemaInfo sch
 			}
 		}
 		rowColumns = append(rowColumns, quoted)
+		rowTypes = append(rowTypes, c.Type)
 		val := c.Value
 
 		val = serializeJSONBValue(c.Type, val)
@@ -299,7 +310,7 @@ func (a *dmlAdapter) filterRowColumnsForAction(cols []wal.Column, schemaInfo sch
 		}
 		rowValues = append(rowValues, val)
 	}
-	return rowColumns, rowValues
+	return rowColumns, rowTypes, rowValues
 }
 
 func (a *dmlAdapter) updateValueForCopy(value any, colType string) any {
@@ -395,6 +406,22 @@ func getTypedTSTZRange(value any) any {
 		UpperType: v.UpperType,
 		Valid:     v.Valid,
 	}
+}
+
+// textOnlyCopyTypes lists postgres type names whose binary wire format pgx
+// can't produce correctly, so bulk ingest must fall back to text-format
+// COPY for any batch that touches one of these columns.
+var textOnlyCopyTypes = map[string]struct{}{
+	"cube": {}, // binary header: int32 dim+flags + N×float8 — pgx writes the text rep, server misreads it as a dimension count
+}
+
+func needsTextCopy(columnTypes []string) bool {
+	for _, t := range columnTypes {
+		if _, ok := textOnlyCopyTypes[t]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func isArray(colType string) bool {

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter_bulk.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter_bulk.go
@@ -214,8 +214,9 @@ func (a *dmlAdapter) buildBulkInsertQueries(events []*wal.Data, si schemaInfo) [
 		return nil
 	}
 
-	// determine column names from first event
-	names, _ := a.filterRowColumns(events[0].Columns, si)
+	// determine column names + types from first event so the writer can
+	// decide between binary and text COPY downstream.
+	names, types, _ := a.filterRowColumnsWithTypes(events[0].Columns, si)
 	if len(names) == 0 {
 		return []*query{}
 	}
@@ -274,11 +275,12 @@ func (a *dmlAdapter) buildBulkInsertQueries(events []*wal.Data, si schemaInfo) [
 			a.buildOnConflictQuery(events[0], names))
 
 		queries = append(queries, &query{
-			schema:      events[0].Schema,
-			table:       events[0].Table,
-			columnNames: names,
-			sql:         sql,
-			args:        args,
+			schema:        events[0].Schema,
+			table:         events[0].Table,
+			columnNames:   names,
+			needsTextCopy: needsTextCopy(types),
+			sql:           sql,
+			args:          args,
 		})
 	}
 

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter_test.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter_test.go
@@ -975,7 +975,7 @@ func TestDMLAdapter_filterRowColumns(t *testing.T) {
 			t.Parallel()
 
 			a := dmlAdapter{}
-			rowColumns, rowValues := a.filterRowColumnsForAction(tc.columns, schemaInfo{
+			rowColumns, _, rowValues := a.filterRowColumnsForAction(tc.columns, schemaInfo{
 				generatedColumns:      tc.generatedColumns,
 				alwaysIdentityColumns: tc.alwaysIdentityColumns,
 			}, tc.forUpdate)


### PR DESCRIPTION
#### Description

This PR adds support for [cube](https://www.postgresql.org/docs/current/cube.html) data type. The data type is used for representing multidimensional cubes.

At the moment snapshotting a table with a `cube` column fails on the COPY step:

```
copy from: program limit exceeded: cube dimension is too large
  module=postgres_bulk_ingest_writer
```

The root cause of the issue `pgx`'s `CopyFrom` is hardcoded to `COPY ... FROM STDIN BINARY` and emits each value through the codec registered for its OID. `cube` has no binary codec in pgx; the fallback writes the raw text bytes into a binary frame, and on the receiving side Postgres parses them through the cube binary input function. The first 4 bytes of `(1,2,3,4,5)` are read as a dimension count, hence "cube dimension is too large".

`pg_dump`/`pg_restore` are unaffected because they use `COPY ... FROM STDIN` (text format), which routes each value through the per-type text input function (`cube_in`).


##### Related Issue(s)

- Fixes #801 

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- **`internal/postgres/pg_tx.go`**: keep `Txn.CopyFrom` on pgx's fast binary path and add a new `Txn.CopyFromText` that runs the postgres COPY protocol in text format via `pgconn.PgConn.CopyFrom(... "COPY … FROM STDIN")`. Values are encoded with `TypeMap.Encode(oid, TextFormatCode, …)` and the stream uses COPY text escaping (`\t \n \r \\ \b \f \v`). The whole COPY payload is serialised into a single `bytes.Buffer` and handed to `pgconn.CopyFrom` via `bytes.Reader`; unescaped runs of bytes are emitted in one `Write` call to keep the hot path cheap.

- **bulk ingest writer dispatch**: `buildInsertQueries` / `buildBulkInsertQueries` compute a `needsTextCopy` flag on the resulting `*query` by checking each column's postgres type against a small `textOnlyCopyTypes` set (just `cube` here). `BulkIngestWriter.copyFromInsertQueries` reads that flag and dispatches to `tx.CopyFromText` only for affected batches; everything else stays on binary COPY, so non-cube snapshots keep their original throughput.

- **`internal/postgres/pg_utils.go`**: generalise the per-type if-blocks into a table-driven `extensionTypes` slice. Each entry binds an extension to a register function. `hstore` and `vector` keep their existing codec/library wiring; `cube` is registered with `pgtype.TextCodec` so the source-side read path (`rows.Values()`) returns cube values as strings rather than raw `[]byte`, which is what the text-format encoder expects.


#### Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary


#### Additional Notes

Text-format COPY is slower than binary on numeric/timestamp/uuid columns (bigger wire payload + per-type input functions instead of memcpy on the destination).

**The conditional dispatch confines the cost to tables that actually contain a cube column. Every other snapshot path keeps the original binary throughput.**

Measured locally with `BenchmarkCopyFrom` in `internal/postgres/pg_tx_bench_test.go` (Postgres 17 in testcontainers, `-benchtime=20x`):

| Shape | n | Binary | Text | Slowdown |
| --- | --- | --- | --- | --- |
| numeric-heavy (int8, timestamptz, uuid) | 10,000 | 42.05 ms / 14.27 MB/s | 44.51 ms / 13.48 MB/s | 6% |
| text-heavy (text, jsonb) | 10,000 | 55.25 ms / 27.33 MB/s | 63.04 ms / 23.95 MB/s | 14% |

Reproduce: `PGSTREAM_INTEGRATION_TESTS=true go test -bench=BenchmarkCopyFrom -benchtime=20x -run=^$ ./internal/postgres/`.
