### PR TITLE
Add support for custom TLS settings for the search stores

### DIFF
--- a/cmd/config/config_env.go
+++ b/cmd/config/config_env.go
@@ -109,6 +109,11 @@ func init() {
 
 	viper.BindEnv("PGSTREAM_OPENSEARCH_STORE_URL")
 	viper.BindEnv("PGSTREAM_ELASTICSEARCH_STORE_URL")
+	viper.BindEnv("PGSTREAM_SEARCH_TLS_ENABLED")
+	viper.BindEnv("PGSTREAM_SEARCH_TLS_CA_CERT_FILE")
+	viper.BindEnv("PGSTREAM_SEARCH_TLS_CLIENT_CERT_FILE")
+	viper.BindEnv("PGSTREAM_SEARCH_TLS_CLIENT_KEY_FILE")
+	viper.BindEnv("PGSTREAM_SEARCH_TLS_INSECURE_SKIP_VERIFY")
 	viper.BindEnv("PGSTREAM_SEARCH_INDEXER_BATCH_SIZE")
 	viper.BindEnv("PGSTREAM_SEARCH_INDEXER_BATCH_TIMEOUT")
 	viper.BindEnv("PGSTREAM_SEARCH_INDEXER_MAX_QUEUE_BYTES")
@@ -471,6 +476,7 @@ func parseSearchProcessorConfig() (*stream.SearchProcessorConfig, error) {
 		Store: store.Config{
 			OpenSearchURL:    opensearchStore,
 			ElasticsearchURL: elasticsearchStore,
+			TLS:              parseSearchTLSConfig(),
 		},
 		Retrier: search.StoreRetryConfig{
 			Backoff: parseBackoffConfig("PGSTREAM_SEARCH_STORE"),
@@ -631,4 +637,18 @@ func parseTLSConfig(prefix string) tls.Config {
 		ClientCertFile: viper.GetString(fmt.Sprintf("%s_TLS_CLIENT_CERT_FILE", prefix)),
 		ClientKeyFile:  viper.GetString(fmt.Sprintf("%s_TLS_CLIENT_KEY_FILE", prefix)),
 	}
+}
+
+// parseSearchTLSConfig reads the search store TLS settings from the
+// environment.
+func parseSearchTLSConfig() tls.Config {
+	cfg := tls.Config{
+		CaCertFile:         viper.GetString("PGSTREAM_SEARCH_TLS_CA_CERT_FILE"),
+		ClientCertFile:     viper.GetString("PGSTREAM_SEARCH_TLS_CLIENT_CERT_FILE"),
+		ClientKeyFile:      viper.GetString("PGSTREAM_SEARCH_TLS_CLIENT_KEY_FILE"),
+		InsecureSkipVerify: viper.GetBool("PGSTREAM_SEARCH_TLS_INSECURE_SKIP_VERIFY"),
+	}
+	cfg.Enabled = viper.GetBool("PGSTREAM_SEARCH_TLS_ENABLED") ||
+		cfg.CaCertFile != "" || cfg.ClientCertFile != "" || cfg.InsecureSkipVerify
+	return cfg
 }

--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -189,11 +189,21 @@ type KafkaTopicConfig struct {
 }
 
 type SearchConfig struct {
-	Engine     string         `mapstructure:"engine" yaml:"engine"`
-	URL        string         `mapstructure:"url" yaml:"url"`
-	Batch      *BatchConfig   `mapstructure:"batch" yaml:"batch"`
-	Backoff    *BackoffConfig `mapstructure:"backoff" yaml:"backoff"`
-	HashDocIDs bool           `mapstructure:"hash_doc_ids" yaml:"hash_doc_ids"`
+	Engine     string           `mapstructure:"engine" yaml:"engine"`
+	URL        string           `mapstructure:"url" yaml:"url"`
+	Batch      *BatchConfig     `mapstructure:"batch" yaml:"batch"`
+	Backoff    *BackoffConfig   `mapstructure:"backoff" yaml:"backoff"`
+	HashDocIDs bool             `mapstructure:"hash_doc_ids" yaml:"hash_doc_ids"`
+	TLS        *SearchTLSConfig `mapstructure:"tls" yaml:"tls"`
+}
+
+// SearchTLSConfig configures the HTTPS transport used to talk to the search
+// store.
+type SearchTLSConfig struct {
+	CACert             string `mapstructure:"ca_cert" yaml:"ca_cert"`
+	ClientCert         string `mapstructure:"client_cert" yaml:"client_cert"`
+	ClientKey          string `mapstructure:"client_key" yaml:"client_key"`
+	InsecureSkipVerify bool   `mapstructure:"insecure_skip_verify" yaml:"insecure_skip_verify"`
 }
 
 type BatchConfig struct {
@@ -646,6 +656,16 @@ func (c *YAMLConfig) parseSearchProcessorConfig() (*stream.SearchProcessorConfig
 		storeCfg.OpenSearchURL = c.Target.Search.URL
 	default:
 		return nil, errUnsupportedSearchEngine
+	}
+
+	if tlsCfg := c.Target.Search.TLS; tlsCfg != nil {
+		storeCfg.TLS = tls.Config{
+			Enabled:            true,
+			CaCertFile:         tlsCfg.CACert,
+			ClientCertFile:     tlsCfg.ClientCert,
+			ClientKeyFile:      tlsCfg.ClientKey,
+			InsecureSkipVerify: tlsCfg.InsecureSkipVerify,
+		}
 	}
 
 	return &stream.SearchProcessorConfig{

--- a/config_template.yaml
+++ b/config_template.yaml
@@ -98,6 +98,11 @@ target:
     engine: "elasticsearch" # options are elasticsearch or opensearch
     url: "http://localhost:9200" # URL of the search engine
     hash_doc_ids: false # if true, hash document IDs using SHA256 to avoid exceeding the 512 byte limit
+    tls: # optional. Only needed when the search target requires HTTPS or a custom CA / mTLS.
+      ca_cert: "" # path to a PEM-encoded CA certificate. Leave empty to use the system pool.
+      client_cert: "" # path to a PEM-encoded client certificate (mTLS).
+      client_key: "" # path to a PEM-encoded client key (mTLS).
+      insecure_skip_verify: false # if true, skip server certificate verification. Use only against trusted/self-signed clusters in internal networks.
     batch:
       timeout: 1000 # batch timeout in milliseconds. Defaults to 1s
       size: 100 # number of messages in a batch. Defaults to 100

--- a/internal/searchstore/elasticsearch/elasticsearch_client.go
+++ b/internal/searchstore/elasticsearch/elasticsearch_client.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,10 +22,30 @@ type Client struct {
 	client *elasticsearch.Client
 }
 
+// Option configures the underlying elasticsearch.Client.
+type Option func(*elasticsearch.Config)
+
+// WithTLS installs the given TLS config on the client's HTTP transport.
+// Passing nil leaves the default transport untouched.
+func WithTLS(tlsCfg *tls.Config) Option {
+	return func(c *elasticsearch.Config) {
+		if tlsCfg == nil {
+			return
+		}
+		base, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			return
+		}
+		transport := base.Clone()
+		transport.TLSClientConfig = tlsCfg
+		c.Transport = transport
+	}
+}
+
 var errInvalidSearchEnvelope = errors.New("invalid search response")
 
-func NewClient(url string) (*Client, error) {
-	es, err := newClient(url)
+func NewClient(url string, opts ...Option) (*Client, error) {
+	es, err := newClient(url, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create elasticsearch client: %w", err)
 	}
@@ -468,7 +489,7 @@ func (ec *Client) isErrResponse(res *esapi.Response) error {
 	return searchstore.IsErrResponse(newAPIResponse(res))
 }
 
-func newClient(address string) (*elasticsearch.Client, error) {
+func newClient(address string, opts ...Option) (*elasticsearch.Client, error) {
 	if address == "" {
 		return nil, errors.New("no address provided")
 	}
@@ -478,6 +499,10 @@ func newClient(address string) (*elasticsearch.Client, error) {
 			address,
 		},
 		Transport: http.DefaultTransport,
+	}
+
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 
 	return elasticsearch.NewClient(cfg)

--- a/internal/searchstore/elasticsearch/elasticsearch_client_test.go
+++ b/internal/searchstore/elasticsearch/elasticsearch_client_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package elasticsearch
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithTLS_NilLeavesTransportUntouched(t *testing.T) {
+	t.Parallel()
+
+	cfg := &elasticsearch.Config{Transport: http.DefaultTransport}
+	WithTLS(nil)(cfg)
+	require.Equal(t, http.DefaultTransport, cfg.Transport)
+}
+
+func TestWithTLS_InstallsTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	tlsCfg := &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12} //nolint:gosec
+	cfg := &elasticsearch.Config{Transport: http.DefaultTransport}
+	WithTLS(tlsCfg)(cfg)
+
+	transport, ok := cfg.Transport.(*http.Transport)
+	require.True(t, ok, "expected *http.Transport, got %T", cfg.Transport)
+	require.NotNil(t, transport.TLSClientConfig)
+	require.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestNewClient_NoAddressErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewClient("")
+	require.Error(t, err)
+}

--- a/internal/searchstore/opensearch/opensearch_client.go
+++ b/internal/searchstore/opensearch/opensearch_client.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,10 +22,30 @@ type Client struct {
 	client *opensearch.Client
 }
 
+// Option configures the underlying opensearch.Client.
+type Option func(*opensearch.Config)
+
+// WithTLS installs the given TLS config on the client's HTTP transport.
+// Passing nil leaves the default transport untouched.
+func WithTLS(tlsCfg *tls.Config) Option {
+	return func(c *opensearch.Config) {
+		if tlsCfg == nil {
+			return
+		}
+		base, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			return
+		}
+		transport := base.Clone()
+		transport.TLSClientConfig = tlsCfg
+		c.Transport = transport
+	}
+}
+
 var errInvalidSearchEnvelope = errors.New("invalid search response")
 
-func NewClient(url string) (*Client, error) {
-	os, err := newClient(url)
+func NewClient(url string, opts ...Option) (*Client, error) {
+	os, err := newClient(url, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create opensearch client: %w", err)
 	}
@@ -473,7 +494,7 @@ func (c *Client) isErrResponse(res *opensearchapi.Response) error {
 	return searchstore.IsErrResponse(newAPIResponse(res))
 }
 
-func newClient(address string) (*opensearch.Client, error) {
+func newClient(address string, opts ...Option) (*opensearch.Client, error) {
 	if address == "" {
 		return nil, errors.New("no address provided")
 	}
@@ -483,6 +504,10 @@ func newClient(address string) (*opensearch.Client, error) {
 			address,
 		},
 		Transport: http.DefaultTransport,
+	}
+
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 
 	return opensearch.NewClient(cfg)

--- a/internal/searchstore/opensearch/opensearch_client_test.go
+++ b/internal/searchstore/opensearch/opensearch_client_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package opensearch
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/opensearch-project/opensearch-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithTLS_NilLeavesTransportUntouched(t *testing.T) {
+	t.Parallel()
+
+	cfg := &opensearch.Config{Transport: http.DefaultTransport}
+	WithTLS(nil)(cfg)
+	require.Equal(t, http.DefaultTransport, cfg.Transport)
+}
+
+func TestWithTLS_InstallsTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	tlsCfg := &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12} //nolint:gosec
+	cfg := &opensearch.Config{Transport: http.DefaultTransport}
+	WithTLS(tlsCfg)(cfg)
+
+	transport, ok := cfg.Transport.(*http.Transport)
+	require.True(t, ok, "expected *http.Transport, got %T", cfg.Transport)
+	require.NotNil(t, transport.TLSClientConfig)
+	require.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+}
+
+func TestNewClient_NoAddressErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewClient("")
+	require.Error(t, err)
+}

--- a/pkg/stream/integration/pg_search_tls_integration_test.go
+++ b/pkg/stream/integration/pg_search_tls_integration_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/internal/searchstore/elasticsearch"
+	"github.com/xataio/pgstream/internal/searchstore/opensearch"
+	pgtls "github.com/xataio/pgstream/pkg/tls"
+	"github.com/xataio/pgstream/pkg/wal/processor/search/store"
+)
+
+// Test_Search_TLSInsecureSkipVerify verifies that the TLS plumbing introduced
+// for #798 lets pgstream talk to a search backend over HTTPS with a
+// self-signed certificate when InsecureSkipVerify is set — and that without
+// it, the TLS handshake fails with the expected x509 error.
+//
+// Uses httptest.NewTLSServer (Go's stdlib generates a self-signed cert) as a
+// stand-in for an OpenSearch 3 cluster behind self-signed HTTPS. The test
+// asserts on the request that reaches the server, which is enough to prove
+// the HTTPS connection was established.
+func Test_Search_TLSInsecureSkipVerify(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx := context.Background()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// minimal OpenSearch-shaped responses; only the status code and
+		// the body shape matter for the calls we exercise below.
+		switch {
+		case r.URL.Path == "/" || strings.HasPrefix(r.URL.Path, "/_cluster/health"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"test","cluster_name":"test"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Run("opensearch insecure_skip_verify=true succeeds", func(t *testing.T) {
+		t.Parallel()
+		client, err := opensearch.NewClient(srv.URL, opensearch.WithTLS(&tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // opt-in for the test
+			MinVersion:         tls.VersionTLS12,
+		}))
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+		require.NoError(t, err)
+
+		resp, err := client.Perform(req)
+		require.NoError(t, err, "TLS handshake should succeed with InsecureSkipVerify=true")
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("opensearch without TLS option errors on x509", func(t *testing.T) {
+		t.Parallel()
+		client, err := opensearch.NewClient(srv.URL) // no WithTLS
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+		require.NoError(t, err)
+
+		_, err = client.Perform(req)
+		require.Error(t, err, "expected TLS verification to fail without InsecureSkipVerify")
+		require.Contains(t, err.Error(), "x509",
+			"expected an x509 / certificate verification error, got: %v", err)
+	})
+
+	t.Run("elasticsearch insecure_skip_verify=true succeeds", func(t *testing.T) {
+		t.Parallel()
+		client, err := elasticsearch.NewClient(srv.URL, elasticsearch.WithTLS(&tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // opt-in for the test
+			MinVersion:         tls.VersionTLS12,
+		}))
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/", nil)
+		require.NoError(t, err)
+
+		resp, err := client.Perform(req)
+		require.NoError(t, err, "TLS handshake should succeed with InsecureSkipVerify=true")
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	// End-to-end through store.NewStore — the path pgstream's config
+	// surface (YAML/env) actually traverses to build a search client.
+	t.Run("store.NewStore wires TLS through to the underlying client", func(t *testing.T) {
+		t.Parallel()
+		_, err := store.NewStore(store.Config{
+			OpenSearchURL: srv.URL,
+			TLS: pgtls.Config{
+				Enabled:            true,
+				InsecureSkipVerify: true,
+			},
+		})
+		require.NoError(t, err, "NewStore should succeed against the self-signed HTTPS server")
+	})
+}

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -23,6 +23,10 @@ type Config struct {
 	// File path to the client PEM key or client PEM key content
 	ClientKeyFile string
 	ClientKeyPEM  string
+	// InsecureSkipVerify disables verification of the server certificate. Use
+	// only against trusted hosts (development, self-signed certs in an
+	// internal network); never against untrusted endpoints.
+	InsecureSkipVerify bool
 }
 
 func NewConfig(cfg *Config) (*tls.Config, error) {
@@ -41,10 +45,11 @@ func NewConfig(cfg *Config) (*tls.Config, error) {
 	}
 
 	return &tls.Config{
-		MinVersion:   tls.VersionTLS12,
-		MaxVersion:   0,
-		Certificates: certificates,
-		RootCAs:      certPool,
+		MinVersion:         tls.VersionTLS12,
+		MaxVersion:         0,
+		Certificates:       certificates,
+		RootCAs:            certPool,
+		InsecureSkipVerify: cfg.InsecureSkipVerify, //nolint:gosec // opt-in
 	}, nil
 }
 

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -107,6 +107,22 @@ func Test_NewConfig(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "ok - insecure_skip_verify propagates",
+			cfg: &Config{
+				Enabled:            true,
+				InsecureSkipVerify: true,
+			},
+
+			wantConfig: &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				MaxVersion:         0,
+				Certificates:       []tls.Certificate{},
+				RootCAs:            systemCAs,
+				InsecureSkipVerify: true, //nolint:gosec // the test case asserts the opt-in skip propagates from Config to *tls.Config
+			},
+			wantErr: nil,
+		},
+		{
 			name: "error - invalid CA certificate file",
 			cfg: &Config{
 				Enabled:    true,

--- a/pkg/wal/processor/search/store/search_store.go
+++ b/pkg/wal/processor/search/store/search_store.go
@@ -12,6 +12,7 @@ import (
 	elasticsearchstore "github.com/xataio/pgstream/internal/searchstore/elasticsearch"
 	opensearchstore "github.com/xataio/pgstream/internal/searchstore/opensearch"
 	loglib "github.com/xataio/pgstream/pkg/log"
+	"github.com/xataio/pgstream/pkg/tls"
 	"github.com/xataio/pgstream/pkg/wal"
 	"github.com/xataio/pgstream/pkg/wal/processor/search"
 )
@@ -29,6 +30,7 @@ type Store struct {
 type Config struct {
 	OpenSearchURL    string
 	ElasticsearchURL string
+	TLS              tls.Config
 }
 
 type Option func(*Store)
@@ -44,15 +46,19 @@ const (
 func NewStore(cfg Config, opts ...Option) (*Store, error) {
 	var searchStore searchstore.Client
 	var err error
+	tlsCfg, err := tls.NewConfig(&cfg.TLS)
+	if err != nil {
+		return nil, fmt.Errorf("building search store TLS config: %w", err)
+	}
 	switch {
 	case cfg.OpenSearchURL != "" && cfg.ElasticsearchURL != "":
 		return nil, errors.New("only one store URL must be provided")
 	case cfg.OpenSearchURL == "" && cfg.ElasticsearchURL == "":
 		return nil, errors.New("a store URL must be provided")
 	case cfg.OpenSearchURL != "":
-		searchStore, err = opensearchstore.NewClient(cfg.OpenSearchURL)
+		searchStore, err = opensearchstore.NewClient(cfg.OpenSearchURL, opensearchstore.WithTLS(tlsCfg))
 	case cfg.ElasticsearchURL != "":
-		searchStore, err = elasticsearchstore.NewClient(cfg.ElasticsearchURL)
+		searchStore, err = elasticsearchstore.NewClient(cfg.ElasticsearchURL, elasticsearchstore.WithTLS(tlsCfg))
 	}
 	if err != nil {
 		return nil, fmt.Errorf("create search store client: %w", err)


### PR DESCRIPTION
Pgstream's search clients always used `http.DefaultTransport` with no way to install a TLS config. Operators running self-hosted OpenSearch 3 with self-signed certificates get the error:

```
failed to verify certificate: x509: certificate signed by unknown authority
```

This PR adds new configuration options:

  ```yaml
  target:
    search:
      engine: opensearch
      url: https://opensearch.internal:9200
      tls:
        ca_cert: /etc/ssl/opensearch-ca.pem   # optional, defaults to system pool
        client_cert: ""                       # optional, mTLS
        client_key: ""                        # optional, mTLS
        insecure_skip_verify: true            # opt-in cert skip
  ```

Environment variables:

  ```
  PGSTREAM_SEARCH_TLS_ENABLED=true
  PGSTREAM_SEARCH_TLS_CA_CERT_FILE=/etc/ssl/opensearch-ca.pem
  PGSTREAM_SEARCH_TLS_CLIENT_CERT_FILE=…
  PGSTREAM_SEARCH_TLS_CLIENT_KEY_FILE=…
  PGSTREAM_SEARCH_TLS_INSECURE_SKIP_VERIFY=true
  ```

Closes #798 
