### PR TITLE
Add new `TableSelection` for filtering tables

### DIFF
--- a/cmd/check_cmd.go
+++ b/cmd/check_cmd.go
@@ -41,6 +41,9 @@ var checkCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("parsing stream config: %w", err)
 			}
+			if err := streamConfig.IsValid(); err != nil {
+				return fmt.Errorf("validating stream config: %w", err)
+			}
 
 			checks, cleanup := preflight.BuildChecks(streamConfig, selectedCategories(cmd))
 			defer func() {

--- a/pkg/stream/config.go
+++ b/pkg/stream/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	pglib "github.com/xataio/pgstream/internal/postgres"
 	"github.com/xataio/pgstream/pkg/backoff"
 	"github.com/xataio/pgstream/pkg/kafka"
 	kafkacheckpoint "github.com/xataio/pgstream/pkg/wal/checkpointer/kafka"
@@ -94,8 +95,10 @@ func (c *Config) IsValid() error {
 	if err := c.Listener.IsValid(); err != nil {
 		return err
 	}
-
-	return c.Processor.IsValid()
+	if err := c.Processor.IsValid(); err != nil {
+		return err
+	}
+	return c.validateTableSelections()
 }
 
 func (c *ListenerConfig) IsValid() error {
@@ -147,6 +150,22 @@ func (c *ProcessorConfig) IsValid() error {
 		// More than one processor is configured, return an error
 		return fmt.Errorf("only one processor can be configured at a time, found %d", processorCount)
 	}
+}
+
+func (c *Config) validateTableSelections() error {
+	if c.Listener.Postgres != nil && c.Listener.Postgres.Snapshot != nil {
+		adapter := c.Listener.Postgres.Snapshot.Adapter
+		if _, err := NewTableSelection(adapter.Tables, adapter.ExcludedTables); err != nil {
+			return fmt.Errorf("snapshot table selection: %w", err)
+		}
+	}
+	if c.Processor.Filter != nil {
+		filter := c.Processor.Filter
+		if _, err := NewTableSelection(filter.IncludeTables, filter.ExcludeTables); err != nil {
+			return fmt.Errorf("replication table selection: %w", err)
+		}
+	}
+	return nil
 }
 
 func (c *Config) SourcePostgresURL() string {
@@ -201,6 +220,126 @@ func (c *Config) RequiredTables() []string {
 			requiredTables = append(requiredTables, c.Listener.Postgres.Snapshot.Adapter.Tables...)
 		}
 	}
-	// TODO: add included tables for the replication case as well
 	return requiredTables
+}
+
+// TableSelection captures the include/exclude filter pgstream applies to the
+// WAL stream. Empty include means "every user table is in scope"; exclude
+// names tables to skip. Include and exclude are mutually exclusive at the
+// source-config level (validated by the filter package).
+type TableSelection struct {
+	include    []string
+	exclude    []string
+	includeMap pglib.SchemaTableMap
+	excludeMap pglib.SchemaTableMap
+}
+
+func NewTableSelection(include, exclude []string) (TableSelection, error) {
+	s := TableSelection{include: include, exclude: exclude}
+	var err error
+	if len(include) > 0 {
+		s.includeMap, err = pglib.NewSchemaTableMap(include)
+		if err != nil {
+			return TableSelection{}, fmt.Errorf("include: %w", err)
+		}
+	}
+	if len(exclude) > 0 {
+		s.excludeMap, err = pglib.NewSchemaTableMap(exclude)
+		if err != nil {
+			return TableSelection{}, fmt.Errorf("exclude: %w", err)
+		}
+	}
+	return s, nil
+}
+
+func (s TableSelection) IsUnfiltered() bool {
+	return len(s.include) == 0 && len(s.exclude) == 0
+}
+
+func (s TableSelection) IsTableInScope(schema, table string) bool {
+	if s.excludeMap != nil && s.excludeMap.ContainsSchemaTable(schema, table) {
+		return false
+	}
+	if s.includeMap == nil {
+		return true
+	}
+	return s.includeMap.ContainsSchemaTable(schema, table)
+}
+
+func (s TableSelection) Include() []string { return s.include }
+
+func (s TableSelection) Exclude() []string { return s.exclude }
+
+func (c *Config) SnapshotTableSelection() TableSelection {
+	if c.Listener.Postgres == nil || c.Listener.Postgres.Snapshot == nil {
+		return TableSelection{}
+	}
+	// IsValid is the gate that catches malformed entries; if a caller skipped
+	// it the constructor error is swallowed and the lazy fallback in
+	// IsTableInScope produces a defined (over-permissive) answer.
+	sel, _ := NewTableSelection(c.Listener.Postgres.Snapshot.Adapter.Tables, c.Listener.Postgres.Snapshot.Adapter.ExcludedTables)
+	return sel
+}
+
+func (c *Config) ReplicationTableSelection() TableSelection {
+	if c.Processor.Filter == nil {
+		return TableSelection{}
+	}
+	// IsValid is the gate that catches malformed entries; if a caller skipped
+	// it the constructor error is swallowed and the lazy fallback in
+	// IsTableInScope produces a defined (over-permissive) answer.
+	sel, _ := NewTableSelection(c.Processor.Filter.IncludeTables, c.Processor.Filter.ExcludeTables)
+	return sel
+}
+
+func (c *Config) AccessTableSelection() TableSelection {
+	snap := c.SnapshotTableSelection()
+	rep := c.ReplicationTableSelection()
+
+	if snap.IsUnfiltered() || rep.IsUnfiltered() {
+		return TableSelection{}
+	}
+
+	switch {
+	case len(snap.include) > 0 && len(rep.include) > 0:
+		sel, _ := NewTableSelection(dedupUnion(snap.include, rep.include), nil)
+		return sel
+	case len(snap.exclude) > 0 && len(rep.exclude) > 0:
+		sel, _ := NewTableSelection(nil, intersection(snap.exclude, rep.exclude))
+		return sel
+	default:
+		return TableSelection{}
+	}
+}
+
+func dedupUnion(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for _, s := range a {
+		seen[s] = struct{}{}
+	}
+	for _, s := range b {
+		seen[s] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	return out
+}
+
+func intersection(a, b []string) []string {
+	if len(a) == 0 || len(b) == 0 {
+		return nil
+	}
+	aSet := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		aSet[s] = struct{}{}
+	}
+	var out []string
+	for _, s := range b {
+		if _, ok := aSet[s]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
 }

--- a/pkg/stream/config_test.go
+++ b/pkg/stream/config_test.go
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package stream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/pkg/wal/listener/snapshot/adapter"
+	snapshotbuilder "github.com/xataio/pgstream/pkg/wal/listener/snapshot/builder"
+	"github.com/xataio/pgstream/pkg/wal/processor/filter"
+)
+
+func TestConfig_ReplicationTableSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         *Config
+		wantInclude []string
+		wantExclude []string
+	}{
+		{
+			name: "no filter configured returns unfiltered selection",
+			cfg:  &Config{},
+		},
+		{
+			name: "empty filter returns unfiltered selection",
+			cfg: &Config{
+				Processor: ProcessorConfig{Filter: &filter.Config{}},
+			},
+		},
+		{
+			name: "include list propagates",
+			cfg: &Config{
+				Processor: ProcessorConfig{
+					Filter: &filter.Config{IncludeTables: []string{"public.users", "public.orders"}},
+				},
+			},
+			wantInclude: []string{"public.users", "public.orders"},
+		},
+		{
+			name: "exclude list propagates",
+			cfg: &Config{
+				Processor: ProcessorConfig{
+					Filter: &filter.Config{ExcludeTables: []string{"public.audit_log"}},
+				},
+			},
+			wantExclude: []string{"public.audit_log"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.cfg.ReplicationTableSelection()
+			require.Equal(t, tc.wantInclude, got.Include())
+			require.Equal(t, tc.wantExclude, got.Exclude())
+		})
+	}
+}
+
+func TestConfig_IsValid_ValidatesTableSelections(t *testing.T) {
+	t.Parallel()
+
+	baseListener := ListenerConfig{Postgres: &PostgresListenerConfig{URL: "postgres://source"}}
+	baseProcessor := ProcessorConfig{Stdout: &StdoutProcessorConfig{}}
+
+	t.Run("malformed snapshot adapter Tables surfaces from IsValid", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Listener: ListenerConfig{
+				Postgres: &PostgresListenerConfig{
+					URL: "postgres://source",
+					Snapshot: &snapshotbuilder.SnapshotListenerConfig{
+						Adapter: adapter.SnapshotConfig{Tables: []string{"too.many.parts"}},
+					},
+				},
+			},
+			Processor: baseProcessor,
+		}
+		err := cfg.IsValid()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "snapshot table selection")
+	})
+
+	t.Run("malformed filter IncludeTables surfaces from IsValid", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Listener: baseListener,
+			Processor: ProcessorConfig{
+				Stdout: &StdoutProcessorConfig{},
+				Filter: &filter.Config{IncludeTables: []string{"too.many.parts"}},
+			},
+		}
+		err := cfg.IsValid()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "replication table selection")
+	})
+
+	t.Run("well-formed selections pass IsValid", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{
+			Listener: ListenerConfig{
+				Postgres: &PostgresListenerConfig{
+					URL: "postgres://source",
+					Snapshot: &snapshotbuilder.SnapshotListenerConfig{
+						Adapter: adapter.SnapshotConfig{Tables: []string{"public.users"}},
+					},
+				},
+			},
+			Processor: ProcessorConfig{
+				Stdout: &StdoutProcessorConfig{},
+				Filter: &filter.Config{IncludeTables: []string{"public.orders"}},
+			},
+		}
+		require.NoError(t, cfg.IsValid())
+	})
+}
+
+func TestNewTableSelection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid include/exclude returns selection with cached maps", func(t *testing.T) {
+		t.Parallel()
+		sel, err := NewTableSelection([]string{"public.users"}, []string{"public.audit_log"})
+		require.NoError(t, err)
+		require.Equal(t, []string{"public.users"}, sel.Include())
+		require.Equal(t, []string{"public.audit_log"}, sel.Exclude())
+
+		require.True(t, sel.IsTableInScope("public", "users"))
+		require.False(t, sel.IsTableInScope("public", "audit_log"))
+		require.False(t, sel.IsTableInScope("public", "orders"))
+	})
+
+	t.Run("malformed include surfaces an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewTableSelection([]string{"too.many.parts"}, nil)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "include")
+	})
+
+	t.Run("malformed exclude surfaces an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewTableSelection(nil, []string{"too.many.parts"})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "exclude")
+	})
+
+	t.Run("empty inputs return an unfiltered selection", func(t *testing.T) {
+		t.Parallel()
+		sel, err := NewTableSelection(nil, nil)
+		require.NoError(t, err)
+		require.True(t, sel.IsUnfiltered())
+		require.True(t, sel.IsTableInScope("anything", "goes"))
+	})
+}
+
+func TestTableSelection_IsUnfiltered(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, TableSelection{}.IsUnfiltered())
+
+	includeOnly, err := NewTableSelection([]string{"public.x"}, nil)
+	require.NoError(t, err)
+	require.False(t, includeOnly.IsUnfiltered())
+
+	excludeOnly, err := NewTableSelection(nil, []string{"public.x"})
+	require.NoError(t, err)
+	require.False(t, excludeOnly.IsUnfiltered())
+}
+
+func TestTableSelection_IsTableInScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		include []string
+		exclude []string
+		schema  string
+		table   string
+		want    bool
+	}{
+		{name: "unfiltered selection includes everything", schema: "public", table: "users", want: true},
+		{name: "include match", include: []string{"public.users"}, schema: "public", table: "users", want: true},
+		{name: "include miss", include: []string{"public.users"}, schema: "public", table: "orders", want: false},
+		{name: "exclude match", exclude: []string{"public.audit_log"}, schema: "public", table: "audit_log", want: false},
+		{name: "exclude miss", exclude: []string{"public.audit_log"}, schema: "public", table: "users", want: true},
+		{name: "exclude wins over include when both match", include: []string{"public.users"}, exclude: []string{"public.users"}, schema: "public", table: "users", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sel, err := NewTableSelection(tc.include, tc.exclude)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, sel.IsTableInScope(tc.schema, tc.table))
+		})
+	}
+}
+
+func TestConfig_SnapshotTableSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         *Config
+		wantInclude []string
+		wantExclude []string
+	}{
+		{
+			name: "no snapshot configured returns unfiltered selection",
+			cfg:  &Config{},
+		},
+		{
+			name: "snapshot adapter include/exclude propagates",
+			cfg: &Config{
+				Listener: ListenerConfig{
+					Postgres: &PostgresListenerConfig{
+						Snapshot: &snapshotbuilder.SnapshotListenerConfig{
+							Adapter: adapter.SnapshotConfig{
+								Tables:         []string{"public.users"},
+								ExcludedTables: []string{"public.audit_log"},
+							},
+						},
+					},
+				},
+			},
+			wantInclude: []string{"public.users"},
+			wantExclude: []string{"public.audit_log"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.cfg.SnapshotTableSelection()
+			require.Equal(t, tc.wantInclude, got.Include())
+			require.Equal(t, tc.wantExclude, got.Exclude())
+		})
+	}
+}
+
+func TestConfig_AccessTableSelection(t *testing.T) {
+	t.Parallel()
+
+	snapInclude := func(tables ...string) *Config {
+		return &Config{
+			Listener: ListenerConfig{
+				Postgres: &PostgresListenerConfig{
+					Snapshot: &snapshotbuilder.SnapshotListenerConfig{
+						Adapter: adapter.SnapshotConfig{Tables: tables},
+					},
+				},
+			},
+		}
+	}
+	snapExclude := func(tables ...string) *Config {
+		return &Config{
+			Listener: ListenerConfig{
+				Postgres: &PostgresListenerConfig{
+					Snapshot: &snapshotbuilder.SnapshotListenerConfig{
+						Adapter: adapter.SnapshotConfig{ExcludedTables: tables},
+					},
+				},
+			},
+		}
+	}
+	withRepInclude := func(c *Config, tables ...string) *Config {
+		c.Processor.Filter = &filter.Config{IncludeTables: tables}
+		return c
+	}
+	withRepExclude := func(c *Config, tables ...string) *Config {
+		c.Processor.Filter = &filter.Config{ExcludeTables: tables}
+		return c
+	}
+
+	tests := []struct {
+		name        string
+		cfg         *Config
+		wantInclude []string
+		wantExclude []string
+	}{
+		{
+			name: "both unfiltered returns unfiltered",
+			cfg:  &Config{},
+		},
+		{
+			name: "only snapshot Include with no filter returns unfiltered (replication covers everything)",
+			cfg:  snapInclude("public.users"),
+		},
+		{
+			name: "only replication Include with no snapshot returns unfiltered (snapshot covers everything)",
+			cfg:  withRepInclude(&Config{}, "public.users"),
+		},
+		{
+			name:        "both Include — access Include is the union",
+			cfg:         withRepInclude(snapInclude("public.orders", "public.users"), "public.users", "public.events"),
+			wantInclude: []string{"public.orders", "public.users", "public.events"},
+		},
+		{
+			name:        "both Exclude — access Exclude is the intersection",
+			cfg:         withRepExclude(snapExclude("public.audit_log", "public.events"), "public.audit_log", "public.tmp"),
+			wantExclude: []string{"public.audit_log"},
+		},
+		{
+			name: "mixed Include + Exclude falls back to unfiltered",
+			cfg:  withRepExclude(snapInclude("public.orders"), "public.audit_log"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.cfg.AccessTableSelection()
+			require.ElementsMatch(t, tc.wantInclude, got.Include(), "Include lists differ")
+			require.ElementsMatch(t, tc.wantExclude, got.Exclude(), "Exclude lists differ")
+		})
+	}
+}

--- a/pkg/stream/preflight/access.go
+++ b/pkg/stream/preflight/access.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 
 	"github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/pkg/stream"
 )
 
 // SourceTableSelectPrivilegesCheck verifies that the source Postgres role can
 // read every table pgstream may need to snapshot or replicate.
 type SourceTableSelectPrivilegesCheck struct {
-	Source         postgres.AcquireFunc
-	Tables         []string
-	ExcludedTables []string
+	Source    postgres.AcquireFunc
+	Selection stream.TableSelection
 }
 
 func (c *SourceTableSelectPrivilegesCheck) Name() string {
@@ -36,11 +36,6 @@ ORDER BY n.nspname, c.relname
 `
 
 func (c *SourceTableSelectPrivilegesCheck) Run(ctx context.Context) ([]Finding, error) {
-	include, exclude, err := c.scopeMaps()
-	if err != nil {
-		return nil, fmt.Errorf("parsing table selection: %w", err)
-	}
-
 	conn, err := c.Source(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("connecting to source: %w", err)
@@ -58,7 +53,7 @@ func (c *SourceTableSelectPrivilegesCheck) Run(ctx context.Context) ([]Finding, 
 		if err := rows.Scan(&row.Role, &row.Schema, &row.Table, &row.HasSelect); err != nil {
 			return nil, fmt.Errorf("scanning row: %w", err)
 		}
-		if !tableInScope(row.Schema, row.Table, include, exclude) {
+		if !c.Selection.IsTableInScope(row.Schema, row.Table) {
 			continue
 		}
 		if !row.HasSelect {
@@ -76,32 +71,6 @@ type sourceTableSelectPrivilegeRow struct {
 	Schema    string
 	Table     string
 	HasSelect bool
-}
-
-func (c *SourceTableSelectPrivilegesCheck) scopeMaps() (include, exclude postgres.SchemaTableMap, err error) {
-	if len(c.Tables) > 0 {
-		include, err = postgres.NewSchemaTableMap(c.Tables)
-		if err != nil {
-			return nil, nil, fmt.Errorf("include: %w", err)
-		}
-	}
-	if len(c.ExcludedTables) > 0 {
-		exclude, err = postgres.NewSchemaTableMap(c.ExcludedTables)
-		if err != nil {
-			return nil, nil, fmt.Errorf("exclude: %w", err)
-		}
-	}
-	return include, exclude, nil
-}
-
-func tableInScope(schema, table string, include, exclude postgres.SchemaTableMap) bool {
-	if exclude != nil && exclude.ContainsSchemaTable(schema, table) {
-		return false
-	}
-	if include != nil {
-		return include.ContainsSchemaTable(schema, table)
-	}
-	return true
 }
 
 func sourceTableSelectPrivilegeMessage(row sourceTableSelectPrivilegeRow) string {

--- a/pkg/stream/preflight/access_test.go
+++ b/pkg/stream/preflight/access_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/xataio/pgstream/pkg/stream"
 	"github.com/xataio/pgstream/pkg/wal/listener/snapshot/adapter"
 	snapshotbuilder "github.com/xataio/pgstream/pkg/wal/listener/snapshot/builder"
+	"github.com/xataio/pgstream/pkg/wal/processor/filter"
 )
 
 func TestSourceTableSelectPrivilegesCheck_Run_AllTablesHaveSelect(t *testing.T) {
@@ -153,9 +154,11 @@ func TestSourceTableSelectPrivilegesCheck_Run_RowsErr(t *testing.T) {
 func TestSourceTableSelectPrivilegesCheck_Run_FiltersTablesByScope(t *testing.T) {
 	t.Parallel()
 
+	sel, err := stream.NewTableSelection([]string{"public.*"}, []string{"public.audit_log"})
+	require.NoError(t, err)
+
 	check := &SourceTableSelectPrivilegesCheck{
-		Tables:         []string{"public.*"},
-		ExcludedTables: []string{"public.audit_log"},
+		Selection: sel,
 		Source: sourceWithRows(t, []sourceTableSelectPrivilegeRow{
 			{Role: "pgstream_user", Schema: "billing", Table: "invoices", HasSelect: false},
 			{Role: "pgstream_user", Schema: "public", Table: "audit_log", HasSelect: false},
@@ -170,34 +173,10 @@ func TestSourceTableSelectPrivilegesCheck_Run_FiltersTablesByScope(t *testing.T)
 	require.Contains(t, findings[0].Message, "public.orders")
 }
 
-func TestSourceTableSelectPrivilegesCheck_Run_InvalidTableSelection(t *testing.T) {
-	t.Parallel()
-
-	check := &SourceTableSelectPrivilegesCheck{
-		Tables: []string{"too.many.parts"},
-		Source: func(context.Context) (postgres.Querier, error) {
-			t.Fatal("Source should not be called when table selection is invalid")
-			return nil, nil
-		},
-	}
-
-	findings, err := check.Run(context.Background())
-
-	require.Nil(t, findings)
-	require.ErrorContains(t, err, "parsing table selection")
-	require.ErrorIs(t, err, postgres.ErrInvalidTableName)
-}
-
 func TestSourceTableSelectPrivilegesCheck_Name(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, "source_table_select_privileges", (&SourceTableSelectPrivilegesCheck{}).Name())
-}
-
-func TestQualifiedTable(t *testing.T) {
-	t.Parallel()
-
-	require.Equal(t, "public.orders", qualifiedTable("public", "orders"))
 }
 
 func TestSourceTableSelectPrivilegeMessage(t *testing.T) {
@@ -214,22 +193,28 @@ func TestSourceTableSelectPrivilegeMessage(t *testing.T) {
 	require.Contains(t, msg, "GRANT SELECT ON TABLE public.orders TO pgstream_user")
 }
 
+func TestQualifiedTable(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "public.orders", qualifiedTable("public", "orders"))
+}
+
 func TestBuildAccessChecks(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		cfg        *stream.Config
-		wantChecks int
-		wantTables []string
-		wantExcl   []string
+		name        string
+		cfg         *stream.Config
+		wantChecks  int
+		wantInclude []string
+		wantExclude []string
 	}{
 		{
 			name: "no source postgres url returns no checks",
 			cfg:  &stream.Config{},
 		},
 		{
-			name: "source postgres url returns select privilege check",
+			name: "source postgres url returns select privilege check with unfiltered selection",
 			cfg: &stream.Config{
 				Listener: stream.ListenerConfig{
 					Postgres: &stream.PostgresListenerConfig{URL: "postgres://source"},
@@ -238,23 +223,26 @@ func TestBuildAccessChecks(t *testing.T) {
 			wantChecks: 1,
 		},
 		{
-			name: "snapshot table scope is passed to check",
+			name: "snapshot+filter Include unions through AccessTableSelection",
 			cfg: &stream.Config{
 				Listener: stream.ListenerConfig{
 					Postgres: &stream.PostgresListenerConfig{
 						URL: "postgres://source",
 						Snapshot: &snapshotbuilder.SnapshotListenerConfig{
 							Adapter: adapter.SnapshotConfig{
-								Tables:         []string{"public.orders"},
-								ExcludedTables: []string{"public.audit_log"},
+								Tables: []string{"public.orders"},
 							},
 						},
 					},
 				},
+				Processor: stream.ProcessorConfig{
+					Filter: &filter.Config{
+						IncludeTables: []string{"public.users"},
+					},
+				},
 			},
-			wantChecks: 1,
-			wantTables: []string{"public.orders"},
-			wantExcl:   []string{"public.audit_log"},
+			wantChecks:  1,
+			wantInclude: []string{"public.orders", "public.users"},
 		},
 	}
 
@@ -272,8 +260,8 @@ func TestBuildAccessChecks(t *testing.T) {
 			require.NotNil(t, cleanup)
 			check, ok := checks[0].(*SourceTableSelectPrivilegesCheck)
 			require.True(t, ok)
-			require.Equal(t, tc.wantTables, check.Tables)
-			require.Equal(t, tc.wantExcl, check.ExcludedTables)
+			require.ElementsMatch(t, tc.wantInclude, check.Selection.Include(), "Include lists differ")
+			require.ElementsMatch(t, tc.wantExclude, check.Selection.Exclude(), "Exclude lists differ")
 		})
 	}
 }

--- a/pkg/stream/preflight/access_test.go
+++ b/pkg/stream/preflight/access_test.go
@@ -209,12 +209,6 @@ func TestSourceTableSelectPrivilegeMessage_QuotesOnlyRemediation(t *testing.T) {
 	require.Contains(t, msg, `GRANT SELECT ON TABLE "Reporting"."DailyRollup" TO "Replicator"`)
 }
 
-func TestQualifiedTable(t *testing.T) {
-	t.Parallel()
-
-	require.Equal(t, "public.orders", qualifiedTable("public", "orders"))
-}
-
 func TestBuildAccessChecks(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/stream/preflight/builder.go
+++ b/pkg/stream/preflight/builder.go
@@ -77,12 +77,12 @@ func BuildAccessChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 		return nil, nil
 	}
 	src := postgres.NewLazyConn(url)
-	check := &SourceTableSelectPrivilegesCheck{Source: src.Acquire}
-	if cfg.Listener.Postgres != nil && cfg.Listener.Postgres.Snapshot != nil {
-		check.Tables = cfg.Listener.Postgres.Snapshot.Adapter.Tables
-		check.ExcludedTables = cfg.Listener.Postgres.Snapshot.Adapter.ExcludedTables
-	}
-	return []Check{check}, src.Close
+	return []Check{
+		&SourceTableSelectPrivilegesCheck{
+			Source:    src.Acquire,
+			Selection: cfg.AccessTableSelection(),
+		},
+	}, src.Close
 }
 
 // BuildChecks returns the concrete checks for the selected categories,


### PR DESCRIPTION
#### Description

This PR adds a new `stream.TableSelection` struct to hold included and excluded tables. This can be used
to check if a table is included in streaming.

```go
// Package-level constructor
func NewTableSelection(include, exclude []string) (TableSelection, error)

// Methods on TableSelection
func (s TableSelection) IsUnfiltered() bool
func (s TableSelection) IsTableInScope(schema, table string) bool
func (s TableSelection) Include() []string
func (s TableSelection) Exclude() []string
```

From now on, incorrect include and exclude configurations return errors instead of silently ignoring the setting.

This change is required by https://github.com/xataio/pgstream/pull/911

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
