### PR TITLE
Add preflight check for source SELECT privileges

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -8,6 +8,11 @@
       "example": "\n\tpgstream check -c pg2pg.env\n\tpgstream check -c pg2pg.yaml --json\n\t",
       "flags": [
         {
+          "name": "access",
+          "description": "Run access and privilege checks against the source",
+          "default": "false"
+        },
+        {
           "name": "connectivity",
           "description": "Run connectivity checks against the configured source and target",
           "default": "false"

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -121,6 +121,7 @@ func Prepare() *cobra.Command {
 	checkCmd.Flags().Bool("json", false, "Output the check report in JSON format")
 	checkCmd.Flags().Bool("connectivity", false, "Run connectivity checks against the configured source and target")
 	checkCmd.Flags().Bool("replication", false, "Run replication checks against the source (requires replication slot configured)")
+	checkCmd.Flags().Bool("access", false, "Run access and privilege checks against the source")
 
 	// Flag binding for root cmd
 	rootFlagBinding(rootCmd)

--- a/pkg/stream/preflight/access.go
+++ b/pkg/stream/preflight/access.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/xataio/pgstream/internal/postgres"
+)
+
+// SourceTableSelectPrivilegesCheck verifies that the source Postgres role can
+// read every table pgstream may need to snapshot or replicate.
+type SourceTableSelectPrivilegesCheck struct {
+	Source         postgres.AcquireFunc
+	Tables         []string
+	ExcludedTables []string
+}
+
+func (c *SourceTableSelectPrivilegesCheck) Name() string {
+	return "source_table_select_privileges"
+}
+
+const sourceTableSelectPrivilegesQuery = `
+SELECT
+  current_user,
+  n.nspname,
+  c.relname,
+  has_table_privilege(c.oid, 'SELECT') AS has_select
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind IN ('r', 'p')
+  AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pgstream')
+  AND n.nspname NOT LIKE 'pg_toast%'
+ORDER BY n.nspname, c.relname
+`
+
+func (c *SourceTableSelectPrivilegesCheck) Run(ctx context.Context) ([]Finding, error) {
+	include, exclude, err := c.scopeMaps()
+	if err != nil {
+		return nil, fmt.Errorf("parsing table selection: %w", err)
+	}
+
+	conn, err := c.Source(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to source: %w", err)
+	}
+
+	rows, err := conn.Query(ctx, sourceTableSelectPrivilegesQuery)
+	if err != nil {
+		return nil, fmt.Errorf("querying source table privileges: %w", err)
+	}
+	defer rows.Close()
+
+	var findings []Finding
+	for rows.Next() {
+		var row sourceTableSelectPrivilegeRow
+		if err := rows.Scan(&row.Role, &row.Schema, &row.Table, &row.HasSelect); err != nil {
+			return nil, fmt.Errorf("scanning row: %w", err)
+		}
+		if !tableInScope(row.Schema, row.Table, include, exclude) {
+			continue
+		}
+		if !row.HasSelect {
+			findings = append(findings, Finding{Message: sourceTableSelectPrivilegeMessage(row)})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating rows: %w", err)
+	}
+	return findings, nil
+}
+
+type sourceTableSelectPrivilegeRow struct {
+	Role      string
+	Schema    string
+	Table     string
+	HasSelect bool
+}
+
+func (c *SourceTableSelectPrivilegesCheck) scopeMaps() (include, exclude postgres.SchemaTableMap, err error) {
+	if len(c.Tables) > 0 {
+		include, err = postgres.NewSchemaTableMap(c.Tables)
+		if err != nil {
+			return nil, nil, fmt.Errorf("include: %w", err)
+		}
+	}
+	if len(c.ExcludedTables) > 0 {
+		exclude, err = postgres.NewSchemaTableMap(c.ExcludedTables)
+		if err != nil {
+			return nil, nil, fmt.Errorf("exclude: %w", err)
+		}
+	}
+	return include, exclude, nil
+}
+
+func tableInScope(schema, table string, include, exclude postgres.SchemaTableMap) bool {
+	if exclude != nil && exclude.ContainsSchemaTable(schema, table) {
+		return false
+	}
+	if include != nil {
+		return include.ContainsSchemaTable(schema, table)
+	}
+	return true
+}
+
+func sourceTableSelectPrivilegeMessage(row sourceTableSelectPrivilegeRow) string {
+	table := qualifiedTable(row.Schema, row.Table)
+	return fmt.Sprintf("source role %q lacks SELECT on %s; run GRANT SELECT ON TABLE %s TO %s", row.Role, table, table, row.Role)
+}
+
+func qualifiedTable(schema, table string) string {
+	return fmt.Sprintf("%s.%s", schema, table)
+}

--- a/pkg/stream/preflight/access_test.go
+++ b/pkg/stream/preflight/access_test.go
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/postgres/mocks"
+	"github.com/xataio/pgstream/pkg/stream"
+	"github.com/xataio/pgstream/pkg/wal/listener/snapshot/adapter"
+	snapshotbuilder "github.com/xataio/pgstream/pkg/wal/listener/snapshot/builder"
+)
+
+func TestSourceTableSelectPrivilegesCheck_Run_AllTablesHaveSelect(t *testing.T) {
+	t.Parallel()
+
+	check := &SourceTableSelectPrivilegesCheck{
+		Source: sourceWithRows(t, []sourceTableSelectPrivilegeRow{
+			{Role: "pgstream_user", Schema: "public", Table: "orders", HasSelect: true},
+			{Role: "pgstream_user", Schema: "public", Table: "users", HasSelect: true},
+		}),
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.NoError(t, err)
+	require.Empty(t, findings)
+}
+
+func TestSourceTableSelectPrivilegesCheck_Run_MissingSelectReturnsFinding(t *testing.T) {
+	t.Parallel()
+
+	check := &SourceTableSelectPrivilegesCheck{
+		Source: sourceWithRows(t, []sourceTableSelectPrivilegeRow{
+			{Role: "pgstream_user", Schema: "public", Table: "orders", HasSelect: false},
+			{Role: "pgstream_user", Schema: "public", Table: "users", HasSelect: true},
+		}),
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Message, `source role "pgstream_user"`)
+	require.Contains(t, findings[0].Message, "public.orders")
+	require.Contains(t, findings[0].Message, "GRANT SELECT")
+}
+
+func TestSourceTableSelectPrivilegesCheck_Run_MultipleMissingSelect(t *testing.T) {
+	t.Parallel()
+
+	check := &SourceTableSelectPrivilegesCheck{
+		Source: sourceWithRows(t, []sourceTableSelectPrivilegeRow{
+			{Role: "pgstream_user", Schema: "billing", Table: "invoices", HasSelect: false},
+			{Role: "pgstream_user", Schema: "public", Table: "orders", HasSelect: false},
+		}),
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, findings, 2)
+	require.Contains(t, findings[0].Message, "billing.invoices")
+	require.Contains(t, findings[1].Message, "public.orders")
+}
+
+func TestSourceTableSelectPrivilegesCheck_Run_SourceAcquireFails(t *testing.T) {
+	t.Parallel()
+
+	checkErr := errors.New("boom")
+	check := &SourceTableSelectPrivilegesCheck{
+		Source: func(context.Context) (postgres.Querier, error) {
+			return nil, checkErr
+		},
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.Nil(t, findings)
+	require.ErrorIs(t, err, checkErr)
+	require.ErrorContains(t, err, "connecting to source")
+}
+
+func TestSourceTableSelectPrivilegesCheck_Run_QueryFails(t *testing.T) {
+	t.Parallel()
+
+	queryErr := errors.New("query failed")
+	check := &SourceTableSelectPrivilegesCheck{
+		Source: func(context.Context) (postgres.Querier, error) {
+			return &mocks.Querier{
+				QueryFn: func(context.Context, uint, string, ...any) (postgres.Rows, error) {
+					return nil, queryErr
+				},
+			}, nil
+		},
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.Nil(t, findings)
+	require.ErrorIs(t, err, queryErr)
+	require.ErrorContains(t, err, "querying source table privileges")
+}
+
+func TestSourceTableSelectPrivilegesCheck_Run_ScanFails(t *testing.T) {
+	t.Parallel()
+
+	scanErr := errors.New("scan failed")
+	check := &SourceTableSelectPrivilegesCheck{
+		Source: sourceWithMockRows(&mocks.Rows{
+			NextFn: func(i uint) bool { return i == 1 },
+			ScanFn: func(uint, ...any) error {
+				return scanErr
+			},
+			ErrFn: func() error { return nil },
+		}),
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.Nil(t, findings)
+	require.ErrorIs(t, err, scanErr)
+	require.ErrorContains(t, err, "scanning row")
+}
+
+func TestSourceTableSelectPrivilegesCheck_Run_RowsErr(t *testing.T) {
+	t.Parallel()
+
+	rowsErr := errors.New("rows failed")
+	check := &SourceTableSelectPrivilegesCheck{
+		Source: sourceWithMockRows(&mocks.Rows{
+			NextFn: func(uint) bool { return false },
+			ScanFn: func(uint, ...any) error {
+				t.Fatal("Scan should not be called")
+				return nil
+			},
+			ErrFn: func() error { return rowsErr },
+		}),
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.Nil(t, findings)
+	require.ErrorIs(t, err, rowsErr)
+	require.ErrorContains(t, err, "iterating rows")
+}
+
+func TestSourceTableSelectPrivilegesCheck_Run_FiltersTablesByScope(t *testing.T) {
+	t.Parallel()
+
+	check := &SourceTableSelectPrivilegesCheck{
+		Tables:         []string{"public.*"},
+		ExcludedTables: []string{"public.audit_log"},
+		Source: sourceWithRows(t, []sourceTableSelectPrivilegeRow{
+			{Role: "pgstream_user", Schema: "billing", Table: "invoices", HasSelect: false},
+			{Role: "pgstream_user", Schema: "public", Table: "audit_log", HasSelect: false},
+			{Role: "pgstream_user", Schema: "public", Table: "orders", HasSelect: false},
+		}),
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Message, "public.orders")
+}
+
+func TestSourceTableSelectPrivilegesCheck_Run_InvalidTableSelection(t *testing.T) {
+	t.Parallel()
+
+	check := &SourceTableSelectPrivilegesCheck{
+		Tables: []string{"too.many.parts"},
+		Source: func(context.Context) (postgres.Querier, error) {
+			t.Fatal("Source should not be called when table selection is invalid")
+			return nil, nil
+		},
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.Nil(t, findings)
+	require.ErrorContains(t, err, "parsing table selection")
+	require.ErrorIs(t, err, postgres.ErrInvalidTableName)
+}
+
+func TestSourceTableSelectPrivilegesCheck_Name(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "source_table_select_privileges", (&SourceTableSelectPrivilegesCheck{}).Name())
+}
+
+func TestQualifiedTable(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "public.orders", qualifiedTable("public", "orders"))
+}
+
+func TestSourceTableSelectPrivilegeMessage(t *testing.T) {
+	t.Parallel()
+
+	msg := sourceTableSelectPrivilegeMessage(sourceTableSelectPrivilegeRow{
+		Role:   "pgstream_user",
+		Schema: "public",
+		Table:  "orders",
+	})
+
+	require.Contains(t, msg, `source role "pgstream_user"`)
+	require.Contains(t, msg, "public.orders")
+	require.Contains(t, msg, "GRANT SELECT ON TABLE public.orders TO pgstream_user")
+}
+
+func TestBuildAccessChecks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cfg        *stream.Config
+		wantChecks int
+		wantTables []string
+		wantExcl   []string
+	}{
+		{
+			name: "no source postgres url returns no checks",
+			cfg:  &stream.Config{},
+		},
+		{
+			name: "source postgres url returns select privilege check",
+			cfg: &stream.Config{
+				Listener: stream.ListenerConfig{
+					Postgres: &stream.PostgresListenerConfig{URL: "postgres://source"},
+				},
+			},
+			wantChecks: 1,
+		},
+		{
+			name: "snapshot table scope is passed to check",
+			cfg: &stream.Config{
+				Listener: stream.ListenerConfig{
+					Postgres: &stream.PostgresListenerConfig{
+						URL: "postgres://source",
+						Snapshot: &snapshotbuilder.SnapshotListenerConfig{
+							Adapter: adapter.SnapshotConfig{
+								Tables:         []string{"public.orders"},
+								ExcludedTables: []string{"public.audit_log"},
+							},
+						},
+					},
+				},
+			},
+			wantChecks: 1,
+			wantTables: []string{"public.orders"},
+			wantExcl:   []string{"public.audit_log"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			checks, cleanup := BuildAccessChecks(tc.cfg)
+
+			require.Len(t, checks, tc.wantChecks)
+			if tc.wantChecks == 0 {
+				require.Nil(t, cleanup)
+				return
+			}
+			require.NotNil(t, cleanup)
+			check, ok := checks[0].(*SourceTableSelectPrivilegesCheck)
+			require.True(t, ok)
+			require.Equal(t, tc.wantTables, check.Tables)
+			require.Equal(t, tc.wantExcl, check.ExcludedTables)
+		})
+	}
+}
+
+func TestBuildChecks_SelectedAccessOnly(t *testing.T) {
+	t.Parallel()
+
+	cfg := &stream.Config{
+		Listener: stream.ListenerConfig{
+			Postgres: &stream.PostgresListenerConfig{
+				URL: "postgres://source",
+			},
+		},
+	}
+
+	checks, cleanup := BuildChecks(cfg, []Category{CategoryAccess})
+
+	require.NotNil(t, cleanup)
+	require.Len(t, checks, 1)
+	require.Equal(t, "source_table_select_privileges", checks[0].Name())
+}
+
+func sourceWithRows(t *testing.T, rows []sourceTableSelectPrivilegeRow) postgres.AcquireFunc {
+	t.Helper()
+	return sourceWithMockRows(privilegeRows(t, rows))
+}
+
+func sourceWithMockRows(rows postgres.Rows) postgres.AcquireFunc {
+	return func(context.Context) (postgres.Querier, error) {
+		return &mocks.Querier{
+			QueryFn: func(context.Context, uint, string, ...any) (postgres.Rows, error) {
+				return rows, nil
+			},
+		}, nil
+	}
+}
+
+func privilegeRows(t *testing.T, rows []sourceTableSelectPrivilegeRow) postgres.Rows {
+	t.Helper()
+	return &mocks.Rows{
+		NextFn: func(i uint) bool {
+			return int(i) <= len(rows)
+		},
+		ScanFn: func(i uint, dest ...any) error {
+			require.Len(t, dest, 4)
+			row := rows[i-1]
+			role, ok := dest[0].(*string)
+			require.True(t, ok)
+			schema, ok := dest[1].(*string)
+			require.True(t, ok)
+			table, ok := dest[2].(*string)
+			require.True(t, ok)
+			hasSelect, ok := dest[3].(*bool)
+			require.True(t, ok)
+			*role = row.Role
+			*schema = row.Schema
+			*table = row.Table
+			*hasSelect = row.HasSelect
+			return nil
+		},
+		ErrFn: func() error { return nil },
+	}
+}

--- a/pkg/stream/preflight/builder.go
+++ b/pkg/stream/preflight/builder.go
@@ -28,6 +28,7 @@ type Builder struct {
 var Builders = []Builder{
 	{CategoryConnectivity, "connectivity", BuildConnectivityChecks},
 	{CategoryReplication, "replication", BuildReplicationChecks},
+	{CategoryAccess, "access", BuildAccessChecks},
 }
 
 // BuildConnectivityChecks returns the connectivity checks applicable to cfg.
@@ -66,6 +67,22 @@ func BuildReplicationChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 		&ReplicationSlotHeadroomCheck{Source: src.Acquire},
 		&ReplicationRoleAttrCheck{Source: src.Acquire},
 	}, src.Close
+}
+
+// BuildAccessChecks returns the access-preflight checks applicable to cfg,
+// plus a cleanup function that closes the shared source connection.
+func BuildAccessChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
+	url := cfg.SourcePostgresURL()
+	if url == "" {
+		return nil, nil
+	}
+	src := postgres.NewLazyConn(url)
+	check := &SourceTableSelectPrivilegesCheck{Source: src.Acquire}
+	if cfg.Listener.Postgres != nil && cfg.Listener.Postgres.Snapshot != nil {
+		check.Tables = cfg.Listener.Postgres.Snapshot.Adapter.Tables
+		check.ExcludedTables = cfg.Listener.Postgres.Snapshot.Adapter.ExcludedTables
+	}
+	return []Check{check}, src.Close
 }
 
 // BuildChecks returns the concrete checks for the selected categories,

--- a/pkg/stream/preflight/preflight.go
+++ b/pkg/stream/preflight/preflight.go
@@ -15,6 +15,7 @@ type Category string
 const (
 	CategoryConnectivity Category = "connectivity"
 	CategoryReplication  Category = "replication"
+	CategoryAccess       Category = "access"
 )
 
 // Finding describes a single issue detected by a Check. Every finding is an


### PR DESCRIPTION
#### Description

Adds a new `pgstream check --access` preflight check that verifies the configured source Postgres role has `SELECT` privileges on in-scope source tables.

##### Related Issue(s): 

- Related to #897 

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [x] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Added an `access` preflight category and `pgstream check --access` flag.
- Added `SourceTableSelectPrivilegesCheck` to report source tables missing `SELECT` privileges.
- Added unit tests for privilege findings, error handling, table scope filtering, and builder wiring.
- Regenerated `cli-definition.json`.

#### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary


#### Additional Notes

No user-facing docs were added; generated CLI metadata was updated for the new `--access` flag.