### PR TITLE
Fix batch sender startup race between NewSender and Close

### DIFF
--- a/pkg/wal/processor/batch/wal_batch_sender.go
+++ b/pkg/wal/processor/batch/wal_batch_sender.go
@@ -71,9 +71,16 @@ func NewSender[T Message](ctx context.Context, config *Config, sendfn sendBatchF
 	}
 	s.queueBytesSema = synclib.NewWeightedSemaphore(int64(maxQueueBytes))
 
+	// derive the cancellable context and register the send goroutine on the
+	// wait group synchronously, before NewSender returns. Otherwise a caller
+	// that Closes immediately races the background goroutine writing s.cancelFn
+	// and calling s.wg.Add after Close's s.wg.Wait (an Add-after-Wait bug).
+	ctx, s.cancelFn = context.WithCancel(ctx)
+	s.wg.Add(1)
+
 	// start the send process in the background
 	go func() {
-		ctx, s.cancelFn = context.WithCancel(ctx)
+		defer s.wg.Done()
 		defer s.cancelFn()
 
 		if err := s.send(ctx); err != nil && !isBenignShutdownErr(err) {

--- a/pkg/wal/processor/batch/wal_batch_sender_test.go
+++ b/pkg/wal/processor/batch/wal_batch_sender_test.go
@@ -576,3 +576,24 @@ func TestSender_CloseAfterSendFailure(t *testing.T) {
 		require.ErrorIs(t, sender.Close(), errTest)
 	}
 }
+
+// Regression test: constructing a sender and closing it immediately must not
+// race the background send goroutine. Before the fix, s.cancelFn was assigned
+// and s.wg.Add called inside the background goroutine, so an immediate Close
+// could read the placeholder cancelFn and pass wg.Wait before Add ran
+// (Add-after-Wait). Caught by the race detector.
+func TestSender_CloseImmediately(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	noopSendFn := func(context.Context, *Batch[*mockMessage]) error { return nil }
+
+	for i := 0; i < 100; i++ {
+		sender, err := NewSender(ctx, &Config{
+			BatchTimeout: 100 * time.Millisecond,
+			MaxBatchSize: 1,
+		}, noopSendFn, log.NewNoopLogger())
+		require.NoError(t, err)
+		require.NoError(t, sender.Close())
+	}
+}


### PR DESCRIPTION
#### Description

The background send goroutine assigned s.cancelFn and registered itself on the wait group after `NewSender` returned. A caller closing the sender immediately could read the placeholder `cancelFn` and pass `wg.Wait` before `wg.Add` ran (an Add-after-Wait violation), tripping the race detector. Derive the cancellable context and register the goroutine synchronously before `NewSender` returns.

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
