### PR TITLE
Add replication checks

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -24,7 +24,7 @@
         },
         {
           "name": "replication",
-          "description": "Run replication-preflight checks against the source (requires replication slot configured)",
+          "description": "Run replication checks against the source (requires replication slot configured)",
           "default": "false"
         },
         {

--- a/cli-definition.json
+++ b/cli-definition.json
@@ -23,6 +23,11 @@
           "default": ""
         },
         {
+          "name": "replication",
+          "description": "Run replication-preflight checks against the source (requires replication slot configured)",
+          "default": "false"
+        },
+        {
           "name": "target-url",
           "description": "Target URL to run checks against",
           "default": ""

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -120,6 +120,7 @@ func Prepare() *cobra.Command {
 	checkCmd.Flags().String("target-url", "", "Target URL to run checks against")
 	checkCmd.Flags().Bool("json", false, "Output the check report in JSON format")
 	checkCmd.Flags().Bool("connectivity", false, "Run connectivity checks against the configured source and target")
+	checkCmd.Flags().Bool("replication", false, "Run replication-preflight checks against the source (requires replication slot configured)")
 
 	// Flag binding for root cmd
 	rootFlagBinding(rootCmd)

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -120,7 +120,7 @@ func Prepare() *cobra.Command {
 	checkCmd.Flags().String("target-url", "", "Target URL to run checks against")
 	checkCmd.Flags().Bool("json", false, "Output the check report in JSON format")
 	checkCmd.Flags().Bool("connectivity", false, "Run connectivity checks against the configured source and target")
-	checkCmd.Flags().Bool("replication", false, "Run replication-preflight checks against the source (requires replication slot configured)")
+	checkCmd.Flags().Bool("replication", false, "Run replication checks against the source (requires replication slot configured)")
 
 	// Flag binding for root cmd
 	rootFlagBinding(rootCmd)

--- a/pkg/stream/preflight/CLAUDE.md
+++ b/pkg/stream/preflight/CLAUDE.md
@@ -7,7 +7,7 @@ Guidance for Claude Code when working inside `pkg/stream/preflight`. The planned
 - `preflight.go` — `Check` interface (`Name()` + `Run(ctx) ([]Finding, error)`), `Finding`, `CheckResult`, `Report`, `Run(ctx, []Check, ...RunOption)` engine.
 - `printer.go` — `ReportPrinter{Report}` is the only thing that formats reports. The `Report` struct itself stays pure data.
 - `builder.go` — `Builder` struct, `Builders` registry slice, per-category builder functions (`BuildConnectivityChecks`, …), `BuildChecks(cfg, selected)`.
-- One file per concrete check (`connectivity.go`, future `wal_level.go`, …).
+- One file per category of concrete checks (`connectivity.go`, `replication.go`, …).
 
 ## Adding a new check
 

--- a/pkg/stream/preflight/builder.go
+++ b/pkg/stream/preflight/builder.go
@@ -17,6 +17,7 @@ type Builder struct {
 // Builder entry here + one flag declaration on checkCmd.
 var Builders = []Builder{
 	{CategoryConnectivity, "connectivity", BuildConnectivityChecks},
+	{CategoryReplication, "replication", BuildReplicationChecks},
 }
 
 // BuildConnectivityChecks returns the connectivity checks applicable to cfg.
@@ -33,6 +34,26 @@ func BuildConnectivityChecks(cfg *stream.Config) []Check {
 		}
 	}
 	return checks
+}
+
+// BuildReplicationChecks returns the replication-preflight checks applicable
+// to cfg. Replication checks only apply when the source is configured with a
+// replication slot (i.e. the run is doing logical replication, not a one-shot
+// snapshot).
+func BuildReplicationChecks(cfg *stream.Config) []Check {
+	if cfg.PostgresReplicationSlot() == "" {
+		return nil
+	}
+	url := cfg.SourcePostgresURL()
+	if url == "" {
+		return nil
+	}
+	return []Check{
+		&WALLevelCheck{URL: url},
+		&WAL2JSONCheck{URL: url},
+		&ReplicationSlotHeadroomCheck{URL: url},
+		&ReplicationRoleAttrCheck{URL: url},
+	}
 }
 
 // BuildChecks returns the concrete checks for the selected categories,

--- a/pkg/stream/preflight/preflight.go
+++ b/pkg/stream/preflight/preflight.go
@@ -14,6 +14,7 @@ type Category string
 
 const (
 	CategoryConnectivity Category = "connectivity"
+	CategoryReplication  Category = "replication"
 )
 
 // Finding describes a single issue detected by a Check. Every finding is an

--- a/pkg/stream/preflight/replication.go
+++ b/pkg/stream/preflight/replication.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/xataio/pgstream/internal/postgres"
+)
+
+// WALLevelCheck verifies the source Postgres has `wal_level=logical`, which
+// pgstream's replication path requires.
+type WALLevelCheck struct {
+	URL string
+}
+
+func (c *WALLevelCheck) Name() string { return "wal_level" }
+
+func (c *WALLevelCheck) Run(ctx context.Context) ([]Finding, error) {
+	conn, err := postgres.NewConn(ctx, c.URL)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to source: %w", err)
+	}
+	defer conn.Close(ctx)
+
+	var level string
+	if err := conn.QueryRow(ctx, []any{&level}, "SHOW wal_level"); err != nil {
+		return nil, fmt.Errorf("querying wal_level: %w", err)
+	}
+	if level != "logical" {
+		return []Finding{{
+			Message: fmt.Sprintf("wal_level=%q on source; set wal_level=logical in postgresql.conf and restart for logical replication", level),
+		}}, nil
+	}
+	return nil, nil
+}
+
+// WAL2JSONCheck verifies that the wal2json output plugin is installed and
+// loadable on the source. pgstream decodes WAL through wal2json.
+type WAL2JSONCheck struct {
+	URL string
+}
+
+func (c *WAL2JSONCheck) Name() string { return "wal2json" }
+
+func (c *WAL2JSONCheck) Run(ctx context.Context) ([]Finding, error) {
+	conn, err := postgres.NewConn(ctx, c.URL)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to source: %w", err)
+	}
+	defer conn.Close(ctx)
+
+	var present int
+	if err := conn.QueryRow(ctx, []any{&present}, "SELECT count(*)::int FROM pg_available_extensions WHERE name = 'wal2json'"); err != nil {
+		return nil, fmt.Errorf("querying pg_available_extensions: %w", err)
+	}
+	if present == 0 {
+		return []Finding{{
+			Message: "wal2json output plugin not available on source; install the wal2json package and verify it appears in pg_available_extensions",
+		}}, nil
+	}
+	return nil, nil
+}
+
+// ReplicationSlotHeadroomCheck reports whether the source has at least one
+// slot still available before max_replication_slots is reached.
+type ReplicationSlotHeadroomCheck struct {
+	URL string
+}
+
+func (c *ReplicationSlotHeadroomCheck) Name() string { return "replication_slot_headroom" }
+
+func (c *ReplicationSlotHeadroomCheck) Run(ctx context.Context) ([]Finding, error) {
+	conn, err := postgres.NewConn(ctx, c.URL)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to source: %w", err)
+	}
+	defer conn.Close(ctx)
+
+	var maxSlots, usedSlots int
+	err = conn.QueryRow(ctx, []any{&maxSlots, &usedSlots}, `
+		SELECT
+		  (SELECT setting::int FROM pg_settings WHERE name = 'max_replication_slots'),
+		  (SELECT count(*)::int FROM pg_replication_slots)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying replication slots: %w", err)
+	}
+	if usedSlots >= maxSlots {
+		return []Finding{{
+			Message: fmt.Sprintf("no replication slot headroom: %d/%d slots in use; raise max_replication_slots (requires restart) or drop unused slots", usedSlots, maxSlots),
+		}}, nil
+	}
+	return nil, nil
+}
+
+// ReplicationRoleAttrCheck verifies the current source role has the
+// REPLICATION attribute, which is required to open a logical replication slot.
+type ReplicationRoleAttrCheck struct {
+	URL string
+}
+
+func (c *ReplicationRoleAttrCheck) Name() string { return "replication_role_attr" }
+
+func (c *ReplicationRoleAttrCheck) Run(ctx context.Context) ([]Finding, error) {
+	conn, err := postgres.NewConn(ctx, c.URL)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to source: %w", err)
+	}
+	defer conn.Close(ctx)
+
+	var roleName string
+	var hasReplication bool
+	if err := conn.QueryRow(ctx, []any{&roleName, &hasReplication}, "SELECT rolname, rolreplication FROM pg_roles WHERE rolname = current_user"); err != nil {
+		return nil, fmt.Errorf("querying pg_roles: %w", err)
+	}
+	if !hasReplication {
+		return []Finding{{
+			Message: fmt.Sprintf("source role %q lacks the REPLICATION attribute; run ALTER ROLE %s REPLICATION as a superuser", roleName, roleName),
+		}}, nil
+	}
+	return nil, nil
+}


### PR DESCRIPTION
#### Description

This PR adds the `replication` preflight category with four checks against the source Postgres: `wal_level=logical`, `wal2json` availability, replication slot headroom, and source role `REPLICATION` attribute.

Replication checks are only built when a replication slot is configured (one-shot snapshots are unaffected).


It implements items 1–4 of the replication section of https://github.com/xataio/pgstream/issues/897; the per-table checks (REPLICA IDENTITY, PK presence, unreplicatable tables) are going to be implemented in a follow-up PR. Also, as a follow-up I am going to refactor connection handling of each category. At the moment each check opens its own connection. In the future they are going to share the connection.


#### Example output

```
$ pgstream check --replication -c pg2pg.yaml
✔ wal_level
✘ wal2json: wal2json output plugin not available on source; install the
  wal2json package and verify it appears in pg_available_extensions
✔ replication_slot_headroom
✔ replication_role_attr
ran 4 checks

Error: checks reported errors
```

##### Related Issue(s)

- Related to https://github.com/xataio/pgstream/issues/897

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [ ] Documentation updated where necessary