### PR TITLE
New target: `stdout`

### DIFF
--- a/cmd/config/config_env.go
+++ b/cmd/config/config_env.go
@@ -137,6 +137,8 @@ func init() {
 	viper.BindEnv("PGSTREAM_WEBHOOK_SUBSCRIPTION_SERVER_READ_TIMEOUT")
 	viper.BindEnv("PGSTREAM_WEBHOOK_SUBSCRIPTION_SERVER_WRITE_TIMEOUT")
 
+	viper.BindEnv("PGSTREAM_STDOUT_WRITER_ENABLED")
+
 	viper.BindEnv("PGSTREAM_INJECTOR_STORE_POSTGRES_URL")
 	viper.BindEnv("PGSTREAM_TRANSFORMER_RULES_FILE")
 	viper.BindEnv("PGSTREAM_FILTER_INCLUDE_TABLES")
@@ -395,10 +397,18 @@ func parseProcessorConfig() (stream.ProcessorConfig, error) {
 		Search:      searchCfg,
 		Webhook:     webhookCfg,
 		Postgres:    postgresCfg,
+		Stdout:      parseStdoutProcessorConfig(),
 		Injector:    parseInjectorConfig(),
 		Transformer: transformerCfg,
 		Filter:      parseFilterConfig(),
 	}, nil
+}
+
+func parseStdoutProcessorConfig() *stream.StdoutProcessorConfig {
+	if !viper.GetBool("PGSTREAM_STDOUT_WRITER_ENABLED") {
+		return nil
+	}
+	return &stream.StdoutProcessorConfig{}
 }
 
 func parseKafkaProcessorConfig() (*stream.KafkaProcessorConfig, error) {

--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -72,7 +72,10 @@ type TargetConfig struct {
 	Kafka    *KafkaTargetConfig    `mapstructure:"kafka" yaml:"kafka"`
 	Search   *SearchConfig         `mapstructure:"search" yaml:"search"`
 	Webhooks *WebhooksConfig       `mapstructure:"webhooks" yaml:"webhooks"`
+	Stdout   *StdoutTargetConfig   `mapstructure:"stdout" yaml:"stdout"`
 }
+
+type StdoutTargetConfig struct{}
 
 type PostgresConfig struct {
 	URL         string             `mapstructure:"url" yaml:"url"`
@@ -407,6 +410,7 @@ func (c *YAMLConfig) parseProcessorConfig() (stream.ProcessorConfig, error) {
 		Kafka:    c.parseKafkaProcessorConfig(),
 		Postgres: c.parsePostgresProcessorConfig(),
 		Webhook:  c.parseWebhookProcessorConfig(),
+		Stdout:   c.parseStdoutProcessorConfig(),
 		Filter:   c.parseFilterConfig(),
 	}
 
@@ -625,6 +629,13 @@ func (c *YAMLConfig) parseKafkaProcessorConfig() *stream.KafkaProcessorConfig {
 			Batch: c.Target.Kafka.Batch.parseBatchConfig(),
 		},
 	}
+}
+
+func (c *YAMLConfig) parseStdoutProcessorConfig() *stream.StdoutProcessorConfig {
+	if c.Target.Stdout == nil {
+		return nil
+	}
+	return &stream.StdoutProcessorConfig{}
 }
 
 func (c *YAMLConfig) parsePostgresProcessorConfig() *stream.PostgresProcessorConfig {

--- a/config_template.yaml
+++ b/config_template.yaml
@@ -137,6 +137,7 @@ target:
     notifier:
       worker_count: 4 # number of notifications to be processed in parallel. Defaults to 10
       client_timeout: 1000 # timeout for the webhook client in milliseconds. Defaults to 10s
+  stdout: {} # write WAL events as NDJSON to stdout. Useful for debugging and validating the pipeline without a real target.
 
 modifiers:
   injector:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,6 +156,7 @@ target:
     notifier:
       worker_count: 4 # number of notifications to be processed in parallel. Defaults to 10
       client_timeout: 1000 # timeout for the webhook client in milliseconds. Defaults to 10s
+  stdout: {} # write WAL events as NDJSON to stdout. Useful for debugging and validating the pipeline without a real target.
 
 modifiers:
   injector:
@@ -302,6 +303,15 @@ One of exponential/constant backoff policies can be provided for the Kafka commi
 One of exponential/constant backoff policies can be provided for the search indexer cleanup retry strategy. If none is provided, no retries apply.
 
 One of exponential/constant/disable retries backoff policies can be provided for the search store retry strategy. If none is provided, a default exponential backoff policy applies.
+
+</details>
+
+<details>
+  <summary>Stdout Writer</summary>
+
+| Environment Variable             | Default | Required | Description                                                                                                                |
+| -------------------------------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| PGSTREAM_STDOUT_WRITER_ENABLED   | False   | No       | Set to true to enable the stdout writer target. WAL events are written as NDJSON (one JSON object per line) to stdout.     |
 
 </details>
 

--- a/pkg/stream/config.go
+++ b/pkg/stream/config.go
@@ -51,10 +51,13 @@ type ProcessorConfig struct {
 	Search      *SearchProcessorConfig
 	Webhook     *WebhookProcessorConfig
 	Postgres    *PostgresProcessorConfig
+	Stdout      *StdoutProcessorConfig
 	Injector    *injector.Config
 	Transformer *transformer.Config
 	Filter      *filter.Config
 }
+
+type StdoutProcessorConfig struct{}
 
 type KafkaProcessorConfig struct {
 	Writer *kafkaprocessor.Config
@@ -123,6 +126,9 @@ func (c *ProcessorConfig) IsValid() error {
 		processorCount++
 	}
 	if c.Webhook != nil {
+		processorCount++
+	}
+	if c.Stdout != nil {
 		processorCount++
 	}
 

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -20,6 +20,7 @@ import (
 	"github.com/xataio/pgstream/pkg/wal/processor/search"
 	searchinstrumentation "github.com/xataio/pgstream/pkg/wal/processor/search/instrumentation"
 	"github.com/xataio/pgstream/pkg/wal/processor/search/store"
+	stdoutwriter "github.com/xataio/pgstream/pkg/wal/processor/stdout"
 	"github.com/xataio/pgstream/pkg/wal/processor/transformer"
 	webhooknotifier "github.com/xataio/pgstream/pkg/wal/processor/webhook/notifier"
 	subscriptionserver "github.com/xataio/pgstream/pkg/wal/processor/webhook/subscription/server"
@@ -164,6 +165,13 @@ func buildProcessor(ctx context.Context, logger loglib.Logger, config *Processor
 
 			processor = pgBatchWriter
 		}
+
+	case config.Stdout != nil:
+		logger.Info("stdout processor configured")
+		processor = stdoutwriter.NewWriter(
+			stdoutwriter.WithLogger(logger),
+			stdoutwriter.WithCheckpoint(checkpoint),
+		)
 
 	default:
 		return nil, errors.New("no supported processor found")

--- a/pkg/wal/processor/stdout/wal_stdout_writer.go
+++ b/pkg/wal/processor/stdout/wal_stdout_writer.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package stdout
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"runtime/debug"
+
+	"github.com/xataio/pgstream/internal/json"
+	loglib "github.com/xataio/pgstream/pkg/log"
+	"github.com/xataio/pgstream/pkg/wal"
+	"github.com/xataio/pgstream/pkg/wal/checkpointer"
+)
+
+// Writer is a processor that serialises WAL events as NDJSON to an
+// io.Writer (defaulting to os.Stdout). It is intended for debugging and
+// quick validation of a pgstream pipeline without needing a real target.
+type Writer struct {
+	logger       loglib.Logger
+	out          io.Writer
+	serialiser   func(any) ([]byte, error)
+	checkpointer checkpointer.Checkpoint
+}
+
+type Option func(*Writer)
+
+func NewWriter(opts ...Option) *Writer {
+	w := &Writer{
+		logger:     loglib.NewNoopLogger(),
+		out:        os.Stdout,
+		serialiser: json.Marshal,
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	return w
+}
+
+func WithLogger(l loglib.Logger) Option {
+	return func(w *Writer) {
+		w.logger = loglib.NewLogger(l).WithFields(loglib.Fields{
+			loglib.ModuleField: "stdout_writer",
+		})
+	}
+}
+
+func WithCheckpoint(c checkpointer.Checkpoint) Option {
+	return func(w *Writer) {
+		w.checkpointer = c
+	}
+}
+
+// WithWriter overrides the destination io.Writer. Primarily intended for tests.
+func WithWriter(out io.Writer) Option {
+	return func(w *Writer) {
+		w.out = out
+	}
+}
+
+func (w *Writer) ProcessWALEvent(ctx context.Context, walEvent *wal.Event) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			w.logger.Panic("[PANIC] Panic while processing replication event", loglib.Fields{
+				"wal_data":    walEvent,
+				"panic":       r,
+				"stack_trace": debug.Stack(),
+			})
+			retErr = fmt.Errorf("stdout writer: understanding event: %v", r)
+		}
+	}()
+
+	if walEvent.Data != nil {
+		payload, err := w.serialiser(walEvent.Data)
+		if err != nil {
+			return fmt.Errorf("marshalling event: %w", err)
+		}
+
+		if _, err := w.out.Write(append(payload, '\n')); err != nil {
+			return fmt.Errorf("writing event: %w", err)
+		}
+	}
+
+	if w.checkpointer != nil && walEvent.CommitPosition != "" {
+		if err := w.checkpointer(ctx, []wal.CommitPosition{walEvent.CommitPosition}); err != nil {
+			w.logger.Warn(err, "stdout writer: error updating commit position")
+		}
+	}
+
+	return nil
+}
+
+func (w *Writer) Name() string {
+	return "stdout-writer"
+}
+
+func (w *Writer) Close() error {
+	return nil
+}

--- a/pkg/wal/processor/stdout/wal_stdout_writer_test.go
+++ b/pkg/wal/processor/stdout/wal_stdout_writer_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package stdout
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/pkg/wal"
+)
+
+func TestWriter_ProcessWALEvent(t *testing.T) {
+	t.Parallel()
+
+	dataEvent := &wal.Event{
+		Data: &wal.Data{
+			Action: "I",
+			Schema: "public",
+			Table:  "users",
+			Columns: []wal.Column{
+				{Name: "id", Type: "int4", Value: int64(42)},
+			},
+		},
+		CommitPosition: wal.CommitPosition("0/16BCAF8"),
+	}
+	keepAliveEvent := &wal.Event{
+		CommitPosition: wal.CommitPosition("0/16BCB00"),
+	}
+
+	t.Run("writes NDJSON for data event", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		w := NewWriter(WithWriter(&buf))
+
+		err := w.ProcessWALEvent(context.Background(), dataEvent)
+		require.NoError(t, err)
+
+		line := buf.String()
+		require.True(t, strings.HasSuffix(line, "\n"), "expected trailing newline, got %q", line)
+		// Verify it's valid JSON that decodes to the same payload.
+		var got wal.Data
+		require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(line)), &got))
+		require.Equal(t, "I", got.Action)
+		require.Equal(t, "public", got.Schema)
+		require.Equal(t, "users", got.Table)
+	})
+
+	t.Run("invokes checkpoint after data event", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		var gotPositions []wal.CommitPosition
+		ckpt := func(_ context.Context, p []wal.CommitPosition) error {
+			gotPositions = append(gotPositions, p...)
+			return nil
+		}
+		w := NewWriter(WithWriter(&buf), WithCheckpoint(ckpt))
+
+		require.NoError(t, w.ProcessWALEvent(context.Background(), dataEvent))
+		require.Equal(t, []wal.CommitPosition{dataEvent.CommitPosition}, gotPositions)
+	})
+
+	t.Run("checkpoints keep-alive event without writing", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		var called bool
+		ckpt := func(_ context.Context, _ []wal.CommitPosition) error {
+			called = true
+			return nil
+		}
+		w := NewWriter(WithWriter(&buf), WithCheckpoint(ckpt))
+
+		require.NoError(t, w.ProcessWALEvent(context.Background(), keepAliveEvent))
+		require.Empty(t, buf.String())
+		require.True(t, called, "expected checkpoint to be called for keep-alive")
+	})
+
+	t.Run("checkpoint error does not fail the event", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		ckpt := func(_ context.Context, _ []wal.CommitPosition) error {
+			return errors.New("boom")
+		}
+		w := NewWriter(WithWriter(&buf), WithCheckpoint(ckpt))
+
+		require.NoError(t, w.ProcessWALEvent(context.Background(), dataEvent))
+		require.NotEmpty(t, buf.String())
+	})
+}
+
+func TestWriter_NameAndClose(t *testing.T) {
+	t.Parallel()
+	w := NewWriter()
+	require.Equal(t, "stdout-writer", w.Name())
+	require.NoError(t, w.Close())
+}


### PR DESCRIPTION
#### Description

This PR adds a new target named `stdout`. This target is intended for debugging data pipelines.
It writes WAL events as NDJSON to `stdout`.

It is configured via the YAML key `target.stdout` or the env var `PGSTREAM_STDOUT_WRITER_ENABLED`.
It is mutually exclusive with the other targets.

Events are written immediately, and the checkpoint callback fires per event so source LSN/offset advances normally.

##### Related Issue(s)

Closes #165

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

-
-
-

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
