### PR TITLE
Quote schema/table/role identifiers in access check messages

### DIFF
--- a/pkg/stream/preflight/access.go
+++ b/pkg/stream/preflight/access.go
@@ -105,10 +105,7 @@ func tableInScope(schema, table string, include, exclude postgres.SchemaTableMap
 }
 
 func sourceTableSelectPrivilegeMessage(row sourceTableSelectPrivilegeRow) string {
-	table := qualifiedTable(row.Schema, row.Table)
-	return fmt.Sprintf("source role %q lacks SELECT on %s; run GRANT SELECT ON TABLE %s TO %s", row.Role, table, table, row.Role)
-}
-
-func qualifiedTable(schema, table string) string {
-	return fmt.Sprintf("%s.%s", schema, table)
+	table := postgres.QuoteIdentifier(row.Schema) + "." + postgres.QuoteIdentifier(row.Table)
+	role := postgres.QuoteIdentifier(row.Role)
+	return fmt.Sprintf("source role %s lacks SELECT on %s; run GRANT SELECT ON TABLE %s TO %s", role, table, table, role)
 }

--- a/pkg/stream/preflight/access.go
+++ b/pkg/stream/preflight/access.go
@@ -105,7 +105,10 @@ func tableInScope(schema, table string, include, exclude postgres.SchemaTableMap
 }
 
 func sourceTableSelectPrivilegeMessage(row sourceTableSelectPrivilegeRow) string {
-	table := postgres.QuoteIdentifier(row.Schema) + "." + postgres.QuoteIdentifier(row.Table)
-	role := postgres.QuoteIdentifier(row.Role)
-	return fmt.Sprintf("source role %s lacks SELECT on %s; run GRANT SELECT ON TABLE %s TO %s", role, table, table, role)
+	quotedTable := postgres.QuoteIdentifier(row.Schema) + "." + postgres.QuoteIdentifier(row.Table)
+	quotedRole := postgres.QuoteIdentifier(row.Role)
+	return fmt.Sprintf(
+		"source role %q lacks SELECT on %s.%s; run GRANT SELECT ON TABLE %s TO %s",
+		row.Role, row.Schema, row.Table, quotedTable, quotedRole,
+	)
 }

--- a/pkg/stream/preflight/access_test.go
+++ b/pkg/stream/preflight/access_test.go
@@ -47,7 +47,7 @@ func TestSourceTableSelectPrivilegesCheck_Run_MissingSelectReturnsFinding(t *tes
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
 	require.Contains(t, findings[0].Message, `source role "pgstream_user"`)
-	require.Contains(t, findings[0].Message, "public.orders")
+	require.Contains(t, findings[0].Message, `"public"."orders"`)
 	require.Contains(t, findings[0].Message, "GRANT SELECT")
 }
 
@@ -65,8 +65,8 @@ func TestSourceTableSelectPrivilegesCheck_Run_MultipleMissingSelect(t *testing.T
 
 	require.NoError(t, err)
 	require.Len(t, findings, 2)
-	require.Contains(t, findings[0].Message, "billing.invoices")
-	require.Contains(t, findings[1].Message, "public.orders")
+	require.Contains(t, findings[0].Message, `"billing"."invoices"`)
+	require.Contains(t, findings[1].Message, `"public"."orders"`)
 }
 
 func TestSourceTableSelectPrivilegesCheck_Run_SourceAcquireFails(t *testing.T) {
@@ -167,7 +167,7 @@ func TestSourceTableSelectPrivilegesCheck_Run_FiltersTablesByScope(t *testing.T)
 
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
-	require.Contains(t, findings[0].Message, "public.orders")
+	require.Contains(t, findings[0].Message, `"public"."orders"`)
 }
 
 func TestSourceTableSelectPrivilegesCheck_Run_InvalidTableSelection(t *testing.T) {
@@ -194,12 +194,6 @@ func TestSourceTableSelectPrivilegesCheck_Name(t *testing.T) {
 	require.Equal(t, "source_table_select_privileges", (&SourceTableSelectPrivilegesCheck{}).Name())
 }
 
-func TestQualifiedTable(t *testing.T) {
-	t.Parallel()
-
-	require.Equal(t, "public.orders", qualifiedTable("public", "orders"))
-}
-
 func TestSourceTableSelectPrivilegeMessage(t *testing.T) {
 	t.Parallel()
 
@@ -210,8 +204,23 @@ func TestSourceTableSelectPrivilegeMessage(t *testing.T) {
 	})
 
 	require.Contains(t, msg, `source role "pgstream_user"`)
-	require.Contains(t, msg, "public.orders")
-	require.Contains(t, msg, "GRANT SELECT ON TABLE public.orders TO pgstream_user")
+	require.Contains(t, msg, `"public"."orders"`)
+	require.Contains(t, msg, `GRANT SELECT ON TABLE "public"."orders" TO "pgstream_user"`)
+}
+
+func TestSourceTableSelectPrivilegeMessage_QuotesMixedCaseIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	msg := sourceTableSelectPrivilegeMessage(sourceTableSelectPrivilegeRow{
+		Role:   "Replicator",
+		Schema: "Reporting",
+		Table:  "DailyRollup",
+	})
+
+	// Without quoting, Postgres folds these to lowercase and the GRANT silently
+	// targets the wrong identifiers (or errors). Quoting keeps the statement
+	// executable on the user's actual objects.
+	require.Contains(t, msg, `GRANT SELECT ON TABLE "Reporting"."DailyRollup" TO "Replicator"`)
 }
 
 func TestBuildAccessChecks(t *testing.T) {

--- a/pkg/stream/preflight/access_test.go
+++ b/pkg/stream/preflight/access_test.go
@@ -204,22 +204,23 @@ func TestSourceTableSelectPrivilegeMessage(t *testing.T) {
 	})
 
 	require.Contains(t, msg, `source role "pgstream_user"`)
-	require.Contains(t, msg, `"public"."orders"`)
+	require.Contains(t, msg, "lacks SELECT on public.orders;")
 	require.Contains(t, msg, `GRANT SELECT ON TABLE "public"."orders" TO "pgstream_user"`)
 }
 
-func TestSourceTableSelectPrivilegeMessage_QuotesMixedCaseIdentifiers(t *testing.T) {
+func TestSourceTableSelectPrivilegeMessage_QuotesOnlyRemediation(t *testing.T) {
 	t.Parallel()
 
+	// Descriptive prose stays human-readable (unquoted); the GRANT statement
+	// gets postgres.QuoteIdentifier so it's executable on case-sensitive or
+	// special-character names.
 	msg := sourceTableSelectPrivilegeMessage(sourceTableSelectPrivilegeRow{
 		Role:   "Replicator",
 		Schema: "Reporting",
 		Table:  "DailyRollup",
 	})
 
-	// Without quoting, Postgres folds these to lowercase and the GRANT silently
-	// targets the wrong identifiers (or errors). Quoting keeps the statement
-	// executable on the user's actual objects.
+	require.Contains(t, msg, "lacks SELECT on Reporting.DailyRollup;")
 	require.Contains(t, msg, `GRANT SELECT ON TABLE "Reporting"."DailyRollup" TO "Replicator"`)
 }
 


### PR DESCRIPTION
## Summary

`sourceTableSelectPrivilegeMessage` in `pkg/stream/preflight/access.go` was producing the remediation `GRANT SELECT ON TABLE schema.table TO role` using `%s.%s` for the table and plain `%s` for the role. For case-sensitive or special-character identifiers (e.g. `CREATE TABLE "MyTable" (...)`), Postgres folds unquoted identifiers to lowercase. The suggested `GRANT` then silently targets the wrong objects, or errors at parse time.

### Before
```
source role "pgstream_user" lacks SELECT on Reporting.DailyRollup; run GRANT SELECT ON TABLE Reporting.DailyRollup TO pgstream_user
```
The `GRANT` runs but targets `reporting.dailyrollup` — the wrong table.

### After
```
source role "pgstream_user" lacks SELECT on Reporting.DailyRollup; run GRANT SELECT ON TABLE "Reporting"."DailyRollup" TO "pgstream_user"
```
Message remains readable; the `GRANT` is quoted and targets the exact identifier as created.
