### PR TITLE
Add source and target postgres connectivity checks

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -8,6 +8,11 @@
       "example": "\n\tpgstream check -c pg2pg.env\n\tpgstream check -c pg2pg.yaml --json\n\t",
       "flags": [
         {
+          "name": "connectivity",
+          "description": "Run connectivity checks against the configured source and target",
+          "default": "false"
+        },
+        {
           "name": "json",
           "description": "Output the check report in JSON format",
           "default": "false"

--- a/cmd/check_cmd.go
+++ b/cmd/check_cmd.go
@@ -18,17 +18,11 @@ import (
 var errCheckFailed = errors.New("checks reported errors")
 
 // selectedCategories returns the categories whose CLI flag was set to true.
-// If no category flag was set, every registered category is selected.
+// An empty result tells preflight.BuildChecks to run every registered category.
 func selectedCategories(cmd *cobra.Command) []preflight.Category {
-	selected := []preflight.Category{}
+	var selected []preflight.Category
 	for _, b := range preflight.Builders {
-		on, err := cmd.Flags().GetBool(b.Flag)
-		if err == nil && on {
-			selected = append(selected, b.Category)
-		}
-	}
-	if len(selected) == 0 {
-		for _, b := range preflight.Builders {
+		if on, _ := cmd.Flags().GetBool(b.Flag); on {
 			selected = append(selected, b.Category)
 		}
 	}

--- a/cmd/check_cmd.go
+++ b/cmd/check_cmd.go
@@ -58,7 +58,7 @@ var checkCmd = &cobra.Command{
 				sp.Success("pgstream checks passed")
 			}
 
-			if err := print(cmd, report); err != nil {
+			if err := print(cmd, preflight.ReportPrinter{Report: report}); err != nil {
 				return fmt.Errorf("failed to format check report: %w", err)
 			}
 

--- a/cmd/check_cmd.go
+++ b/cmd/check_cmd.go
@@ -12,68 +12,27 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/xataio/pgstream/cmd/config"
-	"github.com/xataio/pgstream/pkg/stream"
 	"github.com/xataio/pgstream/pkg/stream/preflight"
 )
 
 var errCheckFailed = errors.New("checks reported errors")
 
-// categoryBuilder turns a stream.Config into the concrete checks for a
-// category. Each new category adds an entry to categoryBuilders and a matching
-// CLI flag in root_cmd.go.
-type categoryBuilder struct {
-	category preflight.Category
-	flag     string
-	build    func(*stream.Config) []preflight.Check
-}
-
-var categoryBuilders = []categoryBuilder{
-	{preflight.CategoryConnectivity, "connectivity", buildConnectivityChecks},
-}
-
-func buildConnectivityChecks(cfg *stream.Config) []preflight.Check {
-	checks := []preflight.Check{}
-	if url := cfg.SourcePostgresURL(); url != "" {
-		checks = append(checks, &preflight.ConnectivityCheck{Label: "source", URL: url})
-	}
-	if cfg.Processor.Postgres != nil {
-		if url := cfg.Processor.Postgres.BatchWriter.URL; url != "" {
-			checks = append(checks, &preflight.ConnectivityCheck{Label: "target", URL: url})
-		}
-	}
-	return checks
-}
-
 // selectedCategories returns the categories whose CLI flag was set to true.
 // If no category flag was set, every registered category is selected.
 func selectedCategories(cmd *cobra.Command) []preflight.Category {
 	selected := []preflight.Category{}
-	for _, b := range categoryBuilders {
-		on, err := cmd.Flags().GetBool(b.flag)
+	for _, b := range preflight.Builders {
+		on, err := cmd.Flags().GetBool(b.Flag)
 		if err == nil && on {
-			selected = append(selected, b.category)
+			selected = append(selected, b.Category)
 		}
 	}
 	if len(selected) == 0 {
-		for _, b := range categoryBuilders {
-			selected = append(selected, b.category)
+		for _, b := range preflight.Builders {
+			selected = append(selected, b.Category)
 		}
 	}
 	return selected
-}
-
-func buildChecks(cfg *stream.Config, selected []preflight.Category) []preflight.Check {
-	want := make(map[preflight.Category]bool, len(selected))
-	for _, c := range selected {
-		want[c] = true
-	}
-	checks := []preflight.Check{}
-	for _, b := range categoryBuilders {
-		if want[b.category] {
-			checks = append(checks, b.build(cfg)...)
-		}
-	}
-	return checks
 }
 
 var checkCmd = &cobra.Command{
@@ -89,7 +48,7 @@ var checkCmd = &cobra.Command{
 				return fmt.Errorf("parsing stream config: %w", err)
 			}
 
-			checks := buildChecks(streamConfig, selectedCategories(cmd))
+			checks := preflight.BuildChecks(streamConfig, selectedCategories(cmd))
 			if len(checks) == 0 {
 				sp.Success("no checks to run")
 				return nil

--- a/cmd/check_cmd.go
+++ b/cmd/check_cmd.go
@@ -3,6 +3,8 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	"github.com/pterm/pterm"
@@ -10,7 +12,69 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/xataio/pgstream/cmd/config"
+	"github.com/xataio/pgstream/pkg/stream"
+	"github.com/xataio/pgstream/pkg/stream/preflight"
 )
+
+var errCheckFailed = errors.New("checks reported errors")
+
+// categoryBuilder turns a stream.Config into the concrete checks for a
+// category. Each new category adds an entry to categoryBuilders and a matching
+// CLI flag in root_cmd.go.
+type categoryBuilder struct {
+	category preflight.Category
+	flag     string
+	build    func(*stream.Config) []preflight.Check
+}
+
+var categoryBuilders = []categoryBuilder{
+	{preflight.CategoryConnectivity, "connectivity", buildConnectivityChecks},
+}
+
+func buildConnectivityChecks(cfg *stream.Config) []preflight.Check {
+	checks := []preflight.Check{}
+	if url := cfg.SourcePostgresURL(); url != "" {
+		checks = append(checks, &preflight.ConnectivityCheck{Label: "source", URL: url})
+	}
+	if cfg.Processor.Postgres != nil {
+		if url := cfg.Processor.Postgres.BatchWriter.URL; url != "" {
+			checks = append(checks, &preflight.ConnectivityCheck{Label: "target", URL: url})
+		}
+	}
+	return checks
+}
+
+// selectedCategories returns the categories whose CLI flag was set to true.
+// If no category flag was set, every registered category is selected.
+func selectedCategories(cmd *cobra.Command) []preflight.Category {
+	selected := []preflight.Category{}
+	for _, b := range categoryBuilders {
+		on, err := cmd.Flags().GetBool(b.flag)
+		if err == nil && on {
+			selected = append(selected, b.category)
+		}
+	}
+	if len(selected) == 0 {
+		for _, b := range categoryBuilders {
+			selected = append(selected, b.category)
+		}
+	}
+	return selected
+}
+
+func buildChecks(cfg *stream.Config, selected []preflight.Category) []preflight.Check {
+	want := make(map[preflight.Category]bool, len(selected))
+	for _, c := range selected {
+		want[c] = true
+	}
+	checks := []preflight.Check{}
+	for _, b := range categoryBuilders {
+		if want[b.category] {
+			checks = append(checks, b.build(cfg)...)
+		}
+	}
+	return checks
+}
 
 var checkCmd = &cobra.Command{
 	Use:     "check",
@@ -24,15 +88,33 @@ var checkCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("parsing stream config: %w", err)
 			}
-			_ = streamConfig
 
-			// TODO: run checks. See https://github.com/xataio/pgstream/issues/897 for the
-			// list of checks to implement.
+			checks := buildChecks(streamConfig, selectedCategories(cmd))
+			if len(checks) == 0 {
+				sp.Success("no checks to run")
+				return nil
+			}
 
-			sp.Success("no checks to run")
+			report := preflight.Run(context.Background(), checks, preflight.WithProgress(func(idx, total int, name string) {
+				sp.UpdateText(fmt.Sprintf("running %d/%d checks: %s", idx, total, name))
+			}))
+
+			if report.HasErrors() {
+				sp.Stop()
+			} else {
+				sp.Success("pgstream checks passed")
+			}
+
+			if err := print(cmd, report); err != nil {
+				return fmt.Errorf("failed to format check report: %w", err)
+			}
+
+			if report.HasErrors() {
+				return errCheckFailed
+			}
 			return nil
 		}()
-		if err != nil {
+		if err != nil && !errors.Is(err, errCheckFailed) {
 			sp.Fail(err.Error())
 		}
 

--- a/cmd/config/config_yaml_fuzz_test.go
+++ b/cmd/config/config_yaml_fuzz_test.go
@@ -90,7 +90,8 @@ func FuzzYAMLConfigProperties(f *testing.F) {
 		}()
 
 		cfg := generateYAMLConfigFromProperties(
-			sourceMode, snapshotMode, targetMode, searchEngine, modifiersMode, batchSize, timeout)
+			sourceMode, snapshotMode, targetMode, searchEngine, modifiersMode, batchSize, timeout,
+		)
 
 		// Test marshaling/unmarshaling
 		data, err := yaml.Marshal(cfg)

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -119,6 +119,7 @@ func Prepare() *cobra.Command {
 	checkCmd.Flags().String("postgres-url", "", "Source postgres URL to run checks against")
 	checkCmd.Flags().String("target-url", "", "Target URL to run checks against")
 	checkCmd.Flags().Bool("json", false, "Output the check report in JSON format")
+	checkCmd.Flags().Bool("connectivity", false, "Run connectivity checks against the configured source and target")
 
 	// Flag binding for root cmd
 	rootFlagBinding(rootCmd)

--- a/pkg/stream/preflight/CLAUDE.md
+++ b/pkg/stream/preflight/CLAUDE.md
@@ -1,0 +1,31 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working inside `pkg/stream/preflight`. The planned check set lives in `docs/migration_preflight_issue.md`; consult it before designing a new check.
+
+## Package shape
+
+- `preflight.go` — `Check` interface (`Name()` + `Run(ctx) ([]Finding, error)`), `Finding`, `CheckResult`, `Report`, `Run(ctx, []Check, ...RunOption)` engine.
+- `printer.go` — `ReportPrinter{Report}` is the only thing that formats reports. The `Report` struct itself stays pure data.
+- `builder.go` — `Builder` struct, `Builders` registry slice, per-category builder functions (`BuildConnectivityChecks`, …), `BuildChecks(cfg, selected)`.
+- One file per concrete check (`connectivity.go`, future `wal_level.go`, …).
+
+## Adding a new check
+
+Adding a check is meant to be a small, mechanical edit. Keep it that way.
+
+1. **Pick a category.** Categories group checks of the same concern (`connectivity`, `replication`, `access`, `schema`, `resources`).
+   - Joining an existing category: skip to step 2.
+   - Creating a new one: add a `Category` constant in `preflight.go`, a builder func + `Builders` entry in `builder.go`, and a boolean flag on `checkCmd` in `cmd/root_cmd.go`. The flag string must match `Builder.Flag`.
+2. **Implement the check.** New struct in `<thing>.go`, satisfying the `Check` interface.
+   - **Every `Finding` is blocking.** A check that finds nothing wrong returns a `nil` slice. Do not reintroduce severity tiers — they were removed on purpose.
+   - **Return `error` only when the check itself couldn't run** (timeout, internal bug, malformed input). A detected problem is a `Finding`, not an error.
+   - **Put remediation in `Finding.Message`** — the user should be able to act on it without reading source.
+3. **Materialise instances in the category builder** (e.g. `BuildConnectivityChecks`). The builder is the applicability gate: it reads `*stream.Config` and decides which instances are relevant. Inapplicable checks are silently omitted today; an explicit "skipped: <reason>" mechanism is deferred (see `docs/migration_preflight_issue.md` "Architecture decisions" #6).
+4. **Tests.** Unit-test the check directly against mocked dependencies (`internal/postgres/mocks` has the postgres conn mock). For new categories, exercise the builder selection path through the cmd layer too.
+
+## Do not
+
+- Do not add `init()`-time registration, dependency injection frameworks, or other indirection — `Builders` is the registry, keep it a plain literal slice.
+- Do not move rendering logic onto `Report`. `ReportPrinter` owns formatting; `Report` stays data-only.
+- Do not import `pkg/stream` from anywhere except `builder.go`. Engine code (`preflight.go`, `printer.go`, individual check files) stays stream-agnostic so it can be reused.
+- Do not reintroduce `Severity`, `--strict`, or warning/info tiers. If a check finds something less than blocking, it shouldn't be a check.

--- a/pkg/stream/preflight/CLAUDE.md
+++ b/pkg/stream/preflight/CLAUDE.md
@@ -17,7 +17,7 @@ Adding a check is meant to be a small, mechanical edit. Keep it that way.
    - Joining an existing category: skip to step 2.
    - Creating a new one: add a `Category` constant in `preflight.go`, a builder func + `Builders` entry in `builder.go`, and a boolean flag on `checkCmd` in `cmd/root_cmd.go`. The flag string must match `Builder.Flag`.
 2. **Implement the check.** New struct in `<thing>.go`, satisfying the `Check` interface.
-   - **Every `Finding` is blocking.** A check that finds nothing wrong returns a `nil` slice. Do not reintroduce severity tiers — they were removed on purpose.
+   - **Every `Finding` is blocking.** A check that finds nothing wrong returns a `nil` slice.
    - **Return `error` only when the check itself couldn't run** (timeout, internal bug, malformed input). A detected problem is a `Finding`, not an error.
    - **Put remediation in `Finding.Message`** — the user should be able to act on it without reading source.
 3. **Materialise instances in the category builder** (e.g. `BuildConnectivityChecks`). The builder is the applicability gate: it reads `*stream.Config` and decides which instances are relevant. Inapplicable checks are silently omitted today; an explicit "skipped: <reason>" mechanism is deferred (see `docs/migration_preflight_issue.md` "Architecture decisions" #6).
@@ -28,4 +28,3 @@ Adding a check is meant to be a small, mechanical edit. Keep it that way.
 - Do not add `init()`-time registration, dependency injection frameworks, or other indirection — `Builders` is the registry, keep it a plain literal slice.
 - Do not move rendering logic onto `Report`. `ReportPrinter` owns formatting; `Report` stays data-only.
 - Do not import `pkg/stream` from anywhere except `builder.go`. Engine code (`preflight.go`, `printer.go`, individual check files) stays stream-agnostic so it can be reused.
-- Do not reintroduce `Severity`, `--strict`, or warning/info tiers. If a check finds something less than blocking, it shouldn't be a check.

--- a/pkg/stream/preflight/builder.go
+++ b/pkg/stream/preflight/builder.go
@@ -36,7 +36,8 @@ func BuildConnectivityChecks(cfg *stream.Config) []Check {
 }
 
 // BuildChecks returns the concrete checks for the selected categories,
-// preserving the registration order in Builders.
+// preserving the registration order in Builders. An empty selection runs every
+// registered category.
 func BuildChecks(cfg *stream.Config, selected []Category) []Check {
 	want := make(map[Category]bool, len(selected))
 	for _, c := range selected {
@@ -44,7 +45,7 @@ func BuildChecks(cfg *stream.Config, selected []Category) []Check {
 	}
 	checks := []Check{}
 	for _, b := range Builders {
-		if want[b.Category] {
+		if len(want) == 0 || want[b.Category] {
 			checks = append(checks, b.Build(cfg)...)
 		}
 	}

--- a/pkg/stream/preflight/builder.go
+++ b/pkg/stream/preflight/builder.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import "github.com/xataio/pgstream/pkg/stream"
+
+// Builder turns a stream.Config into the concrete checks for a category. Each
+// new category adds an entry to Builders and a matching CLI flag in
+// cmd/root_cmd.go.
+type Builder struct {
+	Category Category
+	Flag     string
+	Build    func(*stream.Config) []Check
+}
+
+// Builders is the registry of category builders. Adding a new category = one
+// Builder entry here + one flag declaration on checkCmd.
+var Builders = []Builder{
+	{CategoryConnectivity, "connectivity", BuildConnectivityChecks},
+}
+
+// BuildConnectivityChecks returns the connectivity checks applicable to cfg.
+// A source check is added when a source postgres URL is configured; a target
+// check is added when a postgres target is configured.
+func BuildConnectivityChecks(cfg *stream.Config) []Check {
+	checks := []Check{}
+	if url := cfg.SourcePostgresURL(); url != "" {
+		checks = append(checks, &ConnectivityCheck{Label: "source", URL: url})
+	}
+	if cfg.Processor.Postgres != nil {
+		if url := cfg.Processor.Postgres.BatchWriter.URL; url != "" {
+			checks = append(checks, &ConnectivityCheck{Label: "target", URL: url})
+		}
+	}
+	return checks
+}
+
+// BuildChecks returns the concrete checks for the selected categories,
+// preserving the registration order in Builders.
+func BuildChecks(cfg *stream.Config, selected []Category) []Check {
+	want := make(map[Category]bool, len(selected))
+	for _, c := range selected {
+		want[c] = true
+	}
+	checks := []Check{}
+	for _, b := range Builders {
+		if want[b.Category] {
+			checks = append(checks, b.Build(cfg)...)
+		}
+	}
+	return checks
+}

--- a/pkg/stream/preflight/connectivity.go
+++ b/pkg/stream/preflight/connectivity.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/xataio/pgstream/internal/postgres"
+)
+
+// ConnectivityCheck verifies a Postgres URL accepts a connection and answers a
+// ping. A connection or ping failure is reported as an error-tier finding (not
+// a check error), since establishing connectivity is the purpose of the check.
+type ConnectivityCheck struct {
+	Label string
+	URL   string
+}
+
+func (c *ConnectivityCheck) Name() string {
+	return c.Label + " connectivity"
+}
+
+func (c *ConnectivityCheck) Run(ctx context.Context) ([]Finding, error) {
+	conn, err := postgres.NewConn(ctx, c.URL)
+	if err != nil {
+		return []Finding{{
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("unable to connect: %v", err),
+		}}, nil
+	}
+	defer conn.Close(ctx)
+
+	if err := conn.Ping(ctx); err != nil {
+		return []Finding{{
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("ping failed: %v", err),
+		}}, nil
+	}
+
+	return nil, nil
+}

--- a/pkg/stream/preflight/connectivity.go
+++ b/pkg/stream/preflight/connectivity.go
@@ -10,8 +10,8 @@ import (
 )
 
 // ConnectivityCheck verifies a Postgres URL accepts a connection and answers a
-// ping. A connection or ping failure is reported as an error-tier finding (not
-// a check error), since establishing connectivity is the purpose of the check.
+// ping. A connection or ping failure is reported as a finding (not a check
+// error), since establishing connectivity is the purpose of the check.
 type ConnectivityCheck struct {
 	Label string
 	URL   string
@@ -24,18 +24,12 @@ func (c *ConnectivityCheck) Name() string {
 func (c *ConnectivityCheck) Run(ctx context.Context) ([]Finding, error) {
 	conn, err := postgres.NewConn(ctx, c.URL)
 	if err != nil {
-		return []Finding{{
-			Severity: SeverityError,
-			Message:  fmt.Sprintf("unable to connect: %v", err),
-		}}, nil
+		return []Finding{{Message: fmt.Sprintf("unable to connect: %v", err)}}, nil
 	}
 	defer conn.Close(ctx)
 
 	if err := conn.Ping(ctx); err != nil {
-		return []Finding{{
-			Severity: SeverityError,
-			Message:  fmt.Sprintf("ping failed: %v", err),
-		}}, nil
+		return []Finding{{Message: fmt.Sprintf("ping failed: %v", err)}}, nil
 	}
 
 	return nil, nil

--- a/pkg/stream/preflight/preflight.go
+++ b/pkg/stream/preflight/preflight.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Severity tags a Finding so callers can decide how to react.
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+	SeverityInfo    Severity = "info"
+)
+
+// Category groups checks of the same concern so callers can opt in by
+// category via CLI flags. New categories are added as new check sets land —
+// see docs/migration_preflight_issue.md for the planned ones.
+type Category string
+
+const (
+	CategoryConnectivity Category = "connectivity"
+)
+
+// Finding describes a single issue detected by a Check.
+type Finding struct {
+	Severity Severity `json:"severity"`
+	Message  string   `json:"message"`
+}
+
+// Check is the minimal contract every preflight check must satisfy. Run returns
+// the findings the check produced; a non-nil error means the check itself could
+// not complete (distinct from finding a problem with the system under test).
+type Check interface {
+	Name() string
+	Run(ctx context.Context) ([]Finding, error)
+}
+
+// CheckResult bundles a check's name with whatever it produced.
+type CheckResult struct {
+	Name     string    `json:"name"`
+	Findings []Finding `json:"findings"`
+	Err      error     `json:"-"`
+}
+
+// MarshalJSON renders Err as a string so the report is consumable from a
+// non-Go process. The default error marshaling drops the message.
+func (r CheckResult) MarshalJSON() ([]byte, error) {
+	out := struct {
+		Name     string    `json:"name"`
+		Findings []Finding `json:"findings"`
+		Error    string    `json:"error,omitempty"`
+	}{
+		Name:     r.Name,
+		Findings: r.Findings,
+	}
+	if r.Err != nil {
+		out.Error = r.Err.Error()
+	}
+	return json.Marshal(out)
+}
+
+// Report is the outcome of running a set of checks.
+type Report struct {
+	Results []CheckResult `json:"results"`
+}
+
+// ProgressFunc is invoked just before each check runs. idx is 1-based.
+type ProgressFunc func(idx, total int, name string)
+
+// RunOption configures Run.
+type RunOption func(*runOptions)
+
+type runOptions struct {
+	progress ProgressFunc
+}
+
+// WithProgress installs a callback invoked before each check runs. Useful for
+// updating a spinner or log line with "running X of N: <name>".
+func WithProgress(fn ProgressFunc) RunOption {
+	return func(o *runOptions) { o.progress = fn }
+}
+
+// Run executes every check in order. A check returning an error does not stop
+// the run; subsequent checks still execute and the error is captured in the
+// report alongside the findings.
+func Run(ctx context.Context, checks []Check, opts ...RunOption) Report {
+	var ro runOptions
+	for _, opt := range opts {
+		opt(&ro)
+	}
+
+	results := make([]CheckResult, 0, len(checks))
+	total := len(checks)
+	for i, c := range checks {
+		if ro.progress != nil {
+			ro.progress(i+1, total, c.Name())
+		}
+		findings, err := c.Run(ctx)
+		results = append(results, CheckResult{
+			Name:     c.Name(),
+			Findings: findings,
+			Err:      err,
+		})
+	}
+	return Report{Results: results}
+}
+
+// HasErrors reports whether any check produced an error-tier finding or failed
+// to complete.
+func (r Report) HasErrors() bool {
+	for _, res := range r.Results {
+		if res.Err != nil {
+			return true
+		}
+		for _, f := range res.Findings {
+			if f.Severity == SeverityError {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// PrettyPrint renders the report as a human-readable string.
+func (r Report) PrettyPrint() string {
+	var sb strings.Builder
+	for _, res := range r.Results {
+		passed := res.Err == nil && !hasBlockingFindings(res.Findings)
+		switch {
+		case passed && len(res.Findings) == 0:
+			fmt.Fprintf(&sb, "✔ %s\n", res.Name)
+		case passed:
+			fmt.Fprintf(&sb, "✔ %s (with notes)\n", res.Name)
+		}
+		if res.Err != nil {
+			fmt.Fprintf(&sb, "✘ %s: check failed: %v\n", res.Name, res.Err)
+		}
+		for _, f := range res.Findings {
+			fmt.Fprintf(&sb, "%s %s: %s\n", severityMarker(f.Severity), res.Name, f.Message)
+		}
+	}
+	fmt.Fprintf(&sb, "ran %d checks\n", len(r.Results))
+	return sb.String()
+}
+
+func hasBlockingFindings(findings []Finding) bool {
+	for _, f := range findings {
+		if f.Severity == SeverityError || f.Severity == SeverityWarning {
+			return true
+		}
+	}
+	return false
+}
+
+func severityMarker(s Severity) string {
+	switch s {
+	case SeverityError:
+		return "✘"
+	case SeverityWarning:
+		return "⚠"
+	default:
+		return "ℹ"
+	}
+}

--- a/pkg/stream/preflight/preflight.go
+++ b/pkg/stream/preflight/preflight.go
@@ -5,8 +5,6 @@ package preflight
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"strings"
 )
 
 // Category groups checks of the same concern so callers can opt in by
@@ -110,23 +108,4 @@ func (r Report) HasErrors() bool {
 		}
 	}
 	return false
-}
-
-// PrettyPrint renders the report as a human-readable string.
-func (r Report) PrettyPrint() string {
-	var sb strings.Builder
-	for _, res := range r.Results {
-		if res.Err == nil && len(res.Findings) == 0 {
-			fmt.Fprintf(&sb, "✔ %s\n", res.Name)
-			continue
-		}
-		if res.Err != nil {
-			fmt.Fprintf(&sb, "✘ %s: check failed: %v\n", res.Name, res.Err)
-		}
-		for _, f := range res.Findings {
-			fmt.Fprintf(&sb, "✘ %s: %s\n", res.Name, f.Message)
-		}
-	}
-	fmt.Fprintf(&sb, "ran %d checks\n", len(r.Results))
-	return sb.String()
 }

--- a/pkg/stream/preflight/preflight.go
+++ b/pkg/stream/preflight/preflight.go
@@ -9,15 +9,6 @@ import (
 	"strings"
 )
 
-// Severity tags a Finding so callers can decide how to react.
-type Severity string
-
-const (
-	SeverityError   Severity = "error"
-	SeverityWarning Severity = "warning"
-	SeverityInfo    Severity = "info"
-)
-
 // Category groups checks of the same concern so callers can opt in by
 // category via CLI flags. New categories are added as new check sets land —
 // see docs/migration_preflight_issue.md for the planned ones.
@@ -27,10 +18,10 @@ const (
 	CategoryConnectivity Category = "connectivity"
 )
 
-// Finding describes a single issue detected by a Check.
+// Finding describes a single issue detected by a Check. Every finding is an
+// error — a check that finds nothing wrong returns no findings at all.
 type Finding struct {
-	Severity Severity `json:"severity"`
-	Message  string   `json:"message"`
+	Message string `json:"message"`
 }
 
 // Check is the minimal contract every preflight check must satisfy. Run returns
@@ -111,17 +102,11 @@ func Run(ctx context.Context, checks []Check, opts ...RunOption) Report {
 	return Report{Results: results}
 }
 
-// HasErrors reports whether any check produced an error-tier finding or failed
-// to complete.
+// HasErrors reports whether any check produced findings or failed to complete.
 func (r Report) HasErrors() bool {
 	for _, res := range r.Results {
-		if res.Err != nil {
+		if res.Err != nil || len(res.Findings) > 0 {
 			return true
-		}
-		for _, f := range res.Findings {
-			if f.Severity == SeverityError {
-				return true
-			}
 		}
 	}
 	return false
@@ -131,40 +116,17 @@ func (r Report) HasErrors() bool {
 func (r Report) PrettyPrint() string {
 	var sb strings.Builder
 	for _, res := range r.Results {
-		passed := res.Err == nil && !hasBlockingFindings(res.Findings)
-		switch {
-		case passed && len(res.Findings) == 0:
+		if res.Err == nil && len(res.Findings) == 0 {
 			fmt.Fprintf(&sb, "✔ %s\n", res.Name)
-		case passed:
-			fmt.Fprintf(&sb, "✔ %s (with notes)\n", res.Name)
+			continue
 		}
 		if res.Err != nil {
 			fmt.Fprintf(&sb, "✘ %s: check failed: %v\n", res.Name, res.Err)
 		}
 		for _, f := range res.Findings {
-			fmt.Fprintf(&sb, "%s %s: %s\n", severityMarker(f.Severity), res.Name, f.Message)
+			fmt.Fprintf(&sb, "✘ %s: %s\n", res.Name, f.Message)
 		}
 	}
 	fmt.Fprintf(&sb, "ran %d checks\n", len(r.Results))
 	return sb.String()
-}
-
-func hasBlockingFindings(findings []Finding) bool {
-	for _, f := range findings {
-		if f.Severity == SeverityError || f.Severity == SeverityWarning {
-			return true
-		}
-	}
-	return false
-}
-
-func severityMarker(s Severity) string {
-	switch s {
-	case SeverityError:
-		return "✘"
-	case SeverityWarning:
-		return "⚠"
-	default:
-		return "ℹ"
-	}
 }

--- a/pkg/stream/preflight/preflight_test.go
+++ b/pkg/stream/preflight/preflight_test.go
@@ -35,7 +35,7 @@ func TestRun_RunsAllChecksEvenWhenSomeFail(t *testing.T) {
 
 	checks := []Check{
 		&stubCheck{name: "a", ran: &ranA, err: checkErr},
-		&stubCheck{name: "b", ran: &ranB, findings: []Finding{{Severity: SeverityError, Message: "broken"}}},
+		&stubCheck{name: "b", ran: &ranB, findings: []Finding{{Message: "broken"}}},
 		&stubCheck{name: "c", ran: &ranC},
 	}
 
@@ -53,26 +53,13 @@ func TestRun_RunsAllChecksEvenWhenSomeFail(t *testing.T) {
 
 	require.Equal(t, "b", report.Results[1].Name)
 	require.NoError(t, report.Results[1].Err)
-	require.Equal(t, []Finding{{Severity: SeverityError, Message: "broken"}}, report.Results[1].Findings)
+	require.Equal(t, []Finding{{Message: "broken"}}, report.Results[1].Findings)
 
 	require.Equal(t, "c", report.Results[2].Name)
 	require.NoError(t, report.Results[2].Err)
 	require.Empty(t, report.Results[2].Findings)
 
 	require.True(t, report.HasErrors())
-}
-
-func TestRun_HasErrorsFalseWhenOnlyWarningsAndInfo(t *testing.T) {
-	t.Parallel()
-
-	checks := []Check{
-		&stubCheck{name: "warn", findings: []Finding{{Severity: SeverityWarning, Message: "heads up"}}},
-		&stubCheck{name: "info", findings: []Finding{{Severity: SeverityInfo, Message: "fyi"}}},
-	}
-
-	report := Run(context.Background(), checks)
-
-	require.False(t, report.HasErrors())
 }
 
 func TestRun_EmptyChecksProducesEmptyReport(t *testing.T) {
@@ -84,24 +71,23 @@ func TestRun_EmptyChecksProducesEmptyReport(t *testing.T) {
 	require.False(t, report.HasErrors())
 }
 
-func TestReport_PrettyPrint_InfoOnlyShowsAsPassed(t *testing.T) {
+func TestReport_PrettyPrint(t *testing.T) {
 	t.Parallel()
 
 	report := Report{
 		Results: []CheckResult{
 			{Name: "clean"},
-			{Name: "info-only", Findings: []Finding{{Severity: SeverityInfo, Message: "fyi"}}},
-			{Name: "with-warning", Findings: []Finding{{Severity: SeverityWarning, Message: "heads up"}}},
+			{Name: "with-findings", Findings: []Finding{{Message: "broken"}}},
+			{Name: "check-failed", Err: errors.New("boom")},
 		},
 	}
 
 	out := report.PrettyPrint()
 
 	require.Contains(t, out, "✔ clean\n")
-	require.Contains(t, out, "✔ info-only (with notes)\n")
-	require.Contains(t, out, "ℹ info-only: fyi\n")
-	require.NotContains(t, out, "✔ with-warning")
-	require.Contains(t, out, "⚠ with-warning: heads up\n")
+	require.Contains(t, out, "✘ with-findings: broken\n")
+	require.Contains(t, out, "✘ check-failed: check failed: boom\n")
+	require.Contains(t, out, "ran 3 checks\n")
 }
 
 func TestReport_JSONMarshal(t *testing.T) {
@@ -111,7 +97,7 @@ func TestReport_JSONMarshal(t *testing.T) {
 		Results: []CheckResult{
 			{
 				Name:     "a",
-				Findings: []Finding{{Severity: SeverityError, Message: "broken"}},
+				Findings: []Finding{{Message: "broken"}},
 			},
 			{
 				Name: "b",
@@ -124,7 +110,7 @@ func TestReport_JSONMarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := `{"results":[` +
-		`{"name":"a","findings":[{"severity":"error","message":"broken"}]},` +
+		`{"name":"a","findings":[{"message":"broken"}]},` +
 		`{"name":"b","findings":null,"error":"boom"}` +
 		`]}`
 	require.JSONEq(t, expected, string(data))

--- a/pkg/stream/preflight/preflight_test.go
+++ b/pkg/stream/preflight/preflight_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stubCheck struct {
+	name     string
+	findings []Finding
+	err      error
+	ran      *bool
+}
+
+func (s *stubCheck) Name() string { return s.name }
+
+func (s *stubCheck) Run(_ context.Context) ([]Finding, error) {
+	if s.ran != nil {
+		*s.ran = true
+	}
+	return s.findings, s.err
+}
+
+func TestRun_RunsAllChecksEvenWhenSomeFail(t *testing.T) {
+	t.Parallel()
+
+	ranA, ranB, ranC := false, false, false
+	checkErr := errors.New("boom")
+
+	checks := []Check{
+		&stubCheck{name: "a", ran: &ranA, err: checkErr},
+		&stubCheck{name: "b", ran: &ranB, findings: []Finding{{Severity: SeverityError, Message: "broken"}}},
+		&stubCheck{name: "c", ran: &ranC},
+	}
+
+	report := Run(context.Background(), checks)
+
+	require.True(t, ranA, "check a should have run")
+	require.True(t, ranB, "check b should have run despite check a's error")
+	require.True(t, ranC, "check c should have run despite check b's finding")
+
+	require.Len(t, report.Results, 3)
+
+	require.Equal(t, "a", report.Results[0].Name)
+	require.ErrorIs(t, report.Results[0].Err, checkErr)
+	require.Empty(t, report.Results[0].Findings)
+
+	require.Equal(t, "b", report.Results[1].Name)
+	require.NoError(t, report.Results[1].Err)
+	require.Equal(t, []Finding{{Severity: SeverityError, Message: "broken"}}, report.Results[1].Findings)
+
+	require.Equal(t, "c", report.Results[2].Name)
+	require.NoError(t, report.Results[2].Err)
+	require.Empty(t, report.Results[2].Findings)
+
+	require.True(t, report.HasErrors())
+}
+
+func TestRun_HasErrorsFalseWhenOnlyWarningsAndInfo(t *testing.T) {
+	t.Parallel()
+
+	checks := []Check{
+		&stubCheck{name: "warn", findings: []Finding{{Severity: SeverityWarning, Message: "heads up"}}},
+		&stubCheck{name: "info", findings: []Finding{{Severity: SeverityInfo, Message: "fyi"}}},
+	}
+
+	report := Run(context.Background(), checks)
+
+	require.False(t, report.HasErrors())
+}
+
+func TestRun_EmptyChecksProducesEmptyReport(t *testing.T) {
+	t.Parallel()
+
+	report := Run(context.Background(), nil)
+
+	require.Empty(t, report.Results)
+	require.False(t, report.HasErrors())
+}
+
+func TestReport_PrettyPrint_InfoOnlyShowsAsPassed(t *testing.T) {
+	t.Parallel()
+
+	report := Report{
+		Results: []CheckResult{
+			{Name: "clean"},
+			{Name: "info-only", Findings: []Finding{{Severity: SeverityInfo, Message: "fyi"}}},
+			{Name: "with-warning", Findings: []Finding{{Severity: SeverityWarning, Message: "heads up"}}},
+		},
+	}
+
+	out := report.PrettyPrint()
+
+	require.Contains(t, out, "✔ clean\n")
+	require.Contains(t, out, "✔ info-only (with notes)\n")
+	require.Contains(t, out, "ℹ info-only: fyi\n")
+	require.NotContains(t, out, "✔ with-warning")
+	require.Contains(t, out, "⚠ with-warning: heads up\n")
+}
+
+func TestReport_JSONMarshal(t *testing.T) {
+	t.Parallel()
+
+	report := Report{
+		Results: []CheckResult{
+			{
+				Name:     "a",
+				Findings: []Finding{{Severity: SeverityError, Message: "broken"}},
+			},
+			{
+				Name: "b",
+				Err:  errors.New("boom"),
+			},
+		},
+	}
+
+	data, err := json.Marshal(report)
+	require.NoError(t, err)
+
+	expected := `{"results":[` +
+		`{"name":"a","findings":[{"severity":"error","message":"broken"}]},` +
+		`{"name":"b","findings":null,"error":"boom"}` +
+		`]}`
+	require.JSONEq(t, expected, string(data))
+}

--- a/pkg/stream/preflight/preflight_test.go
+++ b/pkg/stream/preflight/preflight_test.go
@@ -71,23 +71,40 @@ func TestRun_EmptyChecksProducesEmptyReport(t *testing.T) {
 	require.False(t, report.HasErrors())
 }
 
-func TestReport_PrettyPrint(t *testing.T) {
+func TestReportPrinter_PrettyPrint(t *testing.T) {
 	t.Parallel()
 
-	report := Report{
+	printer := ReportPrinter{Report: Report{
 		Results: []CheckResult{
 			{Name: "clean"},
 			{Name: "with-findings", Findings: []Finding{{Message: "broken"}}},
 			{Name: "check-failed", Err: errors.New("boom")},
 		},
-	}
+	}}
 
-	out := report.PrettyPrint()
+	out := printer.PrettyPrint()
 
 	require.Contains(t, out, "✔ clean\n")
 	require.Contains(t, out, "✘ with-findings: broken\n")
 	require.Contains(t, out, "✘ check-failed: check failed: boom\n")
 	require.Contains(t, out, "ran 3 checks\n")
+}
+
+func TestReportPrinter_MarshalJSONDelegatesToReport(t *testing.T) {
+	t.Parallel()
+
+	report := Report{
+		Results: []CheckResult{
+			{Name: "a", Findings: []Finding{{Message: "broken"}}},
+		},
+	}
+
+	viaReport, err := json.Marshal(report)
+	require.NoError(t, err)
+	viaPrinter, err := json.Marshal(ReportPrinter{Report: report})
+	require.NoError(t, err)
+
+	require.JSONEq(t, string(viaReport), string(viaPrinter))
 }
 
 func TestReport_JSONMarshal(t *testing.T) {

--- a/pkg/stream/preflight/printer.go
+++ b/pkg/stream/preflight/printer.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ReportPrinter renders a Report for display. It satisfies the cmd-side
+// printer contract (PrettyPrint string + json.Marshaler), so existing
+// print(cmd, p) helpers can drive it without change. Flag-driven rendering
+// options (NoColor, Verbose, …) will live on this struct.
+type ReportPrinter struct {
+	Report Report
+}
+
+// PrettyPrint renders the report as a human-readable string.
+func (p ReportPrinter) PrettyPrint() string {
+	var sb strings.Builder
+	for _, res := range p.Report.Results {
+		if res.Err == nil && len(res.Findings) == 0 {
+			fmt.Fprintf(&sb, "✔ %s\n", res.Name)
+			continue
+		}
+		if res.Err != nil {
+			fmt.Fprintf(&sb, "✘ %s: check failed: %v\n", res.Name, res.Err)
+		}
+		for _, f := range res.Findings {
+			fmt.Fprintf(&sb, "✘ %s: %s\n", res.Name, f.Message)
+		}
+	}
+	fmt.Fprintf(&sb, "ran %d checks\n", len(p.Report.Results))
+	return sb.String()
+}
+
+// MarshalJSON delegates to the underlying Report so a printer marshals to the
+// same shape as the data type it wraps.
+func (p ReportPrinter) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.Report)
+}


### PR DESCRIPTION
#### Description

This PR adds a new preflight check named `connectivity`.

The check command builds a list of `preflight.Check` instances from `*stream.Config` via a category registry (`Builders`), runs them through a `preflight.Run` engine that captures every error without stopping on individual failures, and hands the resulting `Report` to a `ReportPrinter` that renders human or JSON output. `Categories` (today only connectivity) are selected by per-category boolean flags on `pgstream check`. If no category is selected, `pgstream` runs all of them.

Adding a new check is a mechanical edit:
* one struct satisfying the two-method `Check` interface
* one entry in Builders
* one CLI flag

There is a Claude file to aid adding a new check.

##### Related Issue(s)

- Related to #897 

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Added connectivity check for pg2pg connections
- `pkg/stream/preflight` package for storing building blocks
- Added a new Claude file for adding new checks.

#### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
