### PR TITLE
Improve SQL parameter binding and escaping

### DIFF
--- a/internal/postgres/pg_utils.go
+++ b/internal/postgres/pg_utils.go
@@ -97,7 +97,21 @@ func QuoteQualifiedIdentifier(schema, table string) string {
 }
 
 func IsQuotedIdentifier(s string) bool {
-	return len(s) > 2 && strings.HasPrefix(s, `"`) && strings.HasSuffix(s, `"`)
+	if len(s) <= 2 || !strings.HasPrefix(s, `"`) || !strings.HasSuffix(s, `"`) {
+		return false
+	}
+	inner := s[1 : len(s)-1]
+	for i := 0; i < len(inner); i++ {
+		if inner[i] != '"' {
+			continue
+		}
+		if i+1 < len(inner) && inner[i+1] == '"' {
+			i++
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 type (

--- a/internal/postgres/pg_utils_test.go
+++ b/internal/postgres/pg_utils_test.go
@@ -147,6 +147,30 @@ func Test_QuoteIdentifier(t *testing.T) {
 			input:    "",
 			expected: `""`,
 		},
+		{
+			// starts and ends with a double quote but is not a well-formed
+			// quoted identifier (the inner quote is unpaired) - must be
+			// re-quoted/escaped, not trusted verbatim, or it would allow
+			// SQL injection via a crafted "identifier".
+			name:     "malicious lookalike quoted identifier is escaped, not trusted",
+			input:    `"a" ; DROP TABLE users; --"`,
+			expected: `"""a"" ; DROP TABLE users; --"""`,
+		},
+		{
+			// already well-formed: the inner quote is doubled, so it is a
+			// genuine quoted identifier and is trusted verbatim.
+			name:     "already quoted identifier with escaped inner quote",
+			input:    `"my""table"`,
+			expected: `"my""table"`,
+		},
+		{
+			// injection-looking payload, but every inner quote is doubled, so
+			// it IS a well-formed quoted identifier and is returned as-is
+			// (the ";" and "--" are just part of the identifier's name).
+			name:     "well-formed quoted identifier with doubled inner quotes is trusted",
+			input:    `"a""; DROP TABLE users; --"`,
+			expected: `"a""; DROP TABLE users; --"`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -305,6 +329,16 @@ func Test_IsQuotedIdentifier(t *testing.T) {
 		{
 			name:     "three characters with quotes",
 			input:    `"a"`,
+			expected: true,
+		},
+		{
+			name:     "starts/ends with quote but has an unpaired inner quote - not well-formed",
+			input:    `"a" ; DROP TABLE users; --"`,
+			expected: false,
+		},
+		{
+			name:     "well-formed with doubled inner quotes",
+			input:    `"my""table"`,
 			expected: true,
 		},
 	}
@@ -562,9 +596,9 @@ func Test_UnquoteIdentifier(t *testing.T) {
 			expected: `""`,
 		},
 		{
-			name:     "three quotes - empty after unquoting",
+			name:     "three quotes - malformed (unpaired), returned as-is",
 			input:    `"""`,
-			expected: `"`,
+			expected: `"""`,
 		},
 		{
 			name:     "quoted with special characters",
@@ -585,6 +619,21 @@ func Test_UnquoteIdentifier(t *testing.T) {
 			name:     "quoted with multiple embedded escaped quotes",
 			input:    `"my""table""name"`,
 			expected: `my"table"name`,
+		},
+		{
+			// starts/ends with a quote but the inner quotes are unpaired, so it
+			// is not a well-formed quoted identifier - returned untouched rather
+			// than stripped into a mangled fragment.
+			name:     "malicious lookalike is not unquoted, returned as-is",
+			input:    `"a" ; DROP TABLE users; --"`,
+			expected: `"a" ; DROP TABLE users; --"`,
+		},
+		{
+			// every inner quote is doubled, so this IS a well-formed quoted
+			// identifier: outer quotes stripped and "" collapsed to ".
+			name:     "well-formed quoted identifier with doubled inner quotes is unquoted",
+			input:    `"a""; DROP TABLE users; --"`,
+			expected: `a"; DROP TABLE users; --`,
 		},
 		{
 			name:     "quoted empty string",

--- a/internal/postgres/pg_utils_test.go
+++ b/internal/postgres/pg_utils_test.go
@@ -148,25 +148,16 @@ func Test_QuoteIdentifier(t *testing.T) {
 			expected: `""`,
 		},
 		{
-			// starts and ends with a double quote but is not a well-formed
-			// quoted identifier (the inner quote is unpaired) - must be
-			// re-quoted/escaped, not trusted verbatim, or it would allow
-			// SQL injection via a crafted "identifier".
 			name:     "malicious lookalike quoted identifier is escaped, not trusted",
 			input:    `"a" ; DROP TABLE users; --"`,
 			expected: `"""a"" ; DROP TABLE users; --"""`,
 		},
 		{
-			// already well-formed: the inner quote is doubled, so it is a
-			// genuine quoted identifier and is trusted verbatim.
 			name:     "already quoted identifier with escaped inner quote",
 			input:    `"my""table"`,
 			expected: `"my""table"`,
 		},
 		{
-			// injection-looking payload, but every inner quote is doubled, so
-			// it IS a well-formed quoted identifier and is returned as-is
-			// (the ";" and "--" are just part of the identifier's name).
 			name:     "well-formed quoted identifier with doubled inner quotes is trusted",
 			input:    `"a""; DROP TABLE users; --"`,
 			expected: `"a""; DROP TABLE users; --"`,

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -812,7 +812,7 @@ func (s *SnapshotGenerator) removeRestrictedRoleAttributes(line string) string {
 	if len(roles) == 0 {
 		return line
 	}
-	line += fmt.Sprintf("\nGRANT rds_replication TO %s;", roles[0].name)
+	line += fmt.Sprintf("\nGRANT rds_replication TO %s;", pglib.QuoteIdentifier(roles[0].name))
 	return line
 }
 

--- a/pkg/snapshot/store/postgres/pg_snapshot_store.go
+++ b/pkg/snapshot/store/postgres/pg_snapshot_store.go
@@ -64,8 +64,8 @@ func (s *Store) UpdateSnapshotRequest(ctx context.Context, req *snapshot.Request
 
 func (s *Store) GetSnapshotRequestsByStatus(ctx context.Context, status snapshot.Status) ([]*snapshot.Request, error) {
 	query := fmt.Sprintf(`SELECT schema_name,table_names,status,errors FROM %s
-	WHERE status = '%s' ORDER BY req_id ASC LIMIT %d`, snapshotsTable(), status, queryLimit)
-	rows, err := s.conn.Query(ctx, query)
+	WHERE status = $1 ORDER BY req_id ASC LIMIT %d`, snapshotsTable(), queryLimit)
+	rows, err := s.conn.Query(ctx, query, status)
 	if err != nil {
 		return nil, fmt.Errorf("error getting snapshot requests by status: %w", err)
 	}

--- a/pkg/snapshot/store/postgres/pg_snapshot_store_test.go
+++ b/pkg/snapshot/store/postgres/pg_snapshot_store_test.go
@@ -307,8 +307,9 @@ func TestStore_GetSnapshotRequestsByStatus(t *testing.T) {
 			querier: &postgresmocks.Querier{
 				QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
 					wantQuery := fmt.Sprintf(`SELECT schema_name,table_names,status,errors FROM %s
-	WHERE status = '%s' ORDER BY req_id ASC LIMIT %d`, snapshotsTable(), snapshot.StatusInProgress, queryLimit)
+	WHERE status = $1 ORDER BY req_id ASC LIMIT %d`, snapshotsTable(), queryLimit)
 					require.Equal(t, wantQuery, query)
+					require.Equal(t, []any{snapshot.StatusInProgress}, args)
 					return &postgresmocks.Rows{
 						CloseFn: func() {},
 						NextFn:  func(_ uint) bool { return false },
@@ -324,8 +325,9 @@ func TestStore_GetSnapshotRequestsByStatus(t *testing.T) {
 			querier: &postgresmocks.Querier{
 				QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
 					wantQuery := fmt.Sprintf(`SELECT schema_name,table_names,status,errors FROM %s
-	WHERE status = '%s' ORDER BY req_id ASC LIMIT %d`, snapshotsTable(), snapshot.StatusInProgress, queryLimit)
+	WHERE status = $1 ORDER BY req_id ASC LIMIT %d`, snapshotsTable(), queryLimit)
 					require.Equal(t, wantQuery, query)
+					require.Equal(t, []any{snapshot.StatusInProgress}, args)
 					return &postgresmocks.Rows{
 						CloseFn: func() {},
 						NextFn:  func(i uint) bool { return i == 1 },
@@ -373,8 +375,9 @@ func TestStore_GetSnapshotRequestsByStatus(t *testing.T) {
 			querier: &postgresmocks.Querier{
 				QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
 					wantQuery := fmt.Sprintf(`SELECT schema_name,table_names,status,errors FROM %s
-	WHERE status = '%s' ORDER BY req_id ASC LIMIT %d`, snapshotsTable(), snapshot.StatusInProgress, queryLimit)
+	WHERE status = $1 ORDER BY req_id ASC LIMIT %d`, snapshotsTable(), queryLimit)
 					require.Equal(t, wantQuery, query)
+					require.Equal(t, []any{snapshot.StatusInProgress}, args)
 					return &postgresmocks.Rows{
 						CloseFn: func() {},
 						NextFn:  func(i uint) bool { return i == 1 },

--- a/pkg/stream/stream_init.go
+++ b/pkg/stream/stream_init.go
@@ -204,7 +204,7 @@ func dropMigrationTables(ctx context.Context, conn *pgx.Conn, migrationAssets []
 }
 
 func createReplicationSlot(ctx context.Context, conn *pgx.Conn, slotName string) error {
-	_, err := conn.Exec(ctx, fmt.Sprintf(`SELECT 'init' FROM pg_create_logical_replication_slot ('%s', 'wal2json')`, slotName))
+	_, err := conn.Exec(ctx, `SELECT 'init' FROM pg_create_logical_replication_slot($1, 'wal2json')`, slotName)
 	if err != nil && !isDuplicateObject(err) {
 		return err
 	}
@@ -212,7 +212,7 @@ func createReplicationSlot(ctx context.Context, conn *pgx.Conn, slotName string)
 }
 
 func dropReplicationSlot(ctx context.Context, conn *pgx.Conn, slotName string) error {
-	_, err := conn.Exec(ctx, fmt.Sprintf(`SELECT pg_drop_replication_slot('%[1]s') from pg_replication_slots where slot_name = '%[1]s'`, slotName))
+	_, err := conn.Exec(ctx, `SELECT pg_drop_replication_slot(slot_name) from pg_replication_slots where slot_name = $1`, slotName)
 	return err
 }
 
@@ -296,7 +296,7 @@ func cleanupV09xState(ctx context.Context, conn *pgx.Conn) error {
 		return fmt.Errorf("iterating event triggers: %w", err)
 	}
 	for _, name := range triggers {
-		if _, err := conn.Exec(ctx, fmt.Sprintf("DROP EVENT TRIGGER IF EXISTS %s", name)); err != nil {
+		if _, err := conn.Exec(ctx, fmt.Sprintf("DROP EVENT TRIGGER IF EXISTS %s", pglib.QuoteIdentifier(name))); err != nil {
 			return fmt.Errorf("dropping event trigger %s: %w", name, err)
 		}
 	}

--- a/pkg/wal/replication/postgres/pg_replication_handler.go
+++ b/pkg/wal/replication/postgres/pg_replication_handler.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	pglib "github.com/xataio/pgstream/internal/postgres"
 	loglib "github.com/xataio/pgstream/pkg/log"
@@ -61,6 +62,10 @@ const (
 	logSystemID    = "system_id"
 )
 
+func escapeReplicationOptionValue(s string) string {
+	return strings.ReplaceAll(s, `'`, `''`)
+}
+
 var defaultPluginArguments = []string{
 	`"include-timestamp" '1'`,
 	`"format-version" '2'`,
@@ -84,6 +89,9 @@ func NewHandler(ctx context.Context, cfg Config, opts ...Option) (*Handler, erro
 	replicationSlotName := cfg.ReplicationSlotName
 	if replicationSlotName == "" {
 		replicationSlotName = pglib.DefaultReplicationSlotName(sysID.DBName)
+	}
+	if err := pglib.IsValidReplicationSlotName(replicationSlotName); err != nil {
+		return nil, err
 	}
 
 	connBuilder := func() (pglib.Querier, error) {
@@ -113,10 +121,10 @@ func NewHandler(ctx context.Context, cfg Config, opts ...Option) (*Handler, erro
 		h.pluginArguments = append(h.pluginArguments, `"include-xids" '1'`)
 	}
 	if cfg.PluginArguments.AddTables != "" {
-		h.pluginArguments = append(h.pluginArguments, fmt.Sprintf(`"add-tables" '%s'`, cfg.PluginArguments.AddTables))
+		h.pluginArguments = append(h.pluginArguments, fmt.Sprintf(`"add-tables" '%s'`, escapeReplicationOptionValue(cfg.PluginArguments.AddTables)))
 	}
 	if cfg.PluginArguments.FilterTables != "" {
-		h.pluginArguments = append(h.pluginArguments, fmt.Sprintf(`"filter-tables" '%s'`, cfg.PluginArguments.FilterTables))
+		h.pluginArguments = append(h.pluginArguments, fmt.Sprintf(`"filter-tables" '%s'`, escapeReplicationOptionValue(cfg.PluginArguments.FilterTables)))
 	}
 
 	if len(cfg.IncludeTables) > 0 {


### PR DESCRIPTION
#### Description

This PR addresses multiple SQL issues in pgstream.

- parameters are binded where possible
- `source.postgresql.replication.replication_slot` is escaped correctly
- `IsQuotedIdentifier` not only checks if the quotes but validates the whole token

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
