### PR TITLE
fix: reload log level on SIGHUP

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -25,14 +25,25 @@ const (
 )
 
 func Load() error {
-	return LoadFile(viper.GetString("config"))
+	return loadFile(viper.GetString("config"), true)
+}
+
+// Reload re-reads the configured file without writing startup messages.
+func Reload() error {
+	return loadFile(viper.GetString("config"), false)
 }
 
 func LoadFile(file string) error {
+	return loadFile(file, true)
+}
+
+func loadFile(file string, announce bool) error {
 	if file == "" {
 		return nil
 	}
-	fmt.Printf("using config file: %s\n", file) //nolint:forbidigo //logger hasn't been configured yet
+	if announce {
+		fmt.Printf("using config file: %s\n", file) //nolint:forbidigo //logger hasn't been configured yet
+	}
 	buf, err := os.ReadFile(file)
 	if err != nil {
 		return fmt.Errorf("reading config file: %w", err)

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -12,6 +12,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	zerologlib "github.com/rs/zerolog"
+
 	"github.com/xataio/pgstream/cmd/config"
 	"github.com/xataio/pgstream/internal/log/zerolog"
 	"github.com/xataio/pgstream/internal/profiling"
@@ -149,7 +151,6 @@ func withSignalWatcher(fn func(ctx context.Context) error) func(cmd *cobra.Comma
 
 	sigc := make(chan os.Signal, 1)
 	signal.Notify(sigc,
-		syscall.SIGHUP,
 		syscall.SIGINT,
 		syscall.SIGTERM,
 		syscall.SIGQUIT)
@@ -188,6 +189,67 @@ func withProfiling(fn func(cmd *cobra.Command, args []string) error) func(cmd *c
 
 		return fn(cmd, args)
 	}
+}
+
+func withLogLevelReload(logger *zerologlib.Logger) func() {
+	sigc := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	signal.Notify(sigc, syscall.SIGHUP)
+
+	go func() {
+		defer close(done)
+		for range sigc {
+			reloadLogLevel(logger)
+		}
+	}()
+
+	return func() {
+		signal.Stop(sigc)
+		close(sigc)
+		<-done
+	}
+}
+
+func reloadLogLevel(logger *zerologlib.Logger) {
+	if err := config.Reload(); err != nil {
+		logger.WithLevel(zerologlib.NoLevel).Err(err).Msg("Failed to reload log level")
+		return
+	}
+
+	applyLogLevelFromConfig(logger)
+}
+
+func applyLogLevelFromConfig(logger *zerologlib.Logger) {
+	cfg := loggerConfigFromViper()
+	if err := cfg.Validate(); err != nil {
+		logger.WithLevel(zerologlib.NoLevel).Err(err).Msg("Rejected log level reload")
+		return
+	}
+
+	level, err := parseLogLevel(cfg.LogLevel)
+	if err != nil {
+		logger.WithLevel(zerologlib.NoLevel).Err(err).Msg("Rejected log level reload")
+		return
+	}
+
+	previousLevel := logger.GetLevel()
+	if previousLevel == level {
+		return
+	}
+
+	updatedLogger := logger.Level(level)
+	*logger = updatedLogger
+	logger.WithLevel(zerologlib.NoLevel).
+		Str("previous_level", previousLevel.String()).
+		Str("new_level", level.String()).
+		Msg("Reloaded log level")
+}
+
+func parseLogLevel(level string) (zerologlib.Level, error) {
+	if level == "" {
+		return zerologlib.NoLevel, nil
+	}
+	return zerologlib.ParseLevel(level)
 }
 
 func loggerConfigFromViper() *zerolog.Config {

--- a/cmd/root_cmd_test.go
+++ b/cmd/root_cmd_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"io"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/spf13/viper"
+)
+
+func TestApplyLogLevelFromConfigUpdatesLevel(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set("logging.level", "error")
+
+	logger := zerolog.New(io.Discard).Level(zerolog.InfoLevel)
+
+	applyLogLevelFromConfig(&logger)
+
+	if got := logger.GetLevel(); got != zerolog.ErrorLevel {
+		t.Fatalf("expected log level %q, got %q", zerolog.ErrorLevel, got)
+	}
+}
+
+func TestApplyLogLevelFromConfigRejectsInvalidLevel(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set("logging.level", "bad-level")
+
+	logger := zerolog.New(io.Discard).Level(zerolog.InfoLevel)
+
+	applyLogLevelFromConfig(&logger)
+
+	if got := logger.GetLevel(); got != zerolog.InfoLevel {
+		t.Fatalf("expected log level to remain %q, got %q", zerolog.InfoLevel, got)
+	}
+}

--- a/cmd/run_cmd.go
+++ b/cmd/run_cmd.go
@@ -43,6 +43,8 @@ const (
 func run(ctx context.Context) error {
 	logger := zerolog.NewLogger(loggerConfigFromViper())
 	zerolog.SetGlobalLogger(logger)
+	stopLogLevelReload := withLogLevelReload(logger)
+	defer stopLogLevelReload()
 
 	if isSnapshotMode() {
 		return fmt.Errorf("cannot use the 'run' command in snapshot-only mode; please use the 'snapshot' command instead")

--- a/internal/log/zerolog/zerolog.go
+++ b/internal/log/zerolog/zerolog.go
@@ -54,7 +54,17 @@ func (c *Config) Validate() error {
 	if c.NoColor && c.LogFormat == formatJSON {
 		return ErrNoColorUnderJSONFormat
 	}
+	if _, err := parseLevel(c.LogLevel); err != nil {
+		return fmt.Errorf("invalid log level %q: must be one of trace, debug, info, warn, error, fatal, panic, disabled", c.LogLevel)
+	}
 	return nil
+}
+
+func parseLevel(level string) (zerolog.Level, error) {
+	if level == "" {
+		return zerolog.NoLevel, nil
+	}
+	return zerolog.ParseLevel(level)
 }
 
 // init sets some zerolog global defaults we want to keep throughout the project.
@@ -101,7 +111,7 @@ func NewStdLogger(l *zerolog.Logger) loglib.Logger {
 // per minute is reached.
 func NewLogger(config *Config) *zerolog.Logger {
 	// ignore the error, it defaults to no level
-	level, _ := zerolog.ParseLevel(config.LogLevel)
+	level, _ := parseLevel(config.LogLevel)
 
 	var out io.Writer
 	if config.LogFormat == formatJSON {


### PR DESCRIPTION
Summary
- Handle SIGHUP separately from shutdown signals.
- Re-read the configured log level and apply valid changes to the running logger.
- Keep the existing level when reload fails or the new level is invalid.

Testing
- `go test ./cmd ./internal/log/zerolog`

Closes #943