### PR TITLE
Call `WalDataToDDLEvent` once per event in the processor chain

### DIFF
--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_test.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_test.go
@@ -1178,6 +1178,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 			}
 			diff := cmp.Diff(events, tc.wantEvents,
 				cmpopts.IgnoreFields(wal.Data{}, "Timestamp"),
+				cmpopts.IgnoreUnexported(wal.Data{}),
 				cmpopts.SortSlices(func(a, b *wal.Event) bool { return a.Data.Table < b.Data.Table }))
 			require.Empty(t, diff, fmt.Sprintf("got: \n%v, \nwant \n%v, \ndiff: \n%s", events, tc.wantEvents, diff))
 		})
@@ -1701,6 +1702,7 @@ func TestSnapshotGenerator_snapshotTableRange(t *testing.T) {
 			}
 			diff := cmp.Diff(events, tc.wantEvents,
 				cmpopts.IgnoreFields(wal.Data{}, "Timestamp"),
+				cmpopts.IgnoreUnexported(wal.Data{}),
 				cmpopts.SortSlices(func(a, b *wal.Event) bool { return a.Data.Table < b.Data.Table }))
 			require.Empty(t, diff, fmt.Sprintf("got: \n%v, \nwant \n%v, \ndiff: \n%s", events, tc.wantEvents, diff))
 		})

--- a/pkg/wal/listener/kafka/wal_kafka_reader_test.go
+++ b/pkg/wal/listener/kafka/wal_kafka_reader_test.go
@@ -44,7 +44,12 @@ func TestReader_Listen(t *testing.T) {
 		require.Equal(t, []byte("test-value"), b)
 		data, ok := a.(*wal.Data)
 		require.True(t, ok)
-		*data = *testWalEvent.Data
+		// assign fields individually rather than copying the struct by value:
+		// wal.Data holds a sync.Once for DDL-event memoisation and must not be
+		// copied (this mirrors how the real deserialiser populates fields).
+		data.Action = testWalEvent.Data.Action
+		data.Schema = testWalEvent.Data.Schema
+		data.Table = testWalEvent.Data.Table
 		return nil
 	}
 

--- a/pkg/wal/processor/filter/wal_filter_test.go
+++ b/pkg/wal/processor/filter/wal_filter_test.go
@@ -200,11 +200,9 @@ func TestFilter_ProcessWALEvent(t *testing.T) {
 			},
 			processor: &mocks.Processor{
 				ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Event) error {
-					require.Equal(t, &wal.Data{
-						Action:  wal.LogicalMessageAction,
-						Prefix:  wal.DDLPrefix,
-						Content: string(ddlEventBytes),
-					}, walEvent.Data)
+					require.Equal(t, wal.LogicalMessageAction, walEvent.Data.Action)
+					require.Equal(t, wal.DDLPrefix, walEvent.Data.Prefix)
+					require.Equal(t, string(ddlEventBytes), walEvent.Data.Content)
 					return nil
 				},
 			},

--- a/pkg/wal/wal_data.go
+++ b/pkg/wal/wal_data.go
@@ -5,6 +5,7 @@ package wal
 import (
 	"errors"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/rs/xid"
@@ -33,6 +34,10 @@ type Data struct {
 	Content string `json:"content,omitempty"`
 	// pgstream specific metadata
 	Metadata Metadata `json:"metadata"`
+
+	ddlEventOnce sync.Once
+	ddlEvent     *DDLEvent
+	ddlEventErr  error
 }
 
 // Metadata is pgstream specific properties to help identify the id/version

--- a/pkg/wal/wal_ddl.go
+++ b/pkg/wal/wal_ddl.go
@@ -55,8 +55,16 @@ func (d *Data) IsDDLEvent() bool {
 	return d.Action == LogicalMessageAction && d.Prefix == DDLPrefix
 }
 
-// WalDataToDDLEvent parses the wal data content field as a DDL event
+// WalDataToDDLEvent parses the wal data content field as a DDL event.
+// The parsed result (or error) is cached on the Data value.
 func WalDataToDDLEvent(d *Data) (*DDLEvent, error) {
+	d.ddlEventOnce.Do(func() {
+		d.ddlEvent, d.ddlEventErr = parseDDLEvent(d)
+	})
+	return d.ddlEvent, d.ddlEventErr
+}
+
+func parseDDLEvent(d *Data) (*DDLEvent, error) {
 	if !d.IsDDLEvent() {
 		return nil, fmt.Errorf("%w: action=%s, prefix=%s", ErrNotDDLEvent, d.Action, d.Prefix)
 	}

--- a/pkg/wal/wal_ddl.go
+++ b/pkg/wal/wal_ddl.go
@@ -56,7 +56,20 @@ func (d *Data) IsDDLEvent() bool {
 }
 
 // WalDataToDDLEvent parses the wal data content field as a DDL event.
-// The parsed result (or error) is cached on the Data value.
+//
+// The parsed result (or error) is cached on the Data value, so every processor
+// in the chain that calls this on the same event shares a single parse. The
+// returned *DDLEvent is that shared value and MUST be treated as read-only:
+// mutating it would leak into every other caller for the same event and make
+// behaviour order-dependent. Callers that need to modify it must work on a copy.
+//
+// Note that mutating a copy is only visible locally: the cache is keyed to the
+// Data value, and downstream processors re-derive the event by calling this
+// function again on the same Data, so they get the original cached parse, not
+// the copy. To forward a modified DDL event to the next processor in the
+// pipeline, replace event.Data with a new *Data whose Content reflects the
+// change (a fresh Data has an empty cache and re-parses) rather than expecting a
+// mutated copy to propagate on its own.
 func WalDataToDDLEvent(d *Data) (*DDLEvent, error) {
 	d.ddlEventOnce.Do(func() {
 		d.ddlEvent, d.ddlEventErr = parseDDLEvent(d)

--- a/pkg/wal/wal_ddl_test.go
+++ b/pkg/wal/wal_ddl_test.go
@@ -5,8 +5,98 @@ package wal
 import (
 	"testing"
 
+	jsonlib "github.com/xataio/pgstream/internal/json"
+
 	"github.com/stretchr/testify/require"
 )
+
+const testDDLContent = `{
+	"ddl": "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT)",
+	"schema_name": "public",
+	"command_tag": "CREATE TABLE",
+	"objects": [{
+		"type": "table",
+		"identity": "public.users",
+		"schema": "public",
+		"oid": "16384",
+		"pgstream_id": "ck7s8u4000001"
+	}]
+}`
+
+func TestWalDataToDDLEvent_memoisation(t *testing.T) {
+	t.Parallel()
+
+	data := &Data{
+		Action:  "M",
+		Prefix:  "pgstream.ddl",
+		Content: testDDLContent,
+	}
+
+	first, err := WalDataToDDLEvent(data)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	second, err := WalDataToDDLEvent(data)
+	require.NoError(t, err)
+
+	// repeat calls must return the exact same cached pointer, i.e. the content
+	// is parsed only once.
+	require.Same(t, first, second)
+
+	// the error path is memoised too.
+	notDDL := &Data{Action: "I"}
+	_, err1 := WalDataToDDLEvent(notDDL)
+	_, err2 := WalDataToDDLEvent(notDDL)
+	require.ErrorIs(t, err1, ErrNotDDLEvent)
+	require.ErrorIs(t, err2, ErrNotDDLEvent)
+}
+
+func BenchmarkWalDataToDDLEvent_memoised(b *testing.B) {
+	data := &Data{
+		Action:  "M",
+		Prefix:  "pgstream.ddl",
+		Content: testDDLContent,
+	}
+	// prime the memo so the benchmarked calls only hit the cached fast path.
+	if _, err := WalDataToDDLEvent(data); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := WalDataToDDLEvent(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestWalDataToDDLEvent_serialisationUnaffected(t *testing.T) {
+	t.Parallel()
+
+	// a Data whose DDL event has been memoised must serialise byte-identically
+	// to one that has not: the memo fields are unexported and excluded from JSON.
+	plain := &Data{
+		Action:  "M",
+		Prefix:  "pgstream.ddl",
+		Content: testDDLContent,
+		Schema:  "public",
+	}
+	memoised := &Data{
+		Action:  "M",
+		Prefix:  "pgstream.ddl",
+		Content: testDDLContent,
+		Schema:  "public",
+	}
+	_, err := WalDataToDDLEvent(memoised)
+	require.NoError(t, err)
+
+	plainBytes, err := jsonlib.Marshal(plain)
+	require.NoError(t, err)
+	memoisedBytes, err := jsonlib.Marshal(memoised)
+	require.NoError(t, err)
+
+	require.Equal(t, plainBytes, memoisedBytes)
+}
 
 func TestData_IsDDLEvent(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
#### Description


Every processor in the chain (filter, injector, transformer, and the postgres DDL adapter) independently called `WalDataToDDLEvent` on the same event, and each call ran `json.Unmarshal([]byte(d.Content))`.
From now on parsing result is cached. So there is no need for the expensive `json.Unmarshals`.

Cachingthe parse on `wal.Data` reduces 5 `json.Unmarshal` passes per event down to 1 (+4 cached hits), cutting time and allocations ~74%. The gain scales with how many processors  in the chain call `WalDataToDDLEvent` on the same event.

| Metric | main (baseline) | this pr | Δ vs main |
|---|---|---|---|
| Time | 6.669µ | 1.747µ | −73.80% |
| Bytes/op | 5.104Ki | 1.321Ki | −74.12% |
| Allocs/op | 25.000 | 6.000 | −76.00% |

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
