### PR TITLE
Add new healthcheck endpoints: `/health` and `/ready`

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+	"github.com/xataio/pgstream/internal/health"
 	"github.com/xataio/pgstream/pkg/otel"
 	"github.com/xataio/pgstream/pkg/stream"
 	"github.com/xataio/pgstream/pkg/wal/processor/batch"
@@ -65,10 +66,34 @@ func LoadFile(file string) error {
 	return nil
 }
 
+func isYAMLConfigFile(cfgFile string) bool {
+	switch filepath.Ext(cfgFile) {
+	case ".yml", ".yaml":
+		return true
+	}
+	return false
+}
+
+func ParseHealthConfig() (*health.Config, error) {
+	cfgFile := viper.GetViper().ConfigFileUsed()
+	switch {
+	case isYAMLConfigFile(cfgFile):
+		yamlCfg := struct {
+			Instrumentation InstrumentationConfig `mapstructure:"instrumentation" yaml:"instrumentation"`
+		}{}
+		if err := viper.Unmarshal(&yamlCfg); err != nil {
+			return nil, fmt.Errorf("invalid format for instrumentation in config file %q: %w", cfgFile, err)
+		}
+		return yamlCfg.Instrumentation.toHealthConfig(), nil
+	default:
+		return envToHealthConfig(), nil
+	}
+}
+
 func ParseInstrumentationConfig() (*otel.Config, error) {
 	cfgFile := viper.GetViper().ConfigFileUsed()
-	switch ext := filepath.Ext(cfgFile); ext {
-	case ".yml", ".yaml":
+	switch {
+	case isYAMLConfigFile(cfgFile):
 		yamlCfg := struct {
 			Instrumentation InstrumentationConfig `mapstructure:"instrumentation" yaml:"instrumentation"`
 		}{}
@@ -84,8 +109,8 @@ func ParseInstrumentationConfig() (*otel.Config, error) {
 
 func ParseStreamConfig() (*stream.Config, error) {
 	cfgFile := viper.GetViper().ConfigFileUsed()
-	switch ext := filepath.Ext(cfgFile); ext {
-	case ".yml", ".yaml":
+	switch {
+	case isYAMLConfigFile(cfgFile):
 		yamlCfg := YAMLConfig{}
 		if err := viper.Unmarshal(&yamlCfg, viper.DecodeHook(byteSizeDecodeHook())); err != nil {
 			return nil, fmt.Errorf("invalid format in config file %q: %w", cfgFile, err)

--- a/cmd/config/config_env.go
+++ b/cmd/config/config_env.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/viper"
+	"github.com/xataio/pgstream/internal/health"
 	"github.com/xataio/pgstream/pkg/backoff"
 	"github.com/xataio/pgstream/pkg/kafka"
 	"github.com/xataio/pgstream/pkg/otel"
@@ -34,6 +35,9 @@ func init() {
 	viper.BindEnv("PGSTREAM_METRICS_COLLECTION_INTERVAL")
 	viper.BindEnv("PGSTREAM_TRACES_ENDPOINT")
 	viper.BindEnv("PGSTREAM_TRACES_SAMPLE_RATIO")
+
+	viper.BindEnv("PGSTREAM_HEALTH_CHECK_ENABLED")
+	viper.BindEnv("PGSTREAM_HEALTH_CHECK_ADDRESS")
 
 	viper.BindEnv("PGSTREAM_POSTGRES_LISTENER_URL")
 	viper.BindEnv("PGSTREAM_POSTGRES_LISTENER_EXP_BACKOFF_INITIAL_INTERVAL")
@@ -146,6 +150,13 @@ func init() {
 	viper.BindEnv("PGSTREAM_KAFKA_TLS_CA_CERT_FILE")
 	viper.BindEnv("PGSTREAM_KAFKA_TLS_CLIENT_CERT_FILE")
 	viper.BindEnv("PGSTREAM_KAFKA_TLS_CLIENT_KEY_FILE")
+}
+
+func envToHealthConfig() *health.Config {
+	return &health.Config{
+		Enabled: viper.GetBool("PGSTREAM_HEALTH_CHECK_ENABLED"),
+		Address: viper.GetString("PGSTREAM_HEALTH_CHECK_ADDRESS"),
+	}
 }
 
 func envToOtelConfig() (*otel.Config, error) {

--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/xataio/pgstream/internal/health"
 	"github.com/xataio/pgstream/pkg/backoff"
 	"github.com/xataio/pgstream/pkg/kafka"
 	"github.com/xataio/pgstream/pkg/otel"
@@ -33,6 +34,12 @@ import (
 type InstrumentationConfig struct {
 	Metrics *MetricsConfig `mapstructure:"metrics" yaml:"metrics"`
 	Traces  *TracesConfig  `mapstructure:"traces" yaml:"traces"`
+	Health  *HealthConfig  `mapstructure:"health" yaml:"health"`
+}
+
+type HealthConfig struct {
+	Enabled bool   `mapstructure:"enabled" yaml:"enabled"`
+	Address string `mapstructure:"address" yaml:"address"`
 }
 
 type MetricsConfig struct {
@@ -351,6 +358,16 @@ var (
 	errInvalidSampleRatio                      = errors.New("trace sample ratio must be a value between 0.0 and 1.0")
 	errSchemaSnapshotNotConfigured             = errors.New("schema snapshot config must be provided when snapshot mode is 'full' or 'schema'")
 )
+
+func (c *InstrumentationConfig) toHealthConfig() *health.Config {
+	if c.Health == nil {
+		return &health.Config{}
+	}
+	return &health.Config{
+		Enabled: c.Health.Enabled,
+		Address: c.Health.Address,
+	}
+}
 
 func (c *InstrumentationConfig) toOtelConfig() (*otel.Config, error) {
 	cfg := &otel.Config{}

--- a/cmd/health_cmd.go
+++ b/cmd/health_cmd.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/xataio/pgstream/cmd/config"
+	"github.com/xataio/pgstream/internal/health"
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	loglib "github.com/xataio/pgstream/pkg/log"
+)
+
+const (
+	// healthShutdownTimeout caps how long graceful shutdown of the health
+	// server and its readiness pool can take before we move on.
+	healthShutdownTimeout = 5 * time.Second
+	// healthReadinessPoolMaxConns sizes the postgres pool used by /ready.
+	// Two connections cover concurrent probe traffic with negligible cost.
+	healthReadinessPoolMaxConns = 2
+)
+
+// startHealthServer starts the optional health endpoint, returning a closer
+// that gracefully shuts it down. When health is disabled the closer is a
+// noop. Bind errors are surfaced synchronously so a misconfigured port
+// fails the command immediately rather than silently degrading.
+//
+// sourcePostgresURL, when non-empty, wires the /ready endpoint to ping the
+// source database.
+func startHealthServer(ctx context.Context, logger loglib.Logger, sourcePostgresURL string) (func(), error) {
+	cfg, err := config.ParseHealthConfig()
+	if err != nil {
+		return nil, fmt.Errorf("parsing health config: %w", err)
+	}
+	if !cfg.Enabled {
+		return func() {}, nil
+	}
+
+	opts := []health.Option{
+		health.WithLogger(logger),
+		health.WithVersion(version()),
+	}
+
+	var pool *pglib.Pool
+	if sourcePostgresURL != "" {
+		pool, err = pglib.NewConnPool(ctx, sourcePostgresURL, pglib.WithMaxConnections(healthReadinessPoolMaxConns))
+		if err != nil {
+			return nil, fmt.Errorf("creating health readiness pool: %w", err)
+		}
+		opts = append(opts, health.WithReadinessCheck(pool.Ping))
+	}
+
+	srv := health.NewServer(*cfg, opts...)
+	if err := srv.Listen(); err != nil {
+		if pool != nil {
+			pool.Close(context.Background())
+		}
+		return nil, fmt.Errorf("binding health server: %w", err)
+	}
+	go func() {
+		if err := srv.Serve(); err != nil {
+			logger.Error(err, "health server stopped")
+		}
+	}()
+
+	return func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), healthShutdownTimeout)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			logger.Warn(err, "shutting down health server")
+		}
+		if pool != nil {
+			if err := pool.Close(shutdownCtx); err != nil {
+				logger.Warn(err, "closing health readiness pool")
+			}
+		}
+	}, nil
+}

--- a/cmd/run_cmd.go
+++ b/cmd/run_cmd.go
@@ -58,7 +58,14 @@ func run(ctx context.Context) error {
 	}
 	defer provider.Close()
 
-	return stream.Run(ctx, zerolog.NewStdLogger(logger), streamConfig, initFlag, provider.NewInstrumentation("run"))
+	stdLogger := zerolog.NewStdLogger(logger)
+	stopHealth, err := startHealthServer(ctx, stdLogger, streamConfig.SourcePostgresURL())
+	if err != nil {
+		return err
+	}
+	defer stopHealth()
+
+	return stream.Run(ctx, stdLogger, streamConfig, initFlag, provider.NewInstrumentation("run"))
 }
 
 func runFlagBinding(cmd *cobra.Command, args []string) error {

--- a/cmd/snapshot_cmd.go
+++ b/cmd/snapshot_cmd.go
@@ -42,7 +42,14 @@ func snapshot(ctx context.Context) error {
 	}
 	defer provider.Close()
 
-	return stream.Snapshot(ctx, zerolog.NewStdLogger(logger), streamConfig, provider.NewInstrumentation("snapshot"))
+	stdLogger := zerolog.NewStdLogger(logger)
+	stopHealth, err := startHealthServer(ctx, stdLogger, streamConfig.SourcePostgresURL())
+	if err != nil {
+		return err
+	}
+	defer stopHealth()
+
+	return stream.Snapshot(ctx, stdLogger, streamConfig, provider.NewInstrumentation("snapshot"))
 }
 
 func snapshotFlagBinding(cmd *cobra.Command, args []string) error {

--- a/config_template.yaml
+++ b/config_template.yaml
@@ -11,6 +11,9 @@ instrumentation:
   traces:
     endpoint: "0.0.0.0:4317"
     sample_ratio: 0.5 # ratio of traces that will be sampled. Must be between 0.0-1.0, where 0 is no traces sampled, and 1 is all traces sampled.
+  health:
+    enabled: false # whether to expose the /health (liveness) and /ready (readiness) HTTP endpoints. Only honoured by the run and snapshot commands. Defaults to false.
+    address: "localhost:9910" # address the health server binds to. Defaults to localhost:9910.
 
 source:
   postgres:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -403,3 +403,15 @@ One of exponential/constant/disable retries retry policies can be provided for t
 | PGSTREAM_TRACES_SAMPLE_RATIO | 0       | No       | Ratio for the trace sampling. Value must be between 0.0 and 1.0, where 0.0 is no traces sampled, and 1.0 is all traces sampled. |
 
 </details>
+
+<details>
+  <summary>Health endpoint</summary>
+
+Exposes `/health` (liveness, always 200) and `/ready` (readiness, pings the source postgres database when configured). Only the `run` and `snapshot` commands start the server. Responses are JSON.
+
+| Environment Variable           | Default          | Required | Description                                                                                                  |
+| ------------------------------ | ---------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| PGSTREAM_HEALTH_CHECK_ENABLED  | False            | No       | Enable the health endpoint server.                                                                           |
+| PGSTREAM_HEALTH_CHECK_ADDRESS  | localhost:9910   | No       | Address the health server listens on. Use `:9910` or `0.0.0.0:9910` to expose externally (e.g. in k8s pods). |
+
+</details>

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package health exposes a small HTTP server with /health (liveness) and
+// /ready (readiness) endpoints so that operators and orchestrators can
+// monitor a running pgstream process.
+package health
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/xataio/pgstream/internal/json"
+	loglib "github.com/xataio/pgstream/pkg/log"
+)
+
+const (
+	DefaultAddress = "localhost:9910"
+
+	readinessCheckTimeout = 2 * time.Second
+	readHeaderTimeout     = 5 * time.Second
+)
+
+// Config controls how the health server is exposed.
+type Config struct {
+	Enabled bool
+	Address string
+}
+
+// Server serves /health and /ready over HTTP.
+type Server struct {
+	logger         loglib.Logger
+	address        string
+	version        string
+	readinessCheck func(ctx context.Context) error
+	listener       net.Listener
+	httpServer     *http.Server
+}
+
+var errNotListening = errors.New("health server not initialised: call Listen first")
+
+type Option func(*Server)
+
+// NewServer builds a health server from the given config. The server is not
+// started until Start() is called.
+func NewServer(cfg Config, opts ...Option) *Server {
+	address := cfg.Address
+	if address == "" {
+		address = DefaultAddress
+	}
+	s := &Server{
+		logger:  loglib.NewNoopLogger(),
+		address: address,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+func WithLogger(l loglib.Logger) Option {
+	return func(s *Server) {
+		s.logger = loglib.NewLogger(l).WithFields(loglib.Fields{
+			loglib.ModuleField: "health_server",
+		})
+	}
+}
+
+func WithVersion(v string) Option {
+	return func(s *Server) {
+		s.version = v
+	}
+}
+
+// WithReadinessCheck registers a function the /ready handler will invoke. The
+// function is given a context with a short timeout; returning a non-nil error
+// causes /ready to respond with 503. If no check is registered, /ready
+// behaves like /health.
+func WithReadinessCheck(fn func(ctx context.Context) error) Option {
+	return func(s *Server) {
+		s.readinessCheck = fn
+	}
+}
+
+// Listen binds the configured address synchronously and prepares the HTTP
+// server. After it returns successfully, Serve must be called (typically
+// from a goroutine) to start accepting requests. Splitting bind from serve
+// lets callers surface bind errors synchronously and ensures Shutdown
+// always observes an initialised server.
+func (s *Server) Listen() error {
+	ln, err := net.Listen("tcp", s.address)
+	if err != nil {
+		return err
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", s.handleHealth)
+	mux.HandleFunc("/ready", s.handleReady)
+
+	s.listener = ln
+	s.httpServer = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+	}
+	return nil
+}
+
+// Serve starts serving requests on the listener bound by Listen. It blocks
+// until Shutdown is called. ErrServerClosed is treated as a clean exit.
+func (s *Server) Serve() error {
+	if s.httpServer == nil || s.listener == nil {
+		return errNotListening
+	}
+	s.logger.Info("starting health server", loglib.Fields{"address": s.address})
+	if err := s.httpServer.Serve(s.listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+// Shutdown stops the underlying HTTP server gracefully. Safe to call when
+// the server was never started.
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s.httpServer == nil {
+		return nil
+	}
+	return s.httpServer.Shutdown(ctx)
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	s.writeJSON(w, http.StatusOK, s.okPayload())
+}
+
+func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
+	if s.readinessCheck != nil {
+		ctx, cancel := context.WithTimeout(r.Context(), readinessCheckTimeout)
+		defer cancel()
+		if err := s.readinessCheck(ctx); err != nil {
+			s.writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+				"status": "unready",
+				"failures": []map[string]string{{
+					"component": "postgres_source",
+					"error":     err.Error(),
+				}},
+			})
+			return
+		}
+	}
+	s.writeJSON(w, http.StatusOK, s.okPayload())
+}
+
+func (s *Server) okPayload() map[string]string {
+	payload := map[string]string{"status": "ok"}
+	if s.version != "" {
+		payload["version"] = s.version
+	}
+	return payload
+}
+
+func (s *Server) writeJSON(w http.ResponseWriter, code int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	payload, err := json.Marshal(body)
+	if err != nil {
+		s.logger.Warn(err, "health server: marshalling response")
+		return
+	}
+	if _, err := w.Write(payload); err != nil {
+		s.logger.Warn(err, "health server: writing response")
+	}
+}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServer_DefaultAddress(t *testing.T) {
+	t.Parallel()
+	s := NewServer(Config{})
+	require.Equal(t, DefaultAddress, s.address)
+}
+
+func TestNewServer_CustomAddress(t *testing.T) {
+	t.Parallel()
+	s := NewServer(Config{Address: "127.0.0.1:0"})
+	require.Equal(t, "127.0.0.1:0", s.address)
+}
+
+func TestHandleHealth(t *testing.T) {
+	t.Parallel()
+	s := NewServer(Config{}, WithVersion("v1.2.3"))
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	s.handleHealth(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	body, _ := io.ReadAll(rec.Body)
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.Equal(t, "ok", got["status"])
+	require.Equal(t, "v1.2.3", got["version"])
+}
+
+func TestHandleReady_NoCheck(t *testing.T) {
+	t.Parallel()
+	s := NewServer(Config{}, WithVersion("v1.2.3"))
+
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rec := httptest.NewRecorder()
+	s.handleReady(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body, _ := io.ReadAll(rec.Body)
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.Equal(t, "ok", got["status"])
+}
+
+func TestHandleReady_CheckPasses(t *testing.T) {
+	t.Parallel()
+	var called bool
+	s := NewServer(Config{}, WithReadinessCheck(func(_ context.Context) error {
+		called = true
+		return nil
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rec := httptest.NewRecorder()
+	s.handleReady(rec, req)
+
+	require.True(t, called)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandleReady_CheckFails(t *testing.T) {
+	t.Parallel()
+	s := NewServer(Config{}, WithReadinessCheck(func(_ context.Context) error {
+		return errors.New("source unreachable")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rec := httptest.NewRecorder()
+	s.handleReady(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	body, _ := io.ReadAll(rec.Body)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(body, &got))
+	require.Equal(t, "unready", got["status"])
+	failures, ok := got["failures"].([]any)
+	require.True(t, ok)
+	require.Len(t, failures, 1)
+	failure, ok := failures[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "postgres_source", failure["component"])
+	require.Equal(t, "source unreachable", failure["error"])
+}
+
+func TestListenServeShutdown(t *testing.T) {
+	t.Parallel()
+	s := NewServer(Config{Address: "127.0.0.1:0"})
+
+	require.NoError(t, s.Listen())
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Serve() }()
+
+	require.NoError(t, s.Shutdown(context.Background()))
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Serve did not return after Shutdown")
+	}
+}
+
+func TestServe_BeforeListen(t *testing.T) {
+	t.Parallel()
+	s := NewServer(Config{Address: "127.0.0.1:0"})
+	require.ErrorIs(t, s.Serve(), errNotListening)
+}
+
+func TestShutdown_BeforeListen(t *testing.T) {
+	t.Parallel()
+	s := NewServer(Config{Address: "127.0.0.1:0"})
+	require.NoError(t, s.Shutdown(context.Background()))
+}
+
+func TestListen_BindError(t *testing.T) {
+	t.Parallel()
+	first := NewServer(Config{Address: "127.0.0.1:0"})
+	require.NoError(t, first.Listen())
+	defer first.Shutdown(context.Background())
+
+	second := NewServer(Config{Address: first.listener.Addr().String()})
+	require.Error(t, second.Listen())
+}


### PR DESCRIPTION
#### Description

This PR adds an opt-in HTTP server exposing readiness and liveness probes to the commands `run` and `snapshot`:
* `/health` (liveness, always 200)
* `/ready` (readiness) for monitoring a running pgstream process

Both endpoints respond with JSON `{"status":"ok","version":"..."}`.

`/ready` runs a 2s-timeout SELECT 1 ping query against the source postgres database
when configured, returning 503 with failure detail on error.

For kafka sources or when no source is wired up it behaves like `/health`.

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Added opt-in HTTP health server with `/health` and `/ready` endpoints
- `/ready` pings the source Postgres database with a 2s timeout when configured
- Merged upstream `--upgrade`/`--init` options support into `cmd/run_cmd.go`

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary

#### Additional Notes

<!-- Any context or special instructions for reviewers -->