### PR TITLE
Fix exclude_tables bug with multiple schemas

### DIFF
--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/pg_options_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/pg_options_generator.go
@@ -5,6 +5,7 @@ package pgdumprestore
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 
 	pglib "github.com/xataio/pgstream/internal/postgres"
@@ -85,7 +86,7 @@ func (o *optionGenerator) pgrestoreOptions() pglib.PGRestoreOptions {
 
 func (o *optionGenerator) pgdumpOptions(ctx context.Context, schemaTables map[string][]string, excludedTables map[string][]string) (*pglib.PGDumpOptions, error) {
 	schemas := make([]string, 0, len(schemaTables))
-	for schema := range schemaTables {
+	for _, schema := range slices.Sorted(maps.Keys(schemaTables)) {
 		schemas = append(schemas, quoteSchema(schema))
 	}
 	opts := &pglib.PGDumpOptions{
@@ -134,20 +135,22 @@ func (o *optionGenerator) pgdumpOptions(ctx context.Context, schemaTables map[st
 	// objects for the schema in question. If we use the tables filter, only
 	// those tables are dumped, and any related non table objects will not be
 	// dumped, causing the restore to fail due to missing related objects.
-	for schema, tables := range schemaTables {
+	for _, schema := range slices.Sorted(maps.Keys(schemaTables)) {
+		tables := schemaTables[schema]
 		if hasWildcardTable(tables) {
 			// if there's the wildcard table, we don't need to add excluded
 			// tables, since they are all included.
 			continue
 		}
-		var err error
-		opts.ExcludeTables, err = o.pgdumpExcludedTables(ctx, schema, tables)
+		schemaExcludeTables, err := o.pgdumpExcludedTables(ctx, schema, tables)
 		if err != nil {
 			return nil, err
 		}
+		opts.ExcludeTables = appendMissing(opts.ExcludeTables, schemaExcludeTables...)
 	}
 
-	for schema, tables := range excludedTables {
+	for _, schema := range slices.Sorted(maps.Keys(excludedTables)) {
+		tables := excludedTables[schema]
 		if hasWildcardTable(tables) {
 			opts.ExcludeSchemas = append(opts.ExcludeSchemas, pglib.QuoteIdentifier(schema))
 			continue

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/pg_options_generator_test.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/pg_options_generator_test.go
@@ -269,6 +269,60 @@ func TestOptionsGenerator_pgdumpOptions(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "multiple schemas with explicit table lists",
+			schemaTables: map[string][]string{
+				"public": {"table1"},
+				"other":  {"table2"},
+			},
+			excludedTables: map[string][]string{},
+			includeGlobal:  false,
+			conn: &pglibmocks.Querier{
+				QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
+					require.Equal(t, selectSchemaTablesQuery, query)
+					require.Len(t, args, 2)
+					schema, ok := args[0].(string)
+					require.True(t, ok)
+					excludedRows := func(schema, table string) *pglibmocks.Rows {
+						return &pglibmocks.Rows{
+							NextFn: func(i uint) bool { return i == 1 },
+							ScanFn: func(i uint, dest ...any) error {
+								require.Len(t, dest, 2)
+								schemaDest, ok := dest[0].(*string)
+								require.True(t, ok)
+								*schemaDest = schema
+								tableDest, ok := dest[1].(*string)
+								require.True(t, ok)
+								*tableDest = table
+								return nil
+							},
+							ErrFn:   func() error { return nil },
+							CloseFn: func() {},
+						}
+					}
+					switch schema {
+					case "public":
+						require.Equal(t, []any{"public", []string{"table1"}}, args)
+						return excludedRows("public", "table3"), nil
+					case "other":
+						require.Equal(t, []any{"other", []string{"table2"}}, args)
+						return excludedRows("other", "table4"), nil
+					default:
+						return nil, fmt.Errorf("unexpected schema: %s", schema)
+					}
+				},
+			},
+
+			wantOpts: &pglib.PGDumpOptions{
+				ConnectionString: "source-url",
+				Format:           "p",
+				Schemas:          []string{`"other"`, `"public"`},
+				ExcludeSchemas:   nil,
+				SchemaOnly:       true,
+				ExcludeTables:    []string{`"other"."table4"`, `"public"."table3"`},
+			},
+			wantErr: nil,
+		},
+		{
 			name: "wildcard schema tables and excluded wildcard tables",
 			schemaTables: map[string][]string{
 				"*": {"*"},


### PR DESCRIPTION
#### Description

The bug was:

When a snapshot config lists explicit tables in more than one schema, the loop that converts each schema's include-list into a pg_dump exclude-list assigned to `opts.ExcludeTables` instead of appending. Each iteration wiped the previous schema's exclusions, so only one schema's list survived — and since it iterated a Go map, which schema won was nondeterministic per run.

Impact: The affected dump is schema-only, so for the losing schemas, tables outside the allowlist still had their DDL created on the target as empty tables. No unwanted data was copied (data copy is driven by the allowlist separately) — cosmetic DDL leakage only.

##### Related Issue(s)

- Fixes #(issue number)
- Closes #(issue number)
- Related to #(issue number)

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

-
-
-

#### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

#### Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Code is well-commented
- [ ] Documentation updated where necessary


#### Additional Notes

<!-- Any context or special instructions for reviewers -->
