### PR TITLE
[Preflight] New category: `resources`

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -33,6 +33,11 @@
           "default": "false"
         },
         {
+          "name": "resources",
+          "description": "Run resource capacity checks against the source (snapshot connection headroom vs max_connections)",
+          "default": "false"
+        },
+        {
           "name": "schema",
           "description": "Run schema compatibility checks against the source",
           "default": "false"

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -121,6 +121,7 @@ func Prepare() *cobra.Command {
 	checkCmd.Flags().Bool("replication", false, "Run replication checks against the source (requires replication slot configured)")
 	checkCmd.Flags().Bool("access", false, "Run access and privilege checks against the source")
 	checkCmd.Flags().Bool("schema", false, "Run schema compatibility checks against the source")
+	checkCmd.Flags().Bool("resources", false, "Run resource capacity checks against the source (snapshot connection headroom vs max_connections)")
 
 	// Flag binding for root cmd
 	rootFlagBinding(rootCmd)

--- a/pkg/snapshot/generator/postgres/data/config.go
+++ b/pkg/snapshot/generator/postgres/data/config.go
@@ -60,6 +60,14 @@ func (c *Config) snapshotWorkers() uint {
 	return defaultSnapshotWorkers
 }
 
+// EffectiveSnapshotWorkers returns the number of snapshots processed
+// concurrently once the default is applied.
+func (c *Config) EffectiveSnapshotWorkers() uint { return c.snapshotWorkers() }
+
+// EffectiveTableWorkers returns the number of concurrent workers per table once
+// the default is applied.
+func (c *Config) EffectiveTableWorkers() uint { return c.tableWorkers() }
+
 func (c *Config) maxConnections() uint {
 	if c.MaxConnections > 0 {
 		return c.MaxConnections

--- a/pkg/stream/config.go
+++ b/pkg/stream/config.go
@@ -213,6 +213,22 @@ func (c *Config) GetInitConfig(opts ...InitOption) *InitConfig {
 	return initConfig
 }
 
+// SnapshotConnectionDemand reports the peak number of concurrent source
+// connections the data snapshot will open (snapshot_workers × table_workers,
+// with defaults applied), and whether a data snapshot is configured at all.
+// Callers use ok to gate the resources preflight check: there's no demand to
+// size when no data snapshot runs.
+func (c *Config) SnapshotConnectionDemand() (demand uint, ok bool) {
+	if c.Listener.Postgres == nil || c.Listener.Postgres.Snapshot == nil {
+		return 0, false
+	}
+	data := c.Listener.Postgres.Snapshot.Data
+	if data == nil {
+		return 0, false
+	}
+	return data.EffectiveSnapshotWorkers() * data.EffectiveTableWorkers(), true
+}
+
 func (c *Config) RequiredTables() []string {
 	requiredTables := []string{}
 	if c.Listener.Postgres != nil {

--- a/pkg/stream/preflight/builder.go
+++ b/pkg/stream/preflight/builder.go
@@ -30,6 +30,27 @@ var Builders = []Builder{
 	{CategoryReplication, "replication", BuildReplicationChecks},
 	{CategoryAccess, "access", BuildAccessChecks},
 	{CategorySchema, "schema", BuildSchemaChecks},
+	{CategoryResources, "resources", BuildResourcesChecks},
+}
+
+// BuildResourcesChecks returns the resource-capacity preflight checks
+// applicable to cfg, plus a cleanup function that closes the shared source
+// connection. The snapshot connection-headroom check only applies when a data
+// snapshot is configured (it sizes snapshot_workers × table_workers against the
+// source's max_connections).
+func BuildResourcesChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
+	url := cfg.SourcePostgresURL()
+	if url == "" {
+		return nil, nil
+	}
+	demand, ok := cfg.SnapshotConnectionDemand()
+	if !ok {
+		return nil, nil
+	}
+	src := postgres.NewLazyConn(url)
+	return []Check{
+		&SnapshotConnectionsCheck{Source: src.Acquire, Demand: demand},
+	}, src.Close
 }
 
 // BuildConnectivityChecks returns the connectivity checks applicable to cfg.

--- a/pkg/stream/preflight/preflight.go
+++ b/pkg/stream/preflight/preflight.go
@@ -17,6 +17,7 @@ const (
 	CategoryReplication  Category = "replication"
 	CategoryAccess       Category = "access"
 	CategorySchema       Category = "schema"
+	CategoryResources    Category = "resources"
 )
 
 // Finding describes a single issue detected by a Check. Every finding is an

--- a/pkg/stream/preflight/resources.go
+++ b/pkg/stream/preflight/resources.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/xataio/pgstream/internal/postgres"
+)
+
+// SnapshotConnectionsCheck verifies the source Postgres has enough spare
+// connection slots to serve the snapshot's peak concurrency
+// (snapshot_workers × table_workers) on top of what is already in use, without
+// exceeding max_connections. Non-superuser roles cannot use the slots reserved
+// by superuser_reserved_connections, so those are excluded from the headroom.
+type SnapshotConnectionsCheck struct {
+	Source postgres.AcquireFunc
+	// Demand is the number of concurrent connections the snapshot will open at
+	// peak (snapshot_workers × table_workers).
+	Demand uint
+}
+
+func (c *SnapshotConnectionsCheck) Name() string { return "snapshot_connection_headroom" }
+
+func (c *SnapshotConnectionsCheck) Run(ctx context.Context) ([]Finding, error) {
+	conn, err := c.Source(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to source: %w", err)
+	}
+
+	var maxConns, reserved, used int
+	err = conn.QueryRow(ctx, []any{&maxConns, &reserved, &used}, `
+		SELECT
+		  (SELECT setting::int FROM pg_settings WHERE name = 'max_connections'),
+		  (SELECT setting::int FROM pg_settings WHERE name = 'superuser_reserved_connections'),
+		  (SELECT count(*)::int FROM pg_stat_activity)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying connection limits: %w", err)
+	}
+
+	available := maxConns - reserved - used
+	if available < 0 {
+		available = 0
+	}
+	if int(c.Demand) > available {
+		return []Finding{{
+			Message: fmt.Sprintf(
+				"snapshot needs %d concurrent connections (snapshot_workers × table_workers) but source has only %d available (max_connections=%d, superuser_reserved_connections=%d, %d in use); lower snapshot_workers/table_workers, raise max_connections (requires restart), or reduce existing connections",
+				c.Demand, available, maxConns, reserved, used),
+		}}, nil
+	}
+	return nil, nil
+}

--- a/pkg/stream/preflight/resources_test.go
+++ b/pkg/stream/preflight/resources_test.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/postgres/mocks"
+	pgsnapshotgenerator "github.com/xataio/pgstream/pkg/snapshot/generator/postgres/data"
+	"github.com/xataio/pgstream/pkg/stream"
+	snapshotbuilder "github.com/xataio/pgstream/pkg/wal/listener/snapshot/builder"
+)
+
+// sourceWithConnLimits returns an AcquireFunc whose Querier answers the
+// SnapshotConnectionsCheck query with the given max_connections,
+// superuser_reserved_connections and in-use count.
+func sourceWithConnLimits(t *testing.T, maxConns, reserved, used int) postgres.AcquireFunc {
+	return func(context.Context) (postgres.Querier, error) {
+		return &mocks.Querier{
+			QueryRowFn: func(_ context.Context, dest []any, _ string, _ ...any) error {
+				maxDest, ok := dest[0].(*int)
+				require.True(t, ok)
+				reservedDest, ok := dest[1].(*int)
+				require.True(t, ok)
+				usedDest, ok := dest[2].(*int)
+				require.True(t, ok)
+				*maxDest, *reservedDest, *usedDest = maxConns, reserved, used
+				return nil
+			},
+		}, nil
+	}
+}
+
+func TestSnapshotConnectionsCheck_Run(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		demand   uint
+		maxConns int
+		reserved int
+		used     int
+		wantHit  bool
+		wantSubs []string
+	}{
+		{
+			name:     "ample headroom",
+			demand:   16,
+			maxConns: 100,
+			reserved: 3,
+			used:     10,
+		},
+		{
+			name:     "exactly fits",
+			demand:   87,
+			maxConns: 100,
+			reserved: 3,
+			used:     10,
+		},
+		{
+			name:     "one over available is a finding",
+			demand:   88,
+			maxConns: 100,
+			reserved: 3,
+			used:     10,
+			wantHit:  true,
+			wantSubs: []string{"88 concurrent connections", "87 available", "max_connections=100", "superuser_reserved_connections=3", "10 in use"},
+		},
+		{
+			name:     "reserved connections eat into headroom",
+			demand:   5,
+			maxConns: 10,
+			reserved: 3,
+			used:     3,
+			wantHit:  true,
+			wantSubs: []string{"5 concurrent connections", "4 available"},
+		},
+		{
+			name:     "already over budget clamps available to zero",
+			demand:   1,
+			maxConns: 10,
+			reserved: 3,
+			used:     20,
+			wantHit:  true,
+			wantSubs: []string{"only 0 available"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			check := &SnapshotConnectionsCheck{
+				Source: sourceWithConnLimits(t, tc.maxConns, tc.reserved, tc.used),
+				Demand: tc.demand,
+			}
+
+			findings, err := check.Run(context.Background())
+
+			require.NoError(t, err)
+			if !tc.wantHit {
+				require.Empty(t, findings)
+				return
+			}
+			require.Len(t, findings, 1)
+			for _, sub := range tc.wantSubs {
+				require.Contains(t, findings[0].Message, sub)
+			}
+		})
+	}
+}
+
+func TestBuildResourcesChecks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cfg        *stream.Config
+		wantChecks int
+		wantDemand uint
+	}{
+		{
+			name: "no source postgres url returns no checks",
+			cfg:  &stream.Config{},
+		},
+		{
+			name: "source without data snapshot returns no checks",
+			cfg: &stream.Config{
+				Listener: stream.ListenerConfig{
+					Postgres: &stream.PostgresListenerConfig{URL: "postgres://source"},
+				},
+			},
+		},
+		{
+			name: "data snapshot with defaults sizes 1x4",
+			cfg: &stream.Config{
+				Listener: stream.ListenerConfig{
+					Postgres: &stream.PostgresListenerConfig{
+						URL: "postgres://source",
+						Snapshot: &snapshotbuilder.SnapshotListenerConfig{
+							Data: &pgsnapshotgenerator.Config{},
+						},
+					},
+				},
+			},
+			wantChecks: 1,
+			wantDemand: 4,
+		},
+		{
+			name: "explicit workers multiply",
+			cfg: &stream.Config{
+				Listener: stream.ListenerConfig{
+					Postgres: &stream.PostgresListenerConfig{
+						URL: "postgres://source",
+						Snapshot: &snapshotbuilder.SnapshotListenerConfig{
+							Data: &pgsnapshotgenerator.Config{SnapshotWorkers: 3, TableWorkers: 5},
+						},
+					},
+				},
+			},
+			wantChecks: 1,
+			wantDemand: 15,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			checks, cleanup := BuildResourcesChecks(tc.cfg)
+
+			require.Len(t, checks, tc.wantChecks)
+			if tc.wantChecks == 0 {
+				require.Nil(t, cleanup)
+				return
+			}
+			require.NotNil(t, cleanup)
+			connCheck, ok := checks[0].(*SnapshotConnectionsCheck)
+			require.True(t, ok)
+			require.Equal(t, tc.wantDemand, connCheck.Demand)
+		})
+	}
+}
+
+func TestSnapshotConnectionsCheck_Run_ConnectFails(t *testing.T) {
+	t.Parallel()
+
+	connErr := errors.New("boom")
+	check := &SnapshotConnectionsCheck{
+		Source: func(context.Context) (postgres.Querier, error) {
+			return nil, connErr
+		},
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.Nil(t, findings)
+	require.ErrorIs(t, err, connErr)
+	require.ErrorContains(t, err, "connecting to source")
+}
+
+func TestSnapshotConnectionsCheck_Run_QueryFails(t *testing.T) {
+	t.Parallel()
+
+	queryErr := errors.New("query failed")
+	check := &SnapshotConnectionsCheck{
+		Source: func(context.Context) (postgres.Querier, error) {
+			return &mocks.Querier{
+				QueryRowFn: func(context.Context, []any, string, ...any) error {
+					return queryErr
+				},
+			}, nil
+		},
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.Nil(t, findings)
+	require.ErrorIs(t, err, queryErr)
+	require.ErrorContains(t, err, "querying connection limits")
+}


### PR DESCRIPTION
#### Description

This PR adds a new preflight check category called `resources`. It checks if the available number of connections of the source database match the configuration of `pgstream`.

##### Example

Success

```sh
$ pgstream check --resources
✔ snapshot_connection_headroom
ran 1 checks
```

```sh
$ pgstream check --resources --json
{
      "results": [
              {
                      "findings": null,
                      "name": "snapshot_connection_headroom"
              }
      ]
}
```

Error (insufficient connection headroom)

```sh
$ pgstream check --resources
✘ snapshot_connection_headroom: snapshot needs 88 concurrent connections (snapshot_workers × table_workers) but source has only 87 available (max_connections=100, superuser_reserved_connections=3, 10 in use); lower snapshot_workers/table_workers, raise max_connections
(requires restart), or reduce existing connections
ran 1 checks
```

```sh
$ pgstream check --resources --json
{
      "results": [
              {
                      "findings": [
                              {
                                      "message": "snapshot needs 88 concurrent connections (snapshot_workers × table_workers) but sour
(max_connections=100, superuser_reserved_connections=3, 10 in use); lower snapshot_workers/table_workers, raise max_connections
(requires restart), or reduce existing connections"
                              }
                      ],
                      "name": "snapshot_connection_headroom"
              }
      ]
}
```
##### Related Issue(s)

- Related to #897

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
