### PR TITLE
Fix data race in batch-bytes auto-tuner

### DIFF
--- a/pkg/wal/processor/batch/wal_batch_bytes_tuner.go
+++ b/pkg/wal/processor/batch/wal_batch_bytes_tuner.go
@@ -160,18 +160,21 @@ func (t *batchBytesTuner[T]) sendBatch(ctx context.Context, batch *Batch[T]) err
 		return err
 	}
 
-	t.recordMeasurementAndCalculateNext(start)
+	// Snapshot the send duration before contending for the mutex, so that any
+	// time spent waiting to acquire the lock is not counted as part of the
+	// measured send latency.
+	t.recordMeasurementAndCalculateNext(time.Since(start))
 	return nil
 }
 
 // recordMeasurementAndCalculateNext records the throughput measurement and
 // calculates the next measurement setting once we have enough samples for a
 // measurement, and they are stable enough to be representative.
-func (t *batchBytesTuner[T]) recordMeasurementAndCalculateNext(start time.Time) {
+func (t *batchBytesTuner[T]) recordMeasurementAndCalculateNext(elapsed time.Duration) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	throughput := t.calculateThroughputFn(time.Since(start), t.measurementSetting.value)
+	throughput := t.calculateThroughputFn(elapsed, t.measurementSetting.value)
 	t.measurementSetting.addThroughput(throughput)
 
 	// not enough samples yet, continue with the same measurement

--- a/pkg/wal/processor/batch/wal_batch_bytes_tuner.go
+++ b/pkg/wal/processor/batch/wal_batch_bytes_tuner.go
@@ -160,9 +160,7 @@ func (t *batchBytesTuner[T]) sendBatch(ctx context.Context, batch *Batch[T]) err
 		return err
 	}
 
-	t.mu.Lock()
 	t.recordMeasurementAndCalculateNext(start)
-	t.mu.Unlock()
 	return nil
 }
 
@@ -170,6 +168,9 @@ func (t *batchBytesTuner[T]) sendBatch(ctx context.Context, batch *Batch[T]) err
 // calculates the next measurement setting once we have enough samples for a
 // measurement, and they are stable enough to be representative.
 func (t *batchBytesTuner[T]) recordMeasurementAndCalculateNext(start time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	throughput := t.calculateThroughputFn(time.Since(start), t.measurementSetting.value)
 	t.measurementSetting.addThroughput(throughput)
 

--- a/pkg/wal/processor/batch/wal_batch_bytes_tuner.go
+++ b/pkg/wal/processor/batch/wal_batch_bytes_tuner.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	mathlib "github.com/xataio/pgstream/internal/math"
@@ -21,6 +22,7 @@ type batchBytesTuner[T Message] struct {
 	// can be mocked for testing to generate desired throughput curves
 	calculateThroughputFn func(time.Duration, int64) float64
 
+	mu                        sync.Mutex
 	maxBatchBytes             int64
 	minBatchBytes             int64
 	convergenceThreshold      int64
@@ -152,10 +154,16 @@ func (t *batchBytesTuner[T]) sendBatch(ctx context.Context, batch *Batch[T]) err
 	}
 
 	start := time.Now()
-	defer func() {
-		t.recordMeasurementAndCalculateNext(start)
-	}()
-	return t.sendFn(ctx, batch)
+	if err := t.sendFn(ctx, batch); err != nil {
+		// Only record throughput measurements for successful sends. Recording
+		// on failure would pollute the tuning signal with error latencies.
+		return err
+	}
+
+	t.mu.Lock()
+	t.recordMeasurementAndCalculateNext(start)
+	t.mu.Unlock()
+	return nil
 }
 
 // recordMeasurementAndCalculateNext records the throughput measurement and
@@ -275,7 +283,28 @@ func (t *batchBytesTuner[T]) calculateNextSetting() *batchBytesSetting {
 	return newMeasurementSetting
 }
 
+// currentMaxBatchBytes returns the max batch bytes the batching goroutine
+// should currently use, reading the tuner state under the mutex. It returns the
+// provided fallback if the tuner has errored out or has no setting yet.
+func (t *batchBytesTuner[T]) currentMaxBatchBytes(fallback int64) int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.hasError() {
+		return fallback
+	}
+	switch {
+	case t.hasConverged() && t.candidateSetting != nil:
+		return t.candidateSetting.value
+	case t.measurementSetting != nil:
+		return t.measurementSetting.value
+	}
+	return fallback
+}
+
 func (t *batchBytesTuner[T]) close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.logDebugMeasurements()
 }
 

--- a/pkg/wal/processor/batch/wal_batch_bytes_tuner_test.go
+++ b/pkg/wal/processor/batch/wal_batch_bytes_tuner_test.go
@@ -4,6 +4,8 @@ package batch
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -179,6 +181,106 @@ func TestBatchBytesTuner_sendBatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBatchBytesTuner_concurrentAccess exercises the tuner from two goroutines
+// concurrently (the writer goroutine driving sendBatch, and the batching
+// goroutine reading currentMaxBatchBytes) to ensure the shared state is
+// properly synchronised. Run with -race to detect data races.
+func TestBatchBytesTuner_concurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	testLogger := zerolog.NewStdLogger(zerolog.NewLogger(&zerolog.Config{
+		LogLevel: "error",
+	}))
+
+	sendFn := func(ctx context.Context, b *Batch[*mockMessage]) error { return nil }
+
+	tuner, err := newBatchBytesTuner(AutoTuneConfig{
+		Enabled:              true,
+		MinBatchBytes:        1,
+		MaxBatchBytes:        1000,
+		ConvergenceThreshold: 0.01,
+	}, sendFn, testLogger)
+	require.NoError(t, err)
+	defer tuner.close()
+
+	tuner.batchBytesToleranceFactor = 0.0
+	tuner.minSamples = 1
+	tuner.calculateThroughputFn = func(duration time.Duration, batchBytes int64) float64 {
+		optimal := int64(500)
+		distance := float64(batchBytes - optimal)
+		throughput := 1000.0 - (distance * distance * 0.001)
+		if throughput < 0 {
+			return 0
+		}
+		return throughput
+	}
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+
+	// writer goroutine: drives the tuning by sending batches sized to the
+	// current measurement setting.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 500 {
+			batch := &Batch[*mockMessage]{}
+			batch.totalBytes = int(tuner.currentMaxBatchBytes(1000))
+			_ = tuner.sendBatch(ctx, batch)
+		}
+	}()
+
+	// reader goroutines: mimic the batching goroutine reading the current max
+	// batch bytes.
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 500 {
+				_ = tuner.currentMaxBatchBytes(1000)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestBatchBytesTuner_failedSendNotRecorded verifies that failed sends do not
+// contribute throughput measurements to the tuning signal.
+func TestBatchBytesTuner_failedSendNotRecorded(t *testing.T) {
+	t.Parallel()
+
+	testLogger := zerolog.NewStdLogger(zerolog.NewLogger(&zerolog.Config{
+		LogLevel: "error",
+	}))
+
+	errSend := errors.New("send failed")
+	sendFn := func(ctx context.Context, b *Batch[*mockMessage]) error { return errSend }
+
+	tuner, err := newBatchBytesTuner(AutoTuneConfig{
+		Enabled:              true,
+		MinBatchBytes:        1,
+		MaxBatchBytes:        100,
+		ConvergenceThreshold: 0.01,
+	}, sendFn, testLogger)
+	require.NoError(t, err)
+
+	tuner.batchBytesToleranceFactor = 0.0
+	tuner.minSamples = 1
+	tuner.calculateThroughputFn = func(duration time.Duration, batchBytes int64) float64 { return 1000.0 }
+
+	batch := &Batch[*mockMessage]{}
+	batch.totalBytes = int(tuner.measurementSetting.value)
+
+	// A failing send must return the error and must not record a measurement.
+	for range 5 {
+		require.ErrorIs(t, tuner.sendBatch(context.Background(), batch), errSend)
+	}
+
+	require.Empty(t, tuner.measurementSetting.throughputs)
+	require.Nil(t, tuner.candidateSetting)
 }
 
 func Test_calculateThroughput(t *testing.T) {

--- a/pkg/wal/processor/batch/wal_batch_sender.go
+++ b/pkg/wal/processor/batch/wal_batch_sender.go
@@ -235,13 +235,8 @@ func (s *Sender[T]) Close() {
 }
 
 func (s *Sender[T]) getMaxBatchBytes() int64 {
-	if s.batchBytesTuner != nil && !s.batchBytesTuner.hasError() {
-		switch {
-		case s.batchBytesTuner.hasConverged() && s.batchBytesTuner.candidateSetting != nil:
-			return s.batchBytesTuner.candidateSetting.value
-		case s.batchBytesTuner.measurementSetting != nil:
-			return s.batchBytesTuner.measurementSetting.value
-		}
+	if s.batchBytesTuner != nil {
+		return s.batchBytesTuner.currentMaxBatchBytes(s.maxBatchBytes)
 	}
 	return s.maxBatchBytes
 }


### PR DESCRIPTION
#### Description

This PR addresses a data race when calculating the batch sizes of the autotuner.
Previously, the reader and the writer accessed the values at the same time without
any synchronization. So it was possible that the state was only partially updated.
From now on these numerical values are updated at the same time.

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass
