### PR TITLE
Fix backoff `MaxInterval` wired to `MaxElapsedTime`

### DIFF
--- a/cmd/config/config_env.go
+++ b/cmd/config/config_env.go
@@ -604,13 +604,15 @@ func parseBackoffConfig(prefix string) backoff.Config {
 func parseExponentialBackoffConfig(prefix string) *backoff.ExponentialConfig {
 	initialInterval := viper.GetDuration(fmt.Sprintf("%s_EXP_BACKOFF_INITIAL_INTERVAL", prefix))
 	maxInterval := viper.GetDuration(fmt.Sprintf("%s_EXP_BACKOFF_MAX_INTERVAL", prefix))
+	maxElapsedTime := viper.GetDuration(fmt.Sprintf("%s_EXP_BACKOFF_MAX_ELAPSED_TIME", prefix))
 	maxRetries := viper.GetUint(fmt.Sprintf("%s_EXP_BACKOFF_MAX_RETRIES", prefix))
-	if initialInterval == 0 && maxInterval == 0 && maxRetries == 0 {
+	if initialInterval == 0 && maxInterval == 0 && maxElapsedTime == 0 && maxRetries == 0 {
 		return nil
 	}
 	return &backoff.ExponentialConfig{
 		InitialInterval: initialInterval,
 		MaxInterval:     maxInterval,
+		MaxElapsedTime:  maxElapsedTime,
 		MaxRetries:      maxRetries,
 	}
 }

--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -179,6 +179,7 @@ type ExponentialBackoffConfig struct {
 	MaxRetries      int `mapstructure:"max_retries" yaml:"max_retries"`
 	InitialInterval int `mapstructure:"initial_interval" yaml:"initial_interval"`
 	MaxInterval     int `mapstructure:"max_interval" yaml:"max_interval"`
+	MaxElapsedTime  int `mapstructure:"max_elapsed_time" yaml:"max_elapsed_time"`
 }
 
 type ConstantBackoffConfig struct {
@@ -912,6 +913,7 @@ func (bo *BackoffConfig) parseExponentialBackoffConfig() *backoff.ExponentialCon
 	return &backoff.ExponentialConfig{
 		InitialInterval: time.Duration(bo.Exponential.InitialInterval) * time.Millisecond,
 		MaxInterval:     time.Duration(bo.Exponential.MaxInterval) * time.Millisecond,
+		MaxElapsedTime:  time.Duration(bo.Exponential.MaxElapsedTime) * time.Millisecond,
 		MaxRetries:      uint(bo.Exponential.MaxRetries),
 	}
 }

--- a/config_template.yaml
+++ b/config_template.yaml
@@ -64,6 +64,7 @@ source:
         max_retries: 5 # maximum number of retries
         initial_interval: 1000 # initial interval in milliseconds
         max_interval: 60000 # maximum interval in milliseconds
+        max_elapsed_time: 0 # maximum total retry time in milliseconds (0 = unlimited)
       constant:
         max_retries: 5 # maximum number of retries
         interval: 1000 # interval in milliseconds
@@ -124,6 +125,7 @@ target:
         max_retries: 5 # maximum number of retries
         initial_interval: 1000 # initial interval in milliseconds
         max_interval: 60000 # maximum interval in milliseconds
+        max_elapsed_time: 0 # maximum total retry time in milliseconds (0 = unlimited)
       constant:
         max_retries: 5 # maximum number of retries
         interval: 1000 # interval in milliseconds

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -28,8 +28,9 @@ type Config struct {
 
 type ExponentialConfig struct {
 	InitialInterval time.Duration
-	MaxInterval     time.Duration
-	MaxRetries      uint
+	MaxInterval time.Duration
+	MaxElapsedTime time.Duration
+	MaxRetries     uint
 }
 
 type ConstantConfig struct {
@@ -68,7 +69,8 @@ func NewProvider(cfg *Config) Provider {
 func NewExponentialBackoff(ctx context.Context, cfg *ExponentialConfig) *ExponentialBackoff {
 	exp := backoff.NewExponentialBackOff(
 		backoff.WithInitialInterval(cfg.InitialInterval),
-		backoff.WithMaxElapsedTime(cfg.MaxInterval))
+		backoff.WithMaxInterval(cfg.MaxInterval),
+		backoff.WithMaxElapsedTime(cfg.MaxElapsedTime))
 
 	var bo backoff.BackOff = exp
 	if cfg.MaxRetries > 0 {

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -28,9 +28,9 @@ type Config struct {
 
 type ExponentialConfig struct {
 	InitialInterval time.Duration
-	MaxInterval time.Duration
-	MaxElapsedTime time.Duration
-	MaxRetries     uint
+	MaxInterval     time.Duration
+	MaxElapsedTime  time.Duration
+	MaxRetries      uint
 }
 
 type ConstantConfig struct {

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -18,7 +18,7 @@ func TestNewExponentialBackoff_MaxIntervalCapsPerRetryInterval(t *testing.T) {
 	cfg := &ExponentialConfig{
 		InitialInterval: 5 * time.Millisecond,
 		MaxInterval:     maxInterval,
-		MaxRetries: 8,
+		MaxRetries:      8,
 	}
 
 	bo := NewExponentialBackoff(context.Background(), cfg)

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package backoff
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestNewExponentialBackoff_MaxIntervalCapsPerRetryInterval(t *testing.T) {
+	t.Parallel()
+
+	const maxInterval = 10 * time.Millisecond
+	upperBound := maxInterval + maxInterval/2
+
+	cfg := &ExponentialConfig{
+		InitialInterval: 5 * time.Millisecond,
+		MaxInterval:     maxInterval,
+		MaxRetries: 8,
+	}
+
+	bo := NewExponentialBackoff(context.Background(), cfg)
+
+	wantErr := errors.New("boom")
+	intervals := make([]time.Duration, 0, cfg.MaxRetries)
+	err := bo.RetryNotify(
+		func() error { return wantErr },
+		func(_ error, d time.Duration) { intervals = append(intervals, d) },
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+
+	if len(intervals) == 0 {
+		t.Fatal("expected at least one retry interval to be recorded")
+	}
+	for i, d := range intervals {
+		if d > upperBound {
+			t.Errorf("retry interval %d = %v exceeds MaxInterval bound %v", i, d, upperBound)
+		}
+	}
+}
+
+func TestNewExponentialBackoff_MaxElapsedTimeCapsTotal(t *testing.T) {
+	t.Parallel()
+
+	const maxElapsed = 40 * time.Millisecond
+	cfg := &ExponentialConfig{
+		InitialInterval: time.Millisecond,
+		MaxInterval:     5 * time.Millisecond,
+		MaxElapsedTime:  maxElapsed,
+		MaxRetries:      0,
+	}
+
+	bo := NewExponentialBackoff(context.Background(), cfg)
+
+	wantErr := errors.New("boom")
+	start := time.Now()
+	err := bo.Retry(func() error { return wantErr })
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("retrying took %v, expected it to stop around MaxElapsedTime %v", elapsed, maxElapsed)
+	}
+}
+
+func TestNewExponentialBackoff_ZeroMaxElapsedTimeDoesNotCapByMaxInterval(t *testing.T) {
+	t.Parallel()
+
+	const maxInterval = 5 * time.Millisecond
+	cfg := &ExponentialConfig{
+		InitialInterval: 3 * time.Millisecond,
+		MaxInterval:     maxInterval,
+		MaxRetries:      6,
+	}
+
+	bo := NewExponentialBackoff(context.Background(), cfg)
+
+	wantErr := errors.New("boom")
+	start := time.Now()
+	err := bo.Retry(func() error { return wantErr })
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+	if elapsed <= maxInterval {
+		t.Errorf("total retry time %v did not exceed MaxInterval %v; MaxInterval is capping total time", elapsed, maxInterval)
+	}
+}


### PR DESCRIPTION
#### Description

Previously `BackoffInterval` was wired into `MaxElapsedTime`, instead of `MaxBackoffInterval`. This PR fixes the wiring and exposes the option `max_elapsed_time` in the settings.

From now on backoff interval sets how much time passes between two retries, and max elapsed time sets how long the whole retry process should last.

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- `BackoffInterval` is set to `backoff_interval`
- New option `max_elapsed_time` is added

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
