### PR TITLE
Eliminate panics in transformers when multiple workers are configured

### DIFF
--- a/pkg/transformers/builder/transformer_concurrency_test.go
+++ b/pkg/transformers/builder/transformer_concurrency_test.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"context"
+	"maps"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/pkg/transformers"
+)
+
+// concurrencyTestCase exercises a transformer from multiple goroutines, the
+// way pgstream snapshot workers share a single transformer per column. Run
+// with the race detector enabled, it catches transformers that share rng or
+// buffer state across calls (issues #789 and #800).
+type concurrencyTestCase struct {
+	params transformers.ParameterValues
+	input  any
+	// supportsGenerators runs the case once with the random and once with the
+	// deterministic generator parameter
+	supportsGenerators bool
+	validate           func(t *testing.T, got any)
+	skip               string
+}
+
+func TestTransformers_ConcurrentTransform(t *testing.T) {
+	t.Parallel()
+
+	tests := map[transformers.TransformerType]concurrencyTestCase{
+		transformers.Masking: {
+			params: transformers.ParameterValues{"type": "default"},
+			input:  "sensitive value",
+		},
+		transformers.Email: {
+			input: "user@example.com",
+		},
+		transformers.Template: {
+			params: transformers.ParameterValues{"template": "{{ .GetValue }} - transformed"},
+			input:  "hello",
+		},
+		transformers.JSON: {
+			params: transformers.ParameterValues{
+				"operations": []any{
+					map[string]any{
+						"operation":       "set",
+						"path":            "/greeting",
+						"value":           "hello world",
+						"error_not_exist": false,
+					},
+				},
+			},
+			input: []byte(`{"greeting":"hi"}`),
+		},
+		transformers.Hstore: {
+			params: transformers.ParameterValues{
+				"operations": []any{
+					map[string]any{
+						"operation": "set",
+						"key":       "test",
+						"value":     "value",
+					},
+				},
+			},
+			input: `"a"=>"b"`,
+		},
+		transformers.PhoneNumber: {
+			params:             transformers.ParameterValues{"prefix": "+1", "min_length": 9, "max_length": 12},
+			input:              "1234567890",
+			supportsGenerators: true,
+		},
+		transformers.LiteralString: {
+			params: transformers.ParameterValues{"literal": "fixed"},
+			input:  "anything",
+		},
+		transformers.String: {
+			input: "hello world",
+		},
+		transformers.GreenmaskString: {
+			params:             transformers.ParameterValues{"min_length": 2, "max_length": 12},
+			input:              "hello world",
+			supportsGenerators: true,
+			validate: func(t *testing.T, got any) {
+				str, ok := got.(string)
+				require.True(t, ok, "expected string, got %T", got)
+				// a torn read of the shared rune buffer produces NUL runes,
+				// which postgres rejects on COPY (issue #800)
+				require.NotContains(t, str, "\x00")
+			},
+		},
+		transformers.GreenmaskFirstName: {
+			input:              "John",
+			supportsGenerators: true,
+		},
+		transformers.GreenmaskInteger: {
+			params:             transformers.ParameterValues{"min_value": 0, "max_value": 1000},
+			input:              42,
+			supportsGenerators: true,
+		},
+		transformers.GreenmaskFloat: {
+			params:             transformers.ParameterValues{"min_value": 0.0, "max_value": 1000.0},
+			input:              42.5,
+			supportsGenerators: true,
+		},
+		transformers.GreenmaskUUID: {
+			input:              "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+			supportsGenerators: true,
+		},
+		transformers.GreenmaskBoolean: {
+			input:              true,
+			supportsGenerators: true,
+		},
+		transformers.GreenmaskChoice: {
+			params:             transformers.ParameterValues{"choices": []any{"alpha", "beta", "gamma"}},
+			input:              "x",
+			supportsGenerators: true,
+		},
+		transformers.GreenmaskUnixTimestamp: {
+			params:             transformers.ParameterValues{"min_value": "946684800", "max_value": "1893456000"},
+			input:              int64(1136073600),
+			supportsGenerators: true,
+		},
+		transformers.GreenmaskDate: {
+			params:             transformers.ParameterValues{"min_value": "2020-01-01", "max_value": "2024-12-31"},
+			input:              "2022-06-15",
+			supportsGenerators: true,
+		},
+		transformers.GreenmaskUTCTimestamp: {
+			params:             transformers.ParameterValues{"min_timestamp": "2020-01-01T00:00:00Z", "max_timestamp": "2024-12-31T23:59:59Z"},
+			input:              "2022-06-15T12:00:00Z",
+			supportsGenerators: true,
+		},
+		transformers.NeosyncString: {
+			input: "hello world",
+		},
+		transformers.NeosyncFirstName: {
+			input: "John",
+		},
+		transformers.NeosyncLastName: {
+			input: "Doe",
+		},
+		transformers.NeosyncFullName: {
+			input: "John Doe",
+		},
+		transformers.NeosyncEmail: {
+			input: "user@example.com",
+		},
+		transformers.PGAnonymizer: {
+			skip: "requires a live PostgreSQL connection",
+		},
+	}
+
+	// every registered transformer must have a concurrency test, so that new
+	// transformers can't be added without one
+	for transformerType := range TransformersMap {
+		_, found := tests[transformerType]
+		require.True(t, found, "transformer %q is missing a concurrency test case", transformerType)
+	}
+
+	for transformerType, tc := range tests {
+		t.Run(string(transformerType), func(t *testing.T) {
+			t.Parallel()
+			if tc.skip != "" {
+				t.Skip(tc.skip)
+			}
+
+			generatorTypes := []string{""}
+			if tc.supportsGenerators {
+				generatorTypes = []string{"random", "deterministic"}
+			}
+
+			for _, generatorType := range generatorTypes {
+				params := maps.Clone(tc.params)
+				if generatorType != "" {
+					if params == nil {
+						params = transformers.ParameterValues{}
+					}
+					params["generator"] = generatorType
+				}
+
+				name := generatorType
+				if name == "" {
+					name = "default"
+				}
+				t.Run(name, func(t *testing.T) {
+					t.Parallel()
+					transformer, err := NewTransformerBuilder().New(&transformers.Config{
+						Name:       transformerType,
+						Parameters: params,
+					})
+					require.NoError(t, err)
+					defer transformer.Close()
+
+					// the deterministic generator must keep producing the
+					// same output for the same input, regardless of which
+					// internal instance serves the call
+					wantDeterministic := generatorType == "deterministic"
+					runConcurrentTransforms(t, transformer, tc.input, wantDeterministic, tc.validate)
+				})
+			}
+		})
+	}
+}
+
+func runConcurrentTransforms(t *testing.T, transformer transformers.Transformer, input any, wantDeterministic bool, validate func(t *testing.T, got any)) {
+	const (
+		numGoroutines = 16
+		numIterations = 100
+	)
+
+	value := transformers.NewValue(input, "text", nil)
+	results := make([][]any, numGoroutines)
+	errs := make([]error, numGoroutines)
+
+	var wg sync.WaitGroup
+	for g := range numGoroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range numIterations {
+				got, err := transformer.Transform(context.Background(), value)
+				if err != nil {
+					errs[g] = err
+					return
+				}
+				results[g] = append(results[g], got)
+			}
+		}()
+	}
+	wg.Wait()
+
+	var first any
+	for g := range numGoroutines {
+		require.NoError(t, errs[g])
+		for _, got := range results[g] {
+			if validate != nil {
+				validate(t, got)
+			}
+			if wantDeterministic {
+				if first == nil {
+					first = got
+				}
+				require.Equal(t, first, got)
+			}
+		}
+	}
+}

--- a/pkg/transformers/generators/deterministic_bytes_generator.go
+++ b/pkg/transformers/generators/deterministic_bytes_generator.go
@@ -6,6 +6,11 @@ import (
 	greenmaskgenerators "github.com/eminano/greenmask/pkg/generators"
 )
 
+// NewDeterministicBytesGenerator returns a hash based generator that is safe
+// for concurrent use. All instances hash with the same (empty) salt, so the
+// output only depends on the input.
 func NewDeterministicBytesGenerator(size int) (Generator, error) {
-	return greenmaskgenerators.GetHashBytesGen([]byte{}, size)
+	return newPooledGenerator(size, func() (greenmaskgenerators.Generator, error) {
+		return greenmaskgenerators.GetHashBytesGen([]byte{}, size)
+	})
 }

--- a/pkg/transformers/generators/pooled_generator.go
+++ b/pkg/transformers/generators/pooled_generator.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package generators
+
+import (
+	greenmaskgenerators "github.com/eminano/greenmask/pkg/generators"
+	"github.com/xataio/pgstream/pkg/transformers/internal/pool"
+)
+
+// pooledGenerator makes a non concurrency-safe greenmask generator safe for
+// concurrent use by handing out a dedicated underlying instance per caller.
+type pooledGenerator struct {
+	pool *pool.Pool[greenmaskgenerators.Generator]
+	size int
+}
+
+func newPooledGenerator(size int, newFn func() (greenmaskgenerators.Generator, error)) (Generator, error) {
+	p, err := pool.New(newFn)
+	if err != nil {
+		return nil, err
+	}
+	return &pooledGenerator{pool: p, size: size}, nil
+}
+
+func (g *pooledGenerator) Generate(data []byte) ([]byte, error) {
+	gen, err := g.pool.Acquire()
+	if err != nil {
+		return nil, err
+	}
+	defer g.pool.Release(gen)
+	res, err := gen.Generate(data)
+	if err != nil {
+		return nil, err
+	}
+	// hash based generators return a slice aliasing their internal buffer, so
+	// it must be copied before the instance is released. The copy keeps the
+	// full backing array up to capacity, because greenmask's person
+	// transformer reads past the returned length into the spare bytes the
+	// random generator leaves there.
+	out := make([]byte, len(res), cap(res))
+	copy(out[:cap(out)], res[:cap(res)])
+	return out, nil
+}
+
+func (g *pooledGenerator) Size() int {
+	return g.size
+}

--- a/pkg/transformers/generators/random_bytes_generator.go
+++ b/pkg/transformers/generators/random_bytes_generator.go
@@ -3,11 +3,21 @@
 package generators
 
 import (
+	"sync/atomic"
 	"time"
 
 	greenmaskgenerators "github.com/eminano/greenmask/pkg/generators"
 )
 
+// seedSequence makes sure generator instances created concurrently or within
+// the same clock tick don't share a seed and produce identical streams.
+var seedSequence atomic.Int64
+
+// NewRandomBytesGenerator returns a random bytes generator that is safe for
+// concurrent use.
 func NewRandomBytesGenerator(size int) Generator {
-	return greenmaskgenerators.NewRandomBytes(time.Now().UnixNano(), size)
+	g, _ := newPooledGenerator(size, func() (greenmaskgenerators.Generator, error) {
+		return greenmaskgenerators.NewRandomBytes(time.Now().UnixNano()+seedSequence.Add(1), size), nil
+	})
+	return g
 }

--- a/pkg/transformers/greenmask/greenmask_string_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_string_transformer.go
@@ -8,10 +8,13 @@ import (
 
 	greenmasktransformers "github.com/eminano/greenmask/pkg/generators/transformers"
 	"github.com/xataio/pgstream/pkg/transformers"
+	"github.com/xataio/pgstream/pkg/transformers/internal/pool"
 )
 
 type StringTransformer struct {
-	transformer *greenmasktransformers.RandomStringTransformer
+	// the underlying greenmask transformer writes into a shared rune buffer
+	// on every call, so each concurrent caller needs its own instance
+	pool *pool.Pool[*greenmasktransformers.RandomStringTransformer]
 }
 
 const defaultSymbols = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
@@ -71,17 +74,22 @@ func NewStringTransformer(params transformers.ParameterValues) (*StringTransform
 		return nil, fmt.Errorf("greenmask_string: max_length must be an integer: %w", err)
 	}
 
-	t, err := greenmasktransformers.NewRandomStringTransformer([]rune(symbols), minLength, maxLength)
+	p, err := pool.New(func() (*greenmasktransformers.RandomStringTransformer, error) {
+		t, err := greenmasktransformers.NewRandomStringTransformer([]rune(symbols), minLength, maxLength)
+		if err != nil {
+			return nil, err
+		}
+		if err := setGenerator(t, params); err != nil {
+			return nil, err
+		}
+		return t, nil
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	if err := setGenerator(t, params); err != nil {
-		return nil, err
-	}
-
 	return &StringTransformer{
-		transformer: t,
+		pool: p,
 	}, nil
 }
 
@@ -96,8 +104,15 @@ func (st *StringTransformer) Transform(_ context.Context, value transformers.Val
 		return nil, transformers.ErrUnsupportedValueType
 	}
 
-	ret := st.transformer.Transform(toTransform)
-	return string(ret), nil
+	t, err := st.pool.Acquire()
+	if err != nil {
+		return nil, err
+	}
+	// the returned runes alias the instance's internal buffer, so it must be
+	// copied into a string before the instance is released
+	ret := string(t.Transform(toTransform))
+	st.pool.Release(t)
+	return ret, nil
 }
 
 func (st *StringTransformer) CompatibleTypes() []transformers.SupportedDataType {

--- a/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	greenmasktransformers "github.com/eminano/greenmask/pkg/generators/transformers"
@@ -14,7 +13,6 @@ import (
 )
 
 type UTCTimestampTransformer struct {
-	mu          sync.Mutex
 	transformer *greenmasktransformers.Timestamp
 }
 
@@ -119,12 +117,6 @@ func (t *UTCTimestampTransformer) Transform(_ context.Context, value transformer
 	default:
 		return nil, transformers.ErrUnsupportedValueType
 	}
-	// greenmask's Timestamp transformer holds a *rand.Rand that is not safe
-	// for concurrent use, but pgstream shares one transformer across snapshot
-	// worker goroutines. Serialize the call so concurrent writers don't
-	// corrupt the shared rng (issue #789).
-	t.mu.Lock()
-	defer t.mu.Unlock()
 	return t.transformer.Transform(nil, toTransform)
 }
 

--- a/pkg/transformers/greenmask/greenmask_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_transformer.go
@@ -3,11 +3,9 @@
 package greenmask
 
 import (
-	"time"
-
-	greenmaskgenerators "github.com/eminano/greenmask/pkg/generators"
 	greenmasktransformers "github.com/eminano/greenmask/pkg/generators/transformers"
 	"github.com/xataio/pgstream/pkg/transformers"
+	"github.com/xataio/pgstream/pkg/transformers/generators"
 )
 
 const (
@@ -15,19 +13,24 @@ const (
 	deterministic = "deterministic"
 )
 
+// setGenerator configures the transformer with a generator that is safe for
+// concurrent use. pgstream shares one transformer per column across all
+// snapshot worker goroutines, and the generator is the only mutable state in
+// the greenmask transformers (except for the string one, which pools whole
+// instances), so this makes the transformers safe to call concurrently
+// (issues #789 and #800).
 func setGenerator(t greenmasktransformers.Transformer, params transformers.ParameterValues) error {
 	generatorType, err := getGeneratorType(params)
 	if err != nil {
 		return err
 	}
 
-	var greenmaskGenerator greenmaskgenerators.Generator
+	var generator generators.Generator
 	switch generatorType {
 	case random:
-		greenmaskGenerator = greenmaskgenerators.NewRandomBytes(time.Now().UnixNano(), t.GetRequiredGeneratorByteLength())
+		generator = generators.NewRandomBytesGenerator(t.GetRequiredGeneratorByteLength())
 	case deterministic:
-		var err error
-		greenmaskGenerator, err = greenmaskgenerators.GetHashBytesGen([]byte{}, t.GetRequiredGeneratorByteLength())
+		generator, err = generators.NewDeterministicBytesGenerator(t.GetRequiredGeneratorByteLength())
 		if err != nil {
 			return err
 		}
@@ -35,7 +38,7 @@ func setGenerator(t greenmasktransformers.Transformer, params transformers.Param
 		return transformers.ErrUnsupportedGenerator
 	}
 
-	return t.SetGenerator(greenmaskGenerator)
+	return t.SetGenerator(generator)
 }
 
 func getGeneratorType(params transformers.ParameterValues) (string, error) {

--- a/pkg/transformers/hstore_transformer.go
+++ b/pkg/transformers/hstore_transformer.go
@@ -21,8 +21,6 @@ const (
 
 type HstoreTransformer struct {
 	operations []*hstoreOperation
-	hstoreVal  *hstoreValue
-	buf        *bytes.Buffer
 }
 
 var (
@@ -65,8 +63,6 @@ func NewHstoreTransformer(params ParameterValues) (*HstoreTransformer, error) {
 
 	return &HstoreTransformer{
 		operations: operations,
-		buf:        bytes.NewBuffer(nil),
-		hstoreVal:  &hstoreValue{},
 	}, nil
 }
 
@@ -88,13 +84,17 @@ func (t *HstoreTransformer) Transform(_ context.Context, value Value) (any, erro
 		return nil, fmt.Errorf("hstore_transformer: error parsing hstore: %w", err)
 	}
 
+	// the value and buffer are local to the call so that the transformer can
+	// be used concurrently
+	hstoreVal := &hstoreValue{}
 	// set dynamic values for the hstoreValue instance, to be used in templates
-	t.hstoreVal.setDynamicValues(value.DynamicValues)
+	hstoreVal.setDynamicValues(value.DynamicValues)
+	buf := bytes.NewBuffer(nil)
 
 	transformed := toTransform
 	for idx, op := range t.operations {
-		t.hstoreVal.setValue(transformed, op.key)
-		if !t.hstoreVal.exists {
+		hstoreVal.setValue(transformed, op.key)
+		if !hstoreVal.exists {
 			if op.skipNotExist {
 				continue
 			}
@@ -103,7 +103,7 @@ func (t *HstoreTransformer) Transform(_ context.Context, value Value) (any, erro
 			}
 		}
 		// apply each operation in the order they were provided
-		transformed, err = op.apply(transformed, t.hstoreVal, t.buf)
+		transformed, err = op.apply(transformed, hstoreVal, buf)
 		if err != nil {
 			return nil, fmt.Errorf("hstore_transformer: cannot apply \"%s\" operation[%d] with key %s: %w", op.operation, idx, op.key, err)
 		}

--- a/pkg/transformers/internal/pool/pool.go
+++ b/pkg/transformers/internal/pool/pool.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package pool provides a concurrency-safe pool of instances for libraries
+// whose types are not safe for concurrent use. pgstream shares a single
+// transformer per column across all snapshot worker goroutines, so
+// transformers backed by stateful libraries (shared rng, internal buffers)
+// hand out one underlying instance per concurrent caller instead of
+// serializing calls with a lock.
+package pool
+
+import "sync"
+
+// Pool hands out dedicated instances of T so that concurrent callers never
+// share one. Instances are created lazily with the provided constructor and
+// reused across calls once released.
+type Pool[T any] struct {
+	pool  sync.Pool
+	newFn func() (T, error)
+}
+
+// New returns a pool that creates instances with newFn. The constructor is
+// invoked eagerly once so that invalid configuration fails at build time
+// rather than on first use.
+func New[T any](newFn func() (T, error)) (*Pool[T], error) {
+	instance, err := newFn()
+	if err != nil {
+		return nil, err
+	}
+	p := &Pool[T]{newFn: newFn}
+	p.pool.Put(instance)
+	return p, nil
+}
+
+// Acquire returns an instance for exclusive use by the caller. It must be
+// returned with Release once the caller is done with it, including any reads
+// of buffers the instance owns.
+func (p *Pool[T]) Acquire() (T, error) {
+	if v, ok := p.pool.Get().(T); ok {
+		return v, nil
+	}
+	return p.newFn()
+}
+
+// Release returns an instance to the pool for reuse.
+func (p *Pool[T]) Release(instance T) {
+	p.pool.Put(instance)
+}

--- a/pkg/transformers/json_transformer.go
+++ b/pkg/transformers/json_transformer.go
@@ -43,8 +43,6 @@ var (
 
 type JSONTransformer struct {
 	operations []*jsonOperation
-	jsonVal    *jsonValue
-	buf        *bytes.Buffer
 }
 
 func NewJSONTransformer(params ParameterValues) (*JSONTransformer, error) {
@@ -69,8 +67,6 @@ func NewJSONTransformer(params ParameterValues) (*JSONTransformer, error) {
 
 	return &JSONTransformer{
 		operations: operations,
-		buf:        bytes.NewBuffer(nil),
-		jsonVal:    &jsonValue{},
 	}, nil
 }
 
@@ -88,13 +84,17 @@ func (jt *JSONTransformer) Transform(_ context.Context, value Value) (any, error
 			return nil, fmt.Errorf("json_transformer: error marshalling value to JSON: %w", err)
 		}
 	}
+	// the value and buffer are local to the call so that the transformer can
+	// be used concurrently
+	jsonVal := &jsonValue{}
 	// set dynamic values for the jsonValue instance, to be used in templates
-	jt.jsonVal.setDynamicValues(value.DynamicValues)
+	jsonVal.setDynamicValues(value.DynamicValues)
+	buf := bytes.NewBuffer(nil)
 
 	res := slices.Clone(toTransform)
 	for idx, op := range jt.operations {
-		jt.jsonVal.setValue(res, op.path)
-		if !jt.jsonVal.exists {
+		jsonVal.setValue(res, op.path)
+		if !jsonVal.exists {
 			if op.skipNotExist {
 				continue
 			}
@@ -103,7 +103,7 @@ func (jt *JSONTransformer) Transform(_ context.Context, value Value) (any, error
 			}
 		}
 		// apply each operation in the order they were provided
-		res, err = op.apply(res, jt.jsonVal, jt.buf)
+		res, err = op.apply(res, jsonVal, buf)
 		if err != nil {
 			return nil, fmt.Errorf("cannot apply \"%s\" operation[%d] with path %s: %w", op.operation, idx, op.path, err)
 		}


### PR DESCRIPTION
#### Description

This PR fixes the all the panics that show up when transformers are configured with multiple workers.

##### Related Issue(s)

- https://github.com/xataio/pgstream/issues/800
- https://github.com/xataio/pgstream/issues/789

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Create a pool of transformers. When a transformer is required, one is acquired from the pool or a new one gets created. Once the transformer no longer needed is returned back to the pool.
- All impacted transformers are fixed.

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
