### PR TITLE
Add support for changing logging format

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -276,9 +276,19 @@
       "default": ""
     },
     {
+      "name": "log-format",
+      "description": "log output format. One of console, json",
+      "default": "console"
+    },
+    {
       "name": "log-level",
       "description": "log level for the application. One of trace, debug, info, warn, error, fatal, panic",
       "default": "debug"
+    },
+    {
+      "name": "no-color",
+      "description": "disable ANSI color codes in console log output (ignored when --log-format=json)",
+      "default": "false"
     }
   ]
 }

--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -49,6 +49,17 @@ type YAMLConfig struct {
 	Source    SourceConfig    `mapstructure:"source" yaml:"source"`
 	Target    TargetConfig    `mapstructure:"target" yaml:"target"`
 	Modifiers ModifiersConfig `mapstructure:"modifiers" yaml:"modifiers"`
+	Logging   *LoggingConfig  `mapstructure:"logging" yaml:"logging"`
+}
+
+type LoggingConfig struct {
+	Level  string              `mapstructure:"level" yaml:"level"`
+	Format LoggingFormatConfig `mapstructure:"format" yaml:"format"`
+}
+
+type LoggingFormatConfig struct {
+	Type    string `mapstructure:"type" yaml:"type"`
+	NoColor bool   `mapstructure:"no_color" yaml:"no_color"`
 }
 
 type SourceConfig struct {

--- a/cmd/config/config_yaml_test.go
+++ b/cmd/config/config_yaml_test.go
@@ -24,6 +24,23 @@ func TestYAMLConfig_toStreamConfig(t *testing.T) {
 	validateTestStreamConfig(t, streamConfig)
 }
 
+func TestYAMLConfig_LoggingConfig(t *testing.T) {
+	require.NoError(t, LoadFile("test/test_config.yaml"))
+
+	var config YAMLConfig
+	err := viper.Unmarshal(&config)
+	require.NoError(t, err)
+
+	require.NotNil(t, config.Logging)
+	require.Equal(t, &LoggingConfig{
+		Level: "info",
+		Format: LoggingFormatConfig{
+			Type:    "console",
+			NoColor: true,
+		},
+	}, config.Logging)
+}
+
 func TestYAMLConfig_toStreamConfig_ErrorCases(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/config/test/test_config.yaml
+++ b/cmd/config/test/test_config.yaml
@@ -154,6 +154,12 @@ modifiers:
               gender:
                 column: sex
 
+logging:
+  level: info # log level for the application. One of trace, debug, info, warn, error, fatal, panic.
+  format:
+    type: console # log output format. One of console or json.
+    no_color: true # disable ANSI color codes in console log output. Only valid when type is console.
+
 instrumentation:
   metrics:
     endpoint: "http://localhost:4317"

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/xataio/pgstream/cmd/config"
+	"github.com/xataio/pgstream/internal/log/zerolog"
 	"github.com/xataio/pgstream/internal/profiling"
 	"github.com/xataio/pgstream/pkg/otel"
 )
@@ -35,6 +36,10 @@ func Prepare() *cobra.Command {
 				return fmt.Errorf("loading configuration: %w", err)
 			}
 
+			if err := loggerConfigFromViper().Validate(); err != nil {
+				return err
+			}
+
 			return nil
 		},
 	}
@@ -47,6 +52,8 @@ func Prepare() *cobra.Command {
 	// root cmd
 	rootCmd.PersistentFlags().StringP("config", "c", "", ".env or .yaml config file to use with pgstream if any")
 	rootCmd.PersistentFlags().String("log-level", "debug", "log level for the application. One of trace, debug, info, warn, error, fatal, panic")
+	rootCmd.PersistentFlags().String("log-format", "console", "log output format. One of console, json")
+	rootCmd.PersistentFlags().Bool("no-color", false, "disable ANSI color codes in console log output (ignored when --log-format=json)")
 
 	// init cmd
 	initCmd.Flags().String("postgres-url", "", "Source postgres URL where pgstream setup will be run")
@@ -167,9 +174,19 @@ func withProfiling(fn func(cmd *cobra.Command, args []string) error) func(cmd *c
 	}
 }
 
+func loggerConfigFromViper() *zerolog.Config {
+	return &zerolog.Config{
+		LogLevel:  viper.GetString("PGSTREAM_LOG_LEVEL"),
+		LogFormat: viper.GetString("PGSTREAM_LOG_FORMAT"),
+		NoColor:   viper.GetBool("PGSTREAM_LOG_NO_COLOR"),
+	}
+}
+
 func rootFlagBinding(cmd *cobra.Command) {
 	viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config"))
 	viper.BindPFlag("PGSTREAM_LOG_LEVEL", cmd.PersistentFlags().Lookup("log-level"))
+	viper.BindPFlag("PGSTREAM_LOG_FORMAT", cmd.PersistentFlags().Lookup("log-format"))
+	viper.BindPFlag("PGSTREAM_LOG_NO_COLOR", cmd.PersistentFlags().Lookup("no-color"))
 }
 
 func version() string {

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -176,10 +176,35 @@ func withProfiling(fn func(cmd *cobra.Command, args []string) error) func(cmd *c
 
 func loggerConfigFromViper() *zerolog.Config {
 	return &zerolog.Config{
-		LogLevel:  viper.GetString("PGSTREAM_LOG_LEVEL"),
-		LogFormat: viper.GetString("PGSTREAM_LOG_FORMAT"),
-		NoColor:   viper.GetBool("PGSTREAM_LOG_NO_COLOR"),
+		LogLevel:  resolveLogString("PGSTREAM_LOG_LEVEL", "logging.level"),
+		LogFormat: resolveLogString("PGSTREAM_LOG_FORMAT", "logging.format.type"),
+		NoColor:   resolveLogBool("PGSTREAM_LOG_NO_COLOR", "logging.format.no_color"),
 	}
+}
+
+// resolveLogString picks the value from the flag/env-style key when it was set
+// explicitly (CLI flag changed or env var present), otherwise it falls back to
+// the YAML key, and finally to the flag default.
+func resolveLogString(envKey, yamlKey string) string {
+	if viper.IsSet(envKey) {
+		return viper.GetString(envKey)
+	}
+	if v := viper.GetString(yamlKey); v != "" {
+		return v
+	}
+	return viper.GetString(envKey)
+}
+
+// resolveLogBool mirrors resolveLogString for boolean values: the explicit
+// flag/env wins, then the YAML key, then the flag default.
+func resolveLogBool(envKey, yamlKey string) bool {
+	if viper.IsSet(envKey) {
+		return viper.GetBool(envKey)
+	}
+	if viper.IsSet(yamlKey) {
+		return viper.GetBool(yamlKey)
+	}
+	return viper.GetBool(envKey)
 }
 
 func rootFlagBinding(cmd *cobra.Command) {

--- a/cmd/run_cmd.go
+++ b/cmd/run_cmd.go
@@ -40,9 +40,7 @@ const (
 )
 
 func run(ctx context.Context) error {
-	logger := zerolog.NewLogger(&zerolog.Config{
-		LogLevel: viper.GetString("PGSTREAM_LOG_LEVEL"),
-	})
+	logger := zerolog.NewLogger(loggerConfigFromViper())
 	zerolog.SetGlobalLogger(logger)
 
 	if isSnapshotMode() {

--- a/cmd/snapshot_cmd.go
+++ b/cmd/snapshot_cmd.go
@@ -28,9 +28,7 @@ var snapshotCmd = &cobra.Command{
 }
 
 func snapshot(ctx context.Context) error {
-	logger := zerolog.NewLogger(&zerolog.Config{
-		LogLevel: viper.GetString("PGSTREAM_LOG_LEVEL"),
-	})
+	logger := zerolog.NewLogger(loggerConfigFromViper())
 	zerolog.SetGlobalLogger(logger)
 
 	streamConfig, err := config.ParseStreamConfig()

--- a/config_template.yaml
+++ b/config_template.yaml
@@ -1,3 +1,9 @@
+logging:
+  level: debug # log level for the application. One of trace, debug, info, warn, error, fatal, panic. Defaults to debug.
+  format:
+    type: console # log output format. One of console or json. Defaults to console.
+    no_color: false # disable ANSI color codes in console log output. Only valid when type is console. Defaults to false.
+
 instrumentation:
   metrics:
     endpoint: "0.0.0.0:4317"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,11 +42,15 @@ brew install pgstream
 
 These flags are available for all commands:
 
-| Flag             | Description                                                                         | Default |
-| ---------------- | ----------------------------------------------------------------------------------- | ------- |
-| `--config`, `-c` | .env or .yaml config file to use with pgstream if any                               | -       |
-| `--log-level`    | Log level for the application. One of trace, debug, info, warn, error, fatal, panic | `debug` |
-| `--help`, `-h`   | Show help information                                                               | -       |
+| Flag             | Description                                                                         | Default   |
+| ---------------- | ----------------------------------------------------------------------------------- | --------- |
+| `--config`, `-c` | .env or .yaml config file to use with pgstream if any                               | -         |
+| `--log-level`    | Log level for the application. One of trace, debug, info, warn, error, fatal, panic | `debug`   |
+| `--log-format`   | Log output format. One of `console` (human-readable) or `json` (structured)         | `console` |
+| `--no-color`     | Disable ANSI color codes in console log output (ignored when `--log-format=json`)   | `false`   |
+| `--help`, `-h`   | Show help information                                                               | -         |
+
+Every global flag also has an equivalent `PGSTREAM_`-prefixed environment variable (for example, `PGSTREAM_LOG_FORMAT=json`, `PGSTREAM_LOG_NO_COLOR=true`). Use `--log-format=json` when shipping logs to cloud aggregators like GCP Cloud Logging or Datadog that parse structured JSON.
 
 ## Commands
 
@@ -470,6 +474,7 @@ pgstream run --source kafka --source-url "localhost:9092" --target opensearch --
 export PGSTREAM_POSTGRES_LISTENER_URL="postgres://user:pass@localhost:5432/source_db"
 export PGSTREAM_POSTGRES_REPLICATION_SLOT_NAME="pgstream_slot"
 export PGSTREAM_LOG_LEVEL="info"
+export PGSTREAM_LOG_FORMAT="json"
 
 # Run with environment configuration
 pgstream init

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621
 	golang.org/x/sync v0.21.0
+	golang.org/x/term v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 	pgregory.net/rapid v1.3.0
 )
@@ -178,7 +179,6 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
-	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/internal/log/zerolog/zerolog.go
+++ b/internal/log/zerolog/zerolog.go
@@ -19,6 +19,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	formatConsole = "console"
+	formatJSON    = "json"
+)
+
 type Config struct {
 	// LogLevel selects the minimum log level emitted. Supported values are
 	// trace, debug, info, warn, error, fatal, panic, and disabled. An empty
@@ -42,11 +47,11 @@ var ErrNoColorUnderJSONFormat = fmt.Errorf("no_color is only valid when log form
 // Empty fields are treated as defaults and accepted.
 func (c *Config) Validate() error {
 	switch c.LogFormat {
-	case "", "console", "json":
+	case "", formatConsole, formatJSON:
 	default:
 		return fmt.Errorf("invalid log format %q: must be one of console, json", c.LogFormat)
 	}
-	if c.NoColor && c.LogFormat == "json" {
+	if c.NoColor && c.LogFormat == formatJSON {
 		return ErrNoColorUnderJSONFormat
 	}
 	return nil
@@ -99,7 +104,7 @@ func NewLogger(config *Config) *zerolog.Logger {
 	level, _ := zerolog.ParseLevel(config.LogLevel)
 
 	var out io.Writer
-	if config.LogFormat == "json" {
+	if config.LogFormat == formatJSON {
 		out = os.Stderr
 	} else {
 		out = zerolog.NewConsoleWriter(

--- a/internal/log/zerolog/zerolog.go
+++ b/internal/log/zerolog/zerolog.go
@@ -3,6 +3,7 @@
 package zerolog
 
 import (
+	"fmt"
 	"io"
 	stdlog "log"
 	"os"
@@ -19,7 +20,29 @@ import (
 )
 
 type Config struct {
+	// LogLevel selects the minimum log level emitted. Supported values are
+	// trace, debug, info, warn, error, fatal, panic, and disabled. An empty
+	// string disables level filtering (every event is written).
 	LogLevel string
+	// LogFormat selects the output encoding. Supported values are "console"
+	// (human-readable) and "json" (structured, one JSON object per line).
+	// An empty string defaults to "console". Unknown values also fall back
+	// to "console"; CLI input is validated up front by Config.Validate.
+	LogFormat string
+	// NoColor disables ANSI colors in the "console" format. Ignored when
+	// LogFormat is "json".
+	NoColor bool
+}
+
+// Validate returns an error if the Config contains an unsupported value.
+// Empty fields are treated as defaults and accepted. NoColor is unconstrained.
+func (c *Config) Validate() error {
+	switch c.LogFormat {
+	case "", "console", "json":
+	default:
+		return fmt.Errorf("invalid log format %q: must be one of console, json", c.LogFormat)
+	}
+	return nil
 }
 
 // init sets some zerolog global defaults we want to keep throughout the project.
@@ -67,10 +90,17 @@ func NewStdLogger(l *zerolog.Logger) loglib.Logger {
 func NewLogger(config *Config) *zerolog.Logger {
 	// ignore the error, it defaults to no level
 	level, _ := zerolog.ParseLevel(config.LogLevel)
-	out := zerolog.NewConsoleWriter(
-		withTimeFormat(time.RFC3339Nano),
-		withOut(os.Stderr),
-	)
+
+	var out io.Writer
+	if config.LogFormat == "json" {
+		out = os.Stderr
+	} else {
+		out = zerolog.NewConsoleWriter(
+			withTimeFormat(time.RFC3339Nano),
+			withOut(os.Stderr),
+			withNoColor(config.NoColor),
+		)
+	}
 
 	logger := zerolog.New(out).
 		Sample(zerolog.LevelSampler{
@@ -103,5 +133,11 @@ func withTimeFormat(format string) func(*zerolog.ConsoleWriter) {
 func withOut(out io.Writer) func(*zerolog.ConsoleWriter) {
 	return func(w *zerolog.ConsoleWriter) {
 		w.Out = out
+	}
+}
+
+func withNoColor(noColor bool) func(*zerolog.ConsoleWriter) {
+	return func(w *zerolog.ConsoleWriter) {
+		w.NoColor = noColor
 	}
 }

--- a/internal/log/zerolog/zerolog.go
+++ b/internal/log/zerolog/zerolog.go
@@ -34,13 +34,20 @@ type Config struct {
 	NoColor bool
 }
 
+// ErrNoColorUnderJSONFormat is returned by Validate when NoColor is enabled
+// while LogFormat is "json"; the option only applies to the console writer.
+var ErrNoColorUnderJSONFormat = fmt.Errorf("no_color is only valid when log format is 'console'")
+
 // Validate returns an error if the Config contains an unsupported value.
-// Empty fields are treated as defaults and accepted. NoColor is unconstrained.
+// Empty fields are treated as defaults and accepted.
 func (c *Config) Validate() error {
 	switch c.LogFormat {
 	case "", "console", "json":
 	default:
 		return fmt.Errorf("invalid log format %q: must be one of console, json", c.LogFormat)
+	}
+	if c.NoColor && c.LogFormat == "json" {
+		return ErrNoColorUnderJSONFormat
 	}
 	return nil
 }

--- a/internal/log/zerolog/zerolog_test.go
+++ b/internal/log/zerolog/zerolog_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package zerolog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr error
+	}{
+		{
+			name: "empty config is valid",
+			cfg:  Config{},
+		},
+		{
+			name: "console with no_color",
+			cfg:  Config{LogFormat: "console", NoColor: true},
+		},
+		{
+			name: "json without no_color",
+			cfg:  Config{LogFormat: "json"},
+		},
+		{
+			name:    "json with no_color is rejected",
+			cfg:     Config{LogFormat: "json", NoColor: true},
+			wantErr: ErrNoColorUnderJSONFormat,
+		},
+		{
+			name: "json with no_color=false is accepted",
+			cfg:  Config{LogFormat: "json", NoColor: false},
+		},
+		{
+			name:    "unsupported format",
+			cfg:     Config{LogFormat: "xml"},
+			wantErr: nil, // wrapped error, checked separately below
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.name == "unsupported format" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "invalid log format")
+				return
+			}
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/progress/progress_bar.go
+++ b/internal/progress/progress_bar.go
@@ -4,8 +4,10 @@ package progress
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/schollz/progressbar/v3"
+	"golang.org/x/term"
 )
 
 type Bar interface {
@@ -28,7 +30,27 @@ func (pb *ProgressBar) SetCurrent(value int64) error {
 	return pb.Set64(value)
 }
 
-func NewBar(total int64, description, unit string) *ProgressBar {
+// noopBar is returned when stderr is not a terminal. The progress bar's
+// carriage returns and ANSI codes are noise when output is piped to a file or
+// log shipper, so we drop the bar entirely in that case.
+type noopBar struct{}
+
+func (noopBar) Add(int) error          { return nil }
+func (noopBar) Add64(int64) error      { return nil }
+func (noopBar) Current() int64         { return 0 }
+func (noopBar) SetCurrent(int64) error { return nil }
+func (noopBar) Close() error           { return nil }
+
+// stderrIsTTY reports whether the bar's output sink (stderr) is a terminal.
+// Indirected through a variable so tests can override it.
+var stderrIsTTY = func() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
+func NewBar(total int64, description, unit string) Bar {
+	if !stderrIsTTY() {
+		return noopBar{}
+	}
 	return &ProgressBar{
 		ProgressBar: progressbar.NewOptions64(total,
 			progressbar.OptionShowCount(),
@@ -54,7 +76,10 @@ func NewBar(total int64, description, unit string) *ProgressBar {
 	}
 }
 
-func NewBytesBar(totalBytes int64, description string) *ProgressBar {
+func NewBytesBar(totalBytes int64, description string) Bar {
+	if !stderrIsTTY() {
+		return noopBar{}
+	}
 	return &ProgressBar{
 		ProgressBar: progressbar.NewOptions64(totalBytes,
 			progressbar.OptionShowCount(),

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator.go
@@ -126,9 +126,7 @@ func WithProgressTracking() Option {
 	return func(sg *SnapshotGenerator) {
 		sg.progressTracking = true
 		sg.progressBars = synclib.NewMap[string, progress.Bar]()
-		sg.progressBarBuilder = func(totalBytes int64, description string) progress.Bar {
-			return progress.NewBytesBar(totalBytes, description)
-		}
+		sg.progressBarBuilder = progress.NewBytesBar
 	}
 }
 
@@ -322,7 +320,7 @@ func (sg *SnapshotGenerator) snapshotTable(ctx context.Context, snapshotID strin
 	return errGroup.Wait()
 }
 
-func (sg *SnapshotGenerator) snapshotTableRangeWorker(ctx context.Context, snapshotID string, table *table, pageRangeChan <-chan (pageRange)) error {
+func (sg *SnapshotGenerator) snapshotTableRangeWorker(ctx context.Context, snapshotID string, table *table, pageRangeChan <-chan pageRange) error {
 	for pageRange := range pageRangeChan {
 		if err := sg.snapshotTableRange(ctx, snapshotID, table, pageRange); err != nil {
 			return err

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/pg_snapshot_tracker.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/pg_snapshot_tracker.go
@@ -50,9 +50,7 @@ func newSnapshotTracker(ctx context.Context, pgurl string) (*snapshotTracker, er
 		conn:         connPool,
 		progressBars: synclib.NewMap[string, progress.Bar](),
 		clock:        clockwork.NewRealClock(),
-		barBuilder: func(total int64, description, unit string) progress.Bar {
-			return progress.NewBar(total, description, unit)
-		},
+		barBuilder:   progress.NewBar,
 	}, nil
 }
 


### PR DESCRIPTION
#### Description

This PR adds two new flags. First one is named `--log-format`. It has two possible options: `console` and `json`. If it is not set, it defaults to `console`. The second one is `--no-color` to turn of colours off.

These flags only apply to the commands `run` and `snapshot`.

It also comes with new env variables:
* `PGSTREAM_LOG_FORMAT`
* `PGSTREAM_LOG_NO_COLOR`

##### Related Issue(s)

- Fixes #799

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
