### PR TITLE
Fix snapshot CLI never auto-enabling bulk ingest with flags

### DIFF
--- a/cmd/snapshot_cmd.go
+++ b/cmd/snapshot_cmd.go
@@ -54,6 +54,12 @@ func snapshot(ctx context.Context) error {
 }
 
 func snapshotFlagBinding(cmd *cobra.Command, args []string) error {
+	// bind the target flags first: the bulk ingest defaulting below checks the
+	// target postgres URL, which is bound from the --target-url flag here
+	if err := targetFlagBinding(cmd); err != nil {
+		return err
+	}
+
 	// to be able to overwrite configuration with flags when yaml config file is
 	// provided
 	viper.BindPFlag("source.postgres.url", cmd.Flags().Lookup("postgres-url"))
@@ -101,5 +107,5 @@ func snapshotFlagBinding(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	return targetFlagBinding(cmd)
+	return nil
 }


### PR DESCRIPTION
#### Description

`snapshotFlagBinding` checked `PGSTREAM_POSTGRES_WRITER_TARGET_URL` before `targetFlagBinding` bound it from the `--target-url` flag, so the pure-flag form of the snapshot command silently fell back to the ordered per-row batch writer instead of COPY bulk ingest (and skipped the `disable_triggers` defaulting on the same path). Bind the target flags first.

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
