### PR TITLE
[Transformers] Configurable error policy

### DIFF
--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -305,6 +305,7 @@ type TransformationsConfig struct {
 	DumpInferredRules       bool                      `mapstructure:"dump_inferred_rules" yaml:"dump_inferred_rules"`
 	TransformerRules        []TableTransformersConfig `mapstructure:"table_transformers" yaml:"table_transformers"`
 	ValidationMode          string                    `mapstructure:"validation_mode" yaml:"validation_mode"`
+	OnError                 string                    `mapstructure:"on_error" yaml:"on_error"`
 }
 type TableTransformersConfig struct {
 	Schema         string                              `mapstructure:"schema" yaml:"schema"`
@@ -353,11 +354,19 @@ const (
 	relaxedValidationMode    = "relaxed"
 )
 
+// transformer on-error policies
+const (
+	failOnError        = transformer.OnErrorFail
+	passThroughOnError = transformer.OnErrorPassThrough
+	nullOnError        = transformer.OnErrorNull
+)
+
 var (
 	errUnsupportedSnapshotMode                 = errors.New("unsupported snapshot mode, must be one of 'full', 'schema' or 'data'")
 	errUnsupportedPostgresSourceMode           = errors.New("unsupported postgres source mode, must be one of 'replication', 'snapshot' or 'snapshot_and_replication'")
 	errUnsupportedTransformationValidationMode = errors.New("unsupported transformation validation mode, must be one of 'strict', 'table_level' or 'relaxed'")
 	errUnsupportedTableValidationMode          = errors.New("unsupported table level validation mode, must be either 'strict' or 'relaxed'")
+	errUnsupportedTransformationOnError        = errors.New("unsupported transformation on_error policy, must be one of 'fail', 'pass-through' or 'null'")
 	errTableTransformersNotProvided            = errors.New("table_transformers must be provided when transformation config is set")
 	errInvalidTableValidationConfig            = errors.New("table level validation mode should be used when transformation validation mode is set to 'table_level'")
 	errUnsupportedSearchEngine                 = errors.New("unsupported search engine, must be one of 'opensearch' or 'elasticsearch'")
@@ -798,12 +807,23 @@ func (c TransformationsConfig) parseTransformationConfig() (*transformer.Config,
 		return nil, errUnsupportedTransformationValidationMode
 	}
 
+	var onError string
+	switch c.OnError {
+	case failOnError, passThroughOnError, nullOnError:
+		onError = c.OnError
+	case "":
+		onError = nullOnError
+	default:
+		return nil, errUnsupportedTransformationOnError
+	}
+
 	if c.InferFromSecurityLabels {
 		return &transformer.Config{
 			InferFromSecurityLabels: true,
 			DumpInferredRules:       c.DumpInferredRules,
 			TransformerRules:        nil,
 			ValidationMode:          globalValidationMode,
+			OnError:                 onError,
 		}, nil
 	}
 
@@ -849,6 +869,7 @@ func (c TransformationsConfig) parseTransformationConfig() (*transformer.Config,
 	return &transformer.Config{
 		TransformerRules: rules,
 		ValidationMode:   globalValidationMode,
+		OnError:          onError,
 	}, nil
 }
 

--- a/cmd/config/helper_test.go
+++ b/cmd/config/helper_test.go
@@ -224,6 +224,7 @@ func validateTestStreamConfig(t *testing.T, streamConfig *stream.Config) {
 				InferFromSecurityLabels: false,
 				DumpInferredRules:       false,
 				ValidationMode:          "relaxed",
+				OnError:                 "null",
 				TransformerRules: []transformer.TableRules{
 					{
 						Schema:         "public",

--- a/pkg/wal/processor/transformer/config.go
+++ b/pkg/wal/processor/transformer/config.go
@@ -7,10 +7,18 @@ type Config struct {
 	DumpInferredRules       bool
 	TransformerRules        []TableRules
 	ValidationMode          string
+	OnError                 string
 }
 
 func (c *Config) HasNoRules() bool {
 	return c == nil || len(c.TransformerRules) == 0
+}
+
+func (c *Config) onError() string {
+	if c.OnError == "" {
+		return OnErrorNull
+	}
+	return c.OnError
 }
 
 func (c *Config) validationMode() string {

--- a/pkg/wal/processor/transformer/wal_transformer.go
+++ b/pkg/wal/processor/transformer/wal_transformer.go
@@ -5,6 +5,7 @@ package transformer
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	loglib "github.com/xataio/pgstream/pkg/log"
 	"github.com/xataio/pgstream/pkg/transformers"
@@ -25,6 +26,7 @@ type Transformer struct {
 
 	validationMode       string
 	tableValidationModes map[string]string
+	onError              string
 }
 
 type ParseFn func(ctx context.Context, rules Rules) (*TransformerMap, error)
@@ -41,6 +43,10 @@ const (
 	validationModeStrict     = "strict"
 	validationModeRelaxed    = "relaxed"
 	validationModeTableLevel = "table_level"
+
+	OnErrorFail        = "fail"
+	OnErrorPassThrough = "pass-through"
+	OnErrorNull        = "null"
 )
 
 var (
@@ -60,6 +66,7 @@ func New(ctx context.Context, cfg *Config, processor processor.Processor, builde
 		ddlEventToSchemaDiff: wal.DDLEventToSchemaDiff,
 		validationMode:       validationMode,
 		tableValidationModes: map[string]string{},
+		onError:              cfg.onError(),
 	}
 
 	for _, opt := range opts {
@@ -155,13 +162,27 @@ func (t *Transformer) applyTransformations(ctx context.Context, event *wal.Event
 
 		newValue, err := columnTransformer.Transform(ctx, transformers.NewValue(col.Value, col.Type, dynamicValues))
 		if err != nil {
-			t.logger.Error(err, "transforming column", loglib.Fields{
-				"severity":    "DATALOSS",
-				"column_name": col.Name,
-				"schema":      event.Data.Schema,
-				"table":       event.Data.Table,
-			})
-			newValue = nil
+			switch t.onError {
+			case OnErrorFail:
+				return fmt.Errorf("transforming column %q in %s.%s: %w", col.Name, event.Data.Schema, event.Data.Table, err)
+			case OnErrorPassThrough:
+				t.logger.Warn(err, "transforming column, passing through original value", loglib.Fields{
+					"on_error":    OnErrorPassThrough,
+					"column_name": col.Name,
+					"schema":      event.Data.Schema,
+					"table":       event.Data.Table,
+				})
+				newValue = col.Value
+			default:
+				t.logger.Error(err, "transforming column", loglib.Fields{
+					"severity":    "DATALOSS",
+					"on_error":    OnErrorNull,
+					"column_name": col.Name,
+					"schema":      event.Data.Schema,
+					"table":       event.Data.Table,
+				})
+				newValue = nil
+			}
 		}
 		// avoid logging large values on the hot path unless trace is enabled
 		if t.logger.IsTraceEnabled() {

--- a/pkg/wal/processor/transformer/wal_transformer_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_test.go
@@ -83,6 +83,7 @@ func TestTransformer_New(t *testing.T) {
 				transformerMap:       testTransformerMap,
 				validationMode:       validationModeStrict,
 				tableValidationModes: map[string]string{},
+				onError:              OnErrorNull,
 			},
 			wantErr: nil,
 		},
@@ -124,6 +125,7 @@ func TestTransformer_New(t *testing.T) {
 					"\"public\".\"test1\"": validationModeStrict,
 					"\"test\".\"test2\"":   validationModeRelaxed,
 				},
+				onError: OnErrorNull,
 			},
 			wantErr: nil,
 		},
@@ -211,6 +213,7 @@ func TestTransformer_ProcessWALEvent(t *testing.T) {
 		processor            processor.Processor
 		transformerMap       *TransformerMap
 		validationMode       string
+		onError              string
 		ddlEventToSchemaDiff func(ddlEvent *wal.DDLEvent) (*wal.SchemaDiff, error)
 
 		wantErr error
@@ -385,7 +388,32 @@ func TestTransformer_ProcessWALEvent(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "error - transforming",
+			name: "error - transforming, fail policy stops the pipeline",
+			event: newTestEvent([]wal.Column{
+				{Name: "column_1", Type: "text", Value: "one"},
+				{Name: "column_2", Type: "int", Value: 1},
+			}),
+			processor: &mocks.Processor{
+				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Event) error {
+					return errors.New("ProcessWALEvent should not be called when transformation fails")
+				},
+			},
+			transformerMap: &TransformerMap{
+				activeTransformerMap: map[string]ColumnTransformers{
+					testKey: {
+						"column_1": &transformermocks.Transformer{
+							TransformFn: func(a transformers.Value) (any, error) {
+								return nil, errTest
+							},
+						},
+					},
+				},
+			},
+			onError: OnErrorFail,
+			wantErr: errTest,
+		},
+		{
+			name: "error - transforming, default (null) policy writes NULL",
 			event: newTestEvent([]wal.Column{
 				{Name: "column_1", Type: "text", Value: "one"},
 				{Name: "column_2", Type: "int", Value: 1},
@@ -411,6 +439,37 @@ func TestTransformer_ProcessWALEvent(t *testing.T) {
 					},
 				},
 			},
+			// onError left empty to exercise the default (null) policy.
+			wantErr: nil,
+		},
+		{
+			name: "error - transforming, pass-through policy keeps original value",
+			event: newTestEvent([]wal.Column{
+				{Name: "column_1", Type: "text", Value: "one"},
+				{Name: "column_2", Type: "int", Value: 1},
+			}),
+			processor: &mocks.Processor{
+				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Event) error {
+					wantEvent := newTestEvent([]wal.Column{
+						{Name: "column_1", Type: "text", Value: "one"},
+						{Name: "column_2", Type: "int", Value: 1},
+					})
+					require.Equal(t, wantEvent, walEvent)
+					return nil
+				},
+			},
+			transformerMap: &TransformerMap{
+				activeTransformerMap: map[string]ColumnTransformers{
+					testKey: {
+						"column_1": &transformermocks.Transformer{
+							TransformFn: func(a transformers.Value) (any, error) {
+								return nil, errTest
+							},
+						},
+					},
+				},
+			},
+			onError: OnErrorPassThrough,
 
 			wantErr: nil,
 		},
@@ -450,6 +509,7 @@ func TestTransformer_ProcessWALEvent(t *testing.T) {
 				transformerMap:       tc.transformerMap,
 				processor:            tc.processor,
 				validationMode:       validationModeRelaxed,
+				onError:              tc.onError,
 				walDataToDDLEvent:    func(data *wal.Data) (*wal.DDLEvent, error) { return &wal.DDLEvent{}, nil },
 				ddlEventToSchemaDiff: tc.ddlEventToSchemaDiff,
 			}


### PR DESCRIPTION
#### Description

Previously, if a column transformer returned an error, the WAL transformer set the column value to nil and continued, writing NULL to the target. The event still checkpointed, so the corruption was permanent and only visible as a log line. On `NOT NULL` target columns it instead surfaced as a downstream constraint violation and the whole row change was dropped.

This PR adds on-error policy to the transformer config called `on_error`.

Three possible options:
* `null` (default)
* `pass-through`
* `fail`

`null` is the default value so there is no behaviour change for existing users.

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
