### PR TITLE
Skip legacy public PL/pgSQL handler functions on snapshot restore

### DIFF
--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -500,9 +500,18 @@ func (s *SnapshotGenerator) parseDump(d []byte) *dump {
 	alterTable := ""
 	createEventTrigger := ""
 	createView := ""
+	skipLegacyPLPGSQLHandlerFunction := false
 	for scanner.Scan() {
 		line := scanner.Text()
 		switch {
+		case skipLegacyPLPGSQLHandlerFunction:
+			if strings.HasSuffix(line, ";") {
+				skipLegacyPLPGSQLHandlerFunction = false
+			}
+			continue
+		case isLegacyPLPGSQLHandlerFunctionStart(line):
+			skipLegacyPLPGSQLHandlerFunction = !strings.HasSuffix(line, ";")
+			continue
 		case strings.HasPrefix(line, "SECURITY LABEL") &&
 			isSecurityLabelForExcludedProvider(line, s.excludedSecurityLabels):
 			// skip security labels if configured to do so for the specified providers
@@ -626,6 +635,11 @@ func (s *SnapshotGenerator) parseDump(d []byte) *dump {
 		roles:                 dumpRoles,
 		eventTriggers:         []byte(eventTriggersDump.String()),
 	}
+}
+
+func isLegacyPLPGSQLHandlerFunctionStart(line string) bool {
+	return strings.HasPrefix(line, "CREATE FUNCTION public.plpgsql_call_handler() RETURNS language_handler") ||
+		strings.HasPrefix(line, "CREATE FUNCTION public.plpgsql_validator(oid) RETURNS void")
 }
 
 func (s *SnapshotGenerator) filterTriggers(eventTriggersDump []byte, excludedSchemas []string) []byte {

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
@@ -1415,6 +1415,29 @@ func TestSnapshotGenerator_parseDump(t *testing.T) {
 	require.Equal(t, wantViewsStr, viewsStr)
 }
 
+func TestSnapshotGenerator_parseDumpSkipsLegacyPublicPLPGSQLHandlers(t *testing.T) {
+	t.Parallel()
+
+	dumpBytes := []byte(`CREATE FUNCTION public.plpgsql_call_handler() RETURNS language_handler
+    LANGUAGE c
+    AS '$libdir/plpgsql', 'plpgsql_call_handler';
+
+CREATE FUNCTION public.plpgsql_validator(oid) RETURNS void
+    LANGUAGE c
+    AS '$libdir/plpgsql', 'plpgsql_validator';
+
+CREATE FUNCTION public.keep_me() RETURNS integer
+    LANGUAGE sql
+    AS $$ SELECT 1 $$;
+`)
+
+	dump := (&SnapshotGenerator{}).parseDump(dumpBytes)
+
+	require.NotContains(t, string(dump.filtered), "CREATE FUNCTION public.plpgsql_call_handler()")
+	require.NotContains(t, string(dump.filtered), "CREATE FUNCTION public.plpgsql_validator(oid)")
+	require.Contains(t, string(dump.filtered), "CREATE FUNCTION public.keep_me() RETURNS integer")
+}
+
 func TestGetDumpsDiff(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/stream/integration/snapshot_pg_integration_test.go
+++ b/pkg/stream/integration/snapshot_pg_integration_test.go
@@ -436,6 +436,70 @@ func Test_SnapshotToPostgres_LtreeColumns(t *testing.T) {
 	})
 }
 
+// Test_SnapshotToPostgres_SkipsLegacyPLPGSQLHandlers verifies that legacy
+// public PL/pgSQL handler functions from a source dump are not restored as
+// ordinary user functions, while normal user-defined functions are preserved.
+func Test_SnapshotToPostgres_SkipsLegacyPLPGSQLHandlers(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	var snapshotPGURL string
+	pgcleanup, err := testcontainers.SetupPostgresContainer(context.Background(), &snapshotPGURL, testcontainers.Postgres14, "config/postgresql.conf")
+	require.NoError(t, err)
+	defer pgcleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	suffix := time.Now().UnixNano()
+	testTable := fmt.Sprintf("legacy_plpgsql_snapshot_%d", suffix)
+	regularFunction := fmt.Sprintf("snapshot_regular_fn_%d", suffix)
+
+	execQueryWithURL(t, ctx, snapshotPGURL, `
+		CREATE FUNCTION public.plpgsql_call_handler() RETURNS language_handler
+		AS '$libdir/plpgsql', 'plpgsql_call_handler'
+		LANGUAGE C`)
+	execQueryWithURL(t, ctx, snapshotPGURL, `
+		CREATE FUNCTION public.plpgsql_validator(oid) RETURNS void
+		AS '$libdir/plpgsql', 'plpgsql_validator'
+		LANGUAGE C`)
+	execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+		`CREATE FUNCTION public.%s() RETURNS integer
+		LANGUAGE plpgsql
+		AS $$ BEGIN RETURN 42; END $$`, regularFunction))
+	execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+		`CREATE TABLE %s(id integer PRIMARY KEY)`, testTable))
+	execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+		`INSERT INTO %s(id) VALUES (1)`, testTable))
+
+	cfg := &stream.Config{
+		Listener:  testPostgresListenerCfgWithSnapshot(snapshotPGURL, targetPGURL, []string{"public.*"}),
+		Processor: testPostgresProcessorCfg(),
+	}
+	require.NoError(t, stream.Snapshot(ctx, testLogger(), cfg, nil))
+
+	targetConn, err := pglib.NewConn(ctx, targetPGURL)
+	require.NoError(t, err)
+	defer targetConn.Close(ctx)
+
+	var legacyHandlerCount int
+	err = targetConn.QueryRow(ctx, []any{&legacyHandlerCount}, `
+		SELECT count(*)
+		FROM pg_proc p
+		JOIN pg_namespace n ON n.oid = p.pronamespace
+		WHERE n.nspname = 'public'
+		  AND p.proname IN ('plpgsql_call_handler', 'plpgsql_validator')
+	`)
+	require.NoError(t, err)
+	require.Zero(t, legacyHandlerCount)
+
+	var got int
+	err = targetConn.QueryRow(ctx, []any{&got}, fmt.Sprintf("SELECT public.%s()", regularFunction))
+	require.NoError(t, err)
+	require.Equal(t, 42, got)
+}
+
 // Test_SnapshotToPostgres_IdentityAndGeneratedColumns verifies that identity
 // columns have their values preserved while generated (stored) columns are
 // correctly excluded from inserts and recomputed by the target database.


### PR DESCRIPTION
## Problem
Databases created on/upgraded through older PostgreSQL versions can carry leftover `public.plpgsql_call_handler()` and `public.plpgsql_validator(oid)` C-language function definitions that point at `$libdir/plpgsql`. These are normally provided by the `plpgsql` extension itself; restoring them as ordinary user functions on the target conflicts/errors during a snapshot restore.

## Fix
`parseDump` now detects and skips these two legacy handler function definitions while preserving all genuine user-defined functions.

## Testing
- Unit: `TestSnapshotGenerator_parseDumpSkipsLegacyPublicPLPGSQLHandlers` (confirms a normal `keep_me()` function survives)
- Integration: `Test_SnapshotToPostgres_SkipsLegacyPLPGSQLHandlers`
- `go test ./pkg/snapshot/generator/postgres/schema/pgdumprestore/...`

---
Cherry-picked from [@danddanddand](https://github.com/danddanddand/pgstream) (`fix/skip-legacy-plpgsql-handlers`).