### PR TITLE
Parallelize COPY workers

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -22,6 +22,7 @@ const (
 	defaultPostgresBulkBatchSize    = 20000
 	defaultPostgresBulkBatchTimeout = time.Duration(30 * time.Second)
 	defaultPostgresBulkBatchBytes   = int64(80 * 1024 * 1024) // 80MiB
+	defaultPostgresBulkCopyWorkers  = 8
 )
 
 func Load() error {
@@ -174,8 +175,21 @@ func applyPostgresBulkBatchDefaults(batchCfg *batch.Config) {
 	if batchCfg.MaxBatchSize == 0 {
 		batchCfg.MaxBatchSize = defaultPostgresBulkBatchSize
 	}
+	if batchCfg.SendConcurrency == 0 {
+		batchCfg.SendConcurrency = defaultPostgresBulkCopyWorkers
+	}
 	if batchCfg.MaxBatchBytes == 0 {
 		batchCfg.MaxBatchBytes = defaultPostgresBulkBatchBytes
+		// Split the batch bytes budget across the send workers: the max queue
+		// bytes semaphore holds both in-flight and accumulating batches, so a
+		// single large default batch (80MiB vs the 100MiB default queue) would
+		// only ever allow one batch in flight and the send workers could never
+		// run concurrently on tables with large rows. Splitting keeps the
+		// memory footprint unchanged while letting up to SendConcurrency
+		// batches circulate.
+		if batchCfg.SendConcurrency > 1 {
+			batchCfg.MaxBatchBytes = defaultPostgresBulkBatchBytes / int64(batchCfg.SendConcurrency)
+		}
 	}
 	if batchCfg.BatchTimeout == 0 {
 		batchCfg.BatchTimeout = defaultPostgresBulkBatchTimeout

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -184,12 +184,18 @@ func applyPostgresBulkBatchDefaults(batchCfg *batch.Config) {
 		// bytes semaphore holds both in-flight and accumulating batches, so a
 		// single large default batch (80MiB vs the 100MiB default queue) would
 		// only ever allow one batch in flight and the send workers could never
-		// run concurrently on tables with large rows. Splitting keeps the
-		// memory footprint unchanged while letting up to SendConcurrency
-		// batches circulate.
+		// run concurrently on tables with large rows.
 		if batchCfg.SendConcurrency > 1 {
 			batchCfg.MaxBatchBytes = defaultPostgresBulkBatchBytes / int64(batchCfg.SendConcurrency)
 		}
+	}
+	if batchCfg.MaxQueueBytes == 0 && batchCfg.SendConcurrency > 1 {
+		// Size the in-flight queue to hold every COPY worker's batch plus one
+		// accumulating batch, so the send-drainer pool is never starved. Since
+		// the batch bytes above are split by SendConcurrency, the total
+		// footprint stays bounded to roughly the pre-parallel default (~80MiB)
+		// regardless of copy_workers, rather than growing with it.
+		batchCfg.MaxQueueBytes = batchCfg.MaxBatchBytes * int64(batchCfg.SendConcurrency+1)
 	}
 	if batchCfg.BatchTimeout == 0 {
 		batchCfg.BatchTimeout = defaultPostgresBulkBatchTimeout

--- a/cmd/config/config_env.go
+++ b/cmd/config/config_env.go
@@ -84,6 +84,7 @@ func init() {
 	viper.BindEnv("PGSTREAM_POSTGRES_WRITER_DISABLE_TRIGGERS")
 	viper.BindEnv("PGSTREAM_POSTGRES_WRITER_ON_CONFLICT_ACTION")
 	viper.BindEnv("PGSTREAM_POSTGRES_WRITER_BULK_INGEST_ENABLED")
+	viper.BindEnv("PGSTREAM_POSTGRES_WRITER_BULK_INGEST_COPY_WORKERS")
 	viper.BindEnv("PGSTREAM_POSTGRES_WRITER_EXP_BACKOFF_INITIAL_INTERVAL")
 	viper.BindEnv("PGSTREAM_POSTGRES_WRITER_EXP_BACKOFF_MAX_INTERVAL")
 	viper.BindEnv("PGSTREAM_POSTGRES_WRITER_EXP_BACKOFF_MAX_RETRIES")
@@ -589,6 +590,7 @@ func parsePostgresProcessorConfig() (*stream.PostgresProcessorConfig, error) {
 	}
 
 	if bulkIngestEnabled {
+		cfg.BatchWriter.BatchConfig.SendConcurrency = viper.GetInt("PGSTREAM_POSTGRES_WRITER_BULK_INGEST_COPY_WORKERS")
 		applyPostgresBulkBatchDefaults(&cfg.BatchWriter.BatchConfig)
 	}
 

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -18,31 +18,44 @@ func TestApplyPostgresBulkBatchDefaults(t *testing.T) {
 
 		wantMaxBatchSize    int64
 		wantMaxBatchBytes   int64
+		wantMaxQueueBytes   int64
 		wantSendConcurrency int
 	}{
 		{
-			name: "all defaults - batch bytes split across default copy workers",
+			name: "all defaults - batch bytes split across default copy workers, queue sized to concurrency",
 			cfg:  batch.Config{},
 
 			wantMaxBatchSize:    defaultPostgresBulkBatchSize,
 			wantMaxBatchBytes:   defaultPostgresBulkBatchBytes / defaultPostgresBulkCopyWorkers,
+			wantMaxQueueBytes:   (defaultPostgresBulkBatchBytes / defaultPostgresBulkCopyWorkers) * (defaultPostgresBulkCopyWorkers + 1),
 			wantSendConcurrency: defaultPostgresBulkCopyWorkers,
 		},
 		{
-			name: "single copy worker - full batch bytes",
+			name: "single copy worker - full batch bytes, queue left at default",
 			cfg:  batch.Config{SendConcurrency: 1},
 
 			wantMaxBatchSize:    defaultPostgresBulkBatchSize,
 			wantMaxBatchBytes:   defaultPostgresBulkBatchBytes,
+			wantMaxQueueBytes:   0, // left unset -> GetMaxQueueBytes falls back to the default at runtime
 			wantSendConcurrency: 1,
 		},
 		{
-			name: "explicit batch bytes - not split",
+			name: "explicit batch bytes - not split, queue still sized to concurrency",
 			cfg:  batch.Config{MaxBatchBytes: 1024, SendConcurrency: 4},
 
 			wantMaxBatchSize:    defaultPostgresBulkBatchSize,
 			wantMaxBatchBytes:   1024,
+			wantMaxQueueBytes:   1024 * (4 + 1),
 			wantSendConcurrency: 4,
+		},
+		{
+			name: "explicit queue bytes - left untouched",
+			cfg:  batch.Config{MaxQueueBytes: 123456789, SendConcurrency: 8},
+
+			wantMaxBatchSize:    defaultPostgresBulkBatchSize,
+			wantMaxBatchBytes:   defaultPostgresBulkBatchBytes / 8,
+			wantMaxQueueBytes:   123456789,
+			wantSendConcurrency: 8,
 		},
 		{
 			name: "explicit copy workers - batch bytes split accordingly",
@@ -50,6 +63,7 @@ func TestApplyPostgresBulkBatchDefaults(t *testing.T) {
 
 			wantMaxBatchSize:    defaultPostgresBulkBatchSize,
 			wantMaxBatchBytes:   defaultPostgresBulkBatchBytes / 16,
+			wantMaxQueueBytes:   (defaultPostgresBulkBatchBytes / 16) * (16 + 1),
 			wantSendConcurrency: 16,
 		},
 	}
@@ -63,6 +77,7 @@ func TestApplyPostgresBulkBatchDefaults(t *testing.T) {
 
 			require.Equal(t, tc.wantMaxBatchSize, cfg.MaxBatchSize)
 			require.Equal(t, tc.wantMaxBatchBytes, cfg.MaxBatchBytes)
+			require.Equal(t, tc.wantMaxQueueBytes, cfg.MaxQueueBytes)
 			require.Equal(t, tc.wantSendConcurrency, cfg.SendConcurrency)
 			require.Equal(t, defaultPostgresBulkBatchTimeout, cfg.BatchTimeout)
 		})

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/pkg/wal/processor/batch"
+)
+
+func TestApplyPostgresBulkBatchDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  batch.Config
+
+		wantMaxBatchSize    int64
+		wantMaxBatchBytes   int64
+		wantSendConcurrency int
+	}{
+		{
+			name: "all defaults - batch bytes split across default copy workers",
+			cfg:  batch.Config{},
+
+			wantMaxBatchSize:    defaultPostgresBulkBatchSize,
+			wantMaxBatchBytes:   defaultPostgresBulkBatchBytes / defaultPostgresBulkCopyWorkers,
+			wantSendConcurrency: defaultPostgresBulkCopyWorkers,
+		},
+		{
+			name: "single copy worker - full batch bytes",
+			cfg:  batch.Config{SendConcurrency: 1},
+
+			wantMaxBatchSize:    defaultPostgresBulkBatchSize,
+			wantMaxBatchBytes:   defaultPostgresBulkBatchBytes,
+			wantSendConcurrency: 1,
+		},
+		{
+			name: "explicit batch bytes - not split",
+			cfg:  batch.Config{MaxBatchBytes: 1024, SendConcurrency: 4},
+
+			wantMaxBatchSize:    defaultPostgresBulkBatchSize,
+			wantMaxBatchBytes:   1024,
+			wantSendConcurrency: 4,
+		},
+		{
+			name: "explicit copy workers - batch bytes split accordingly",
+			cfg:  batch.Config{SendConcurrency: 16},
+
+			wantMaxBatchSize:    defaultPostgresBulkBatchSize,
+			wantMaxBatchBytes:   defaultPostgresBulkBatchBytes / 16,
+			wantSendConcurrency: 16,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := tc.cfg
+			applyPostgresBulkBatchDefaults(&cfg)
+
+			require.Equal(t, tc.wantMaxBatchSize, cfg.MaxBatchSize)
+			require.Equal(t, tc.wantMaxBatchBytes, cfg.MaxBatchBytes)
+			require.Equal(t, tc.wantSendConcurrency, cfg.SendConcurrency)
+			require.Equal(t, defaultPostgresBulkBatchTimeout, cfg.BatchTimeout)
+		})
+	}
+}

--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -248,6 +248,11 @@ type BatchAutoTuneConfig struct {
 
 type BulkIngestConfig struct {
 	Enabled bool `mapstructure:"enabled" yaml:"enabled"`
+	// CopyWorkers is the number of concurrent COPY streams (send drainers) used
+	// per table when bulk ingesting. Defaults to 8. It names the write-side
+	// COPY streams, distinct from snapshot.data.table_workers which is the
+	// read-side page-range reader count.
+	CopyWorkers int `mapstructure:"copy_workers" yaml:"copy_workers"`
 }
 
 type WebhooksConfig struct {
@@ -694,6 +699,7 @@ func (c *YAMLConfig) parsePostgresProcessorConfig() *stream.PostgresProcessorCon
 	if c.Target.Postgres.BulkIngest != nil {
 		cfg.BatchWriter.BulkIngestEnabled = c.Target.Postgres.BulkIngest.Enabled
 		if cfg.BatchWriter.BulkIngestEnabled {
+			cfg.BatchWriter.BatchConfig.SendConcurrency = c.Target.Postgres.BulkIngest.CopyWorkers
 			applyPostgresBulkBatchDefaults(&cfg.BatchWriter.BatchConfig)
 		}
 	}

--- a/cmd/config/config_yaml_test.go
+++ b/cmd/config/config_yaml_test.go
@@ -24,6 +24,51 @@ func TestYAMLConfig_toStreamConfig(t *testing.T) {
 	validateTestStreamConfig(t, streamConfig)
 }
 
+func TestYAMLConfig_parsePostgresProcessorConfig_CopyWorkers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		bulkIngest          *BulkIngestConfig
+		wantSendConcurrency int
+	}{
+		{
+			name:                "bulk ingest disabled - send concurrency untouched",
+			bulkIngest:          &BulkIngestConfig{Enabled: false, CopyWorkers: 4},
+			wantSendConcurrency: 0,
+		},
+		{
+			name:                "bulk ingest enabled, copy_workers unset - defaults to 8",
+			bulkIngest:          &BulkIngestConfig{Enabled: true},
+			wantSendConcurrency: 8,
+		},
+		{
+			name:                "bulk ingest enabled, copy_workers overridden",
+			bulkIngest:          &BulkIngestConfig{Enabled: true, CopyWorkers: 16},
+			wantSendConcurrency: 16,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &YAMLConfig{
+				Target: TargetConfig{
+					Postgres: &PostgresTargetConfig{
+						URL:        "postgresql://user:password@localhost:5432/mytargetdatabase",
+						BulkIngest: tc.bulkIngest,
+					},
+				},
+			}
+
+			cfg := c.parsePostgresProcessorConfig()
+			require.NotNil(t, cfg)
+			require.Equal(t, tc.wantSendConcurrency, cfg.BatchWriter.BatchConfig.SendConcurrency)
+		})
+	}
+}
+
 func TestYAMLConfig_LoggingConfig(t *testing.T) {
 	require.NoError(t, LoadFile("test/test_config.yaml"))
 

--- a/cmd/config/helper_test.go
+++ b/cmd/config/helper_test.go
@@ -130,6 +130,7 @@ func validateTestStreamConfig(t *testing.T, streamConfig *stream.Config) {
 						MaxBatchBytes:    1572864,
 						MaxQueueBytes:    204800,
 						IgnoreSendErrors: true,
+						SendConcurrency:  8,
 						AutoTune: batch.AutoTuneConfig{
 							Enabled:              true,
 							MinBatchBytes:        10,

--- a/config_template.yaml
+++ b/config_template.yaml
@@ -88,6 +88,7 @@ target:
     on_conflict_action: "nothing" # options are update, nothing or error. Defaults to error
     bulk_ingest:
       enabled: true # whether to enable bulk ingest on the target postgres, using COPY FROM (supported for insert only workloads)
+      copy_workers: 8 # number of concurrent COPY streams per table when bulk ingesting. Defaults to 8. Only applies when bulk_ingest.enabled is true.
   kafka:
     servers: ["localhost:9092"]
     topic:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,6 +99,7 @@ target:
     strict_mode: false # whether to stop on non-internal query failures instead of dropping them. Defaults to false
     bulk_ingest:
       enabled: true # whether to enable bulk ingest on the target postgres, using COPY FROM (supported for insert only workloads)
+      copy_workers: 8 # number of concurrent COPY streams per table when bulk ingesting. Defaults to 8. Only applies when bulk_ingest.enabled is true.
     retry_policy: # retry policy for postgres connections, one of exponential or constant or disable_retries.
       disable_retries: false
       exponential:
@@ -352,6 +353,7 @@ One of exponential/constant/disable retries backoff policies can be provided for
 | PGSTREAM_POSTGRES_WRITER_ON_CONFLICT_ACTION                    | error                           | No       | Action to apply to inserts on conflict. Options are `nothing`, `update` or `error`.                                                                                                                            |
 | PGSTREAM_POSTGRES_WRITER_STRICT_MODE                           | False                           | No       | Whether to stop on non-internal query failures instead of dropping them and continuing. It defaults to false.                                                                                                  |
 | PGSTREAM_POSTGRES_WRITER_BULK_INGEST_ENABLED                   | False(run), True(snapshot)      | No       | Whether to use COPY FROM on insert only workloads. It defaults to false when using the run command, and to true when using the snapshot command.                                                               |
+| PGSTREAM_POSTGRES_WRITER_BULK_INGEST_COPY_WORKERS              | 8                               | No       | Number of concurrent COPY streams per table when bulk ingesting. Only applies when bulk ingest is enabled.                                                                                                     |
 | PGSTREAM_POSTGRES_WRITER_EXP_BACKOFF_INITIAL_INTERVAL          | 500ms                           | No       | Initial interval for the exponential backoff policy to be applied to the Postgres connection retries.                                                                                                          |
 | PGSTREAM_POSTGRES_WRITER_EXP_BACKOFF_MAX_INTERVAL              | 10s                             | No       | Max interval for the exponential backoff policy to be applied to the Postgres connection retries.                                                                                                              |
 | PGSTREAM_POSTGRES_WRITER_EXP_BACKOFF_MAX_RETRIES               | 20                              | No       | Max retries for the exponential backoff policy to be applied to the Postgres connection retries.                                                                                                               |

--- a/internal/postgres/pg_conn_pool.go
+++ b/internal/postgres/pg_conn_pool.go
@@ -16,7 +16,10 @@ type Pool struct {
 
 type PoolOption func(*pgxpool.Config)
 
-const maxConns = 50
+// MaxConns is the default maximum number of connections in a Postgres
+// connection pool. It also bounds the global concurrent-COPY budget in the
+// bulk-ingest writer, so the two never drift.
+const MaxConns = 50
 
 func NewConnPool(ctx context.Context, url string, opts ...PoolOption) (*Pool, error) {
 	escapedURL, err := escapeConnectionURL(url)
@@ -27,7 +30,7 @@ func NewConnPool(ctx context.Context, url string, opts ...PoolOption) (*Pool, er
 	if err != nil {
 		return nil, fmt.Errorf("failed parsing postgres connection string: %w", MapError(err))
 	}
-	pgCfg.MaxConns = maxConns
+	pgCfg.MaxConns = MaxConns
 	pgCfg.AfterConnect = registerTypesToConnMap
 
 	configureTCPKeepalive(pgCfg.ConnConfig)

--- a/pkg/wal/processor/batch/wal_batch_sender.go
+++ b/pkg/wal/processor/batch/wal_batch_sender.go
@@ -31,6 +31,7 @@ type Sender[T Message] struct {
 	maxBatchSize      int64
 	batchSendInterval time.Duration
 	batchBytesTuner   *batchBytesTuner[T]
+	sendConcurrency   int
 
 	wg       *sync.WaitGroup
 	cancelFn context.CancelFunc
@@ -55,13 +56,22 @@ func NewSender[T Message](ctx context.Context, config *Config, sendfn sendBatchF
 		wg:                &sync.WaitGroup{},
 		cancelFn:          func() {},
 		ignoreSendErrors:  config.IgnoreSendErrors,
+		sendConcurrency:   config.GetSendConcurrency(),
 	}
 
 	if config.AutoTune.Enabled {
-		var err error
-		s.batchBytesTuner, err = newBatchBytesTuner(config.GetAutoTuneConfig(), sendfn, logger)
-		if err != nil {
-			return nil, fmt.Errorf("unable to create batch bytes auto tuner: %w", err)
+		// The batch bytes auto-tuner relies on a per-batch serial-timing model
+		// that is corrupted by concurrent sends, so it is incompatible with a
+		// send-drainer pool. Disable it (rather than silently ignoring it) when
+		// send concurrency is enabled.
+		if s.sendConcurrency > 1 {
+			logger.Warn(nil, "batch auto-tune is incompatible with send concurrency > 1: disabling auto-tune", loglib.Fields{"send_concurrency": s.sendConcurrency})
+		} else {
+			var err error
+			s.batchBytesTuner, err = newBatchBytesTuner(config.GetAutoTuneConfig(), sendfn, logger)
+			if err != nil {
+				return nil, fmt.Errorf("unable to create batch bytes auto tuner: %w", err)
+			}
 		}
 	}
 
@@ -130,30 +140,9 @@ func (s *Sender[T]) send(ctx context.Context) error {
 	// ensuring the goroutine is always sending, and minimise the wait time
 	// between batch sending
 	batchChan := make(chan *Batch[T])
-	defer close(batchChan)
-	sendErrChan := make(chan error, 1)
-	s.wg.Add(1)
-	go func() {
-		defer func() {
-			close(sendErrChan)
-			s.wg.Done()
-		}()
-		for batch := range batchChan {
-			// If the send fails, the writer goroutine returns an error over the
-			// error channel and shuts down.
-			err := s.sendBatch(context.Background(), batch)
-			s.queueBytesSema.Release(int64(batch.totalBytes))
-			if err != nil {
-				s.logger.Error(err, "failed to send batch")
-				if s.ignoreSendErrors {
-					continue
-				}
-				s.recordSendErr(err)
-				sendErrChan <- err
-				return
-			}
-		}
-	}()
+
+	drainerWg, sendErrChan, cleanupDrainers := s.startSendDrainers(batchChan)
+	defer cleanupDrainers()
 
 	drainBatch := func(batch *Batch[T]) error {
 		if batch.isEmpty() {
@@ -225,11 +214,91 @@ func (s *Sender[T]) send(ctx context.Context) error {
 	if err != nil && !isBenignShutdownErr(err) {
 		s.logger.Error(err, "sending stopped")
 	}
+	// stop the drainers and wait for them to finish before signalling shutdown,
+	// so Close (which waits on this goroutine via s.wg) never returns while a
+	// COPY is still in flight.
+	close(batchChan)
+	drainerWg.Wait()
+
 	// publish the send error before signalling shutdown so any goroutines
 	// waiting in SendMessage can observe it after the channel is closed.
 	s.recordSendErr(err)
 	close(s.sendDone)
 	return err
+}
+
+// startSendDrainers spawns the goroutine(s) that drain batchChan and call
+// sendBatch. It returns the drainer wait group (send waits on it before
+// returning, so Close never returns with a COPY still in flight), the channel
+// over which the first send error is published, and a cleanup function to be
+// deferred by the caller. The drainers are tracked on the returned local wait
+// group, not on s.wg, which tracks the send goroutine as a whole.
+func (s *Sender[T]) startSendDrainers(batchChan chan *Batch[T]) (*sync.WaitGroup, chan error, func()) {
+	drainerWg := &sync.WaitGroup{}
+
+	// send on a separate go routine (or pool of them) to isolate the IO
+	// operations, ensuring a drainer is always sending, and minimise the wait
+	// time between batch sending.
+	if s.sendConcurrency <= 1 {
+		// Single send goroutine: preserves the original ordered behavior.
+		// sendBatch is called with context.Background() so an in-flight batch
+		// always completes, and sendErrChan is buffered to 1. This is the path
+		// used by the ordered replication writer.
+		sendErrChan := make(chan error, 1)
+		drainerWg.Add(1)
+		go func() {
+			defer drainerWg.Done()
+			for batch := range batchChan {
+				// If the send fails, the writer goroutine returns an error over
+				// the error channel and shuts down.
+				err := s.sendBatch(context.Background(), batch)
+				s.queueBytesSema.Release(int64(batch.totalBytes))
+				if err != nil {
+					s.logger.Error(err, "failed to send batch")
+					if s.ignoreSendErrors {
+						continue
+					}
+					s.recordSendErr(err)
+					sendErrChan <- err
+					return
+				}
+			}
+		}()
+		return drainerWg, sendErrChan, func() {}
+	}
+
+	// Pool of send drainers. All drainers range the same batchChan; the single
+	// accumulator loop hands each completed batch to whichever drainer is free.
+	// The first drainer to fail cancels the shared send-ctx so any in-flight
+	// COPYs in the other drainers abort promptly (each batch is its own tx, so
+	// cancel rolls that batch back cleanly and retry is whole-table).
+	sendErrChan := make(chan error, s.sendConcurrency)
+	sendCtx, cancelSend := context.WithCancel(context.Background())
+	var firstErr sync.Once
+	for i := 0; i < s.sendConcurrency; i++ {
+		drainerWg.Add(1)
+		go func() {
+			defer drainerWg.Done()
+			for batch := range batchChan {
+				err := s.sendBatch(sendCtx, batch)
+				s.queueBytesSema.Release(int64(batch.totalBytes))
+				if err != nil {
+					s.logger.Error(err, "failed to send batch")
+					if s.ignoreSendErrors {
+						continue
+					}
+					firstErr.Do(func() {
+						s.recordSendErr(err)
+						// abort in-flight COPYs in the other drainers
+						cancelSend()
+						sendErrChan <- err
+					})
+					return
+				}
+			}
+		}()
+	}
+	return drainerWg, sendErrChan, cancelSend
 }
 
 // Close will stop the sending, and wait for all ongoing batches to finish. It

--- a/pkg/wal/processor/batch/wal_batch_sender_config.go
+++ b/pkg/wal/processor/batch/wal_batch_sender_config.go
@@ -25,6 +25,12 @@ type Config struct {
 	// not. If set to true, errors will be logged but the batch will continue
 	// processing. Defaults to false.
 	IgnoreSendErrors bool
+	// SendConcurrency is the number of concurrent send goroutines (drainers)
+	// used to send batches. When set to 1 (the default) the sender uses a
+	// single send goroutine, preserving strict ordering. Values greater than 1
+	// are only meaningful for order-independent workloads (e.g. the bulk-ingest
+	// snapshot writer) and are never enabled on the ordered replication path.
+	SendConcurrency int
 
 	AutoTune AutoTuneConfig
 }
@@ -68,6 +74,13 @@ func (c *Config) GetMaxBatchSize() int64 {
 		return c.MaxBatchSize
 	}
 	return defaultMaxBatchSize
+}
+
+func (c *Config) GetSendConcurrency() int {
+	if c.SendConcurrency > 1 {
+		return c.SendConcurrency
+	}
+	return 1
 }
 
 func (c *Config) GetBatchTimeout() time.Duration {

--- a/pkg/wal/processor/batch/wal_batch_sender_test.go
+++ b/pkg/wal/processor/batch/wal_batch_sender_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -538,6 +539,158 @@ func TestSender_ConcurrentSendErrorPropagation(t *testing.T) {
 		require.ErrorIsf(t, err, errTest, "worker %d: missing underlying send error", i)
 		require.NotContainsf(t, err.Error(), "%!w(<nil>)", "worker %d: nil error wrapping leaked through", i)
 	}
+}
+
+// TestSender_sendConcurrency verifies that with SendConcurrency > 1 the sender
+// runs that many COPYs concurrently. The send function blocks until N sends are
+// in flight at once; if the sender were serial this would deadlock and the test
+// would hit its timeout.
+func TestSender_sendConcurrency(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	const concurrency = 4
+	testCommitPos := wal.CommitPosition("1")
+
+	var active, maxActive atomic.Int32
+	// barrier closes once `concurrency` sends are simultaneously in flight.
+	var arrived atomic.Int32
+	barrier := make(chan struct{})
+
+	sendFn := func(_ context.Context, _ *Batch[*mockMessage]) error {
+		n := active.Add(1)
+		for {
+			m := maxActive.Load()
+			if n <= m || maxActive.CompareAndSwap(m, n) {
+				break
+			}
+		}
+		if arrived.Add(1) == concurrency {
+			close(barrier)
+		}
+		// wait until all concurrent drainers have arrived, proving they run in
+		// parallel rather than serially.
+		select {
+		case <-barrier:
+		case <-time.After(5 * time.Second):
+		}
+		active.Add(-1)
+		return nil
+	}
+
+	sender, err := NewSender(ctx, &Config{
+		BatchTimeout:    time.Minute,
+		MaxBatchSize:    1,
+		SendConcurrency: concurrency,
+	}, sendFn, log.NewNoopLogger())
+	require.NoError(t, err)
+	defer sender.Close()
+
+	for i := 0; i < concurrency; i++ {
+		require.NoError(t, sender.SendMessage(ctx, NewWALMessage(&mockMessage{id: uint(i + 1)}, testCommitPos)))
+	}
+
+	select {
+	case <-barrier:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %d concurrent sends (max observed: %d)", concurrency, maxActive.Load())
+	}
+	require.Equal(t, int32(concurrency), maxActive.Load())
+	require.NoError(t, sender.Close())
+}
+
+// TestSender_multiDrainerFirstErrorWins verifies that when one of several
+// drainers fails, the first error is surfaced, the in-flight COPYs in the other
+// drainers are cancelled via the shared send-ctx, all drainers exit and Close
+// returns the recorded error cleanly (no goroutine leak / no deadlock).
+func TestSender_multiDrainerFirstErrorWins(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	const concurrency = 4
+	testCommitPos := wal.CommitPosition("1")
+	errTest := errors.New("first error")
+
+	var ctxCancelledCount atomic.Int32
+	// the first send fails; the rest block until their ctx is cancelled by the
+	// first error, then report the cancellation.
+	sendFn := func(sendCtx context.Context, b *Batch[*mockMessage]) error {
+		if b.messages[0].id == 1 {
+			return errTest
+		}
+		select {
+		case <-sendCtx.Done():
+			ctxCancelledCount.Add(1)
+			return sendCtx.Err()
+		case <-time.After(5 * time.Second):
+			return nil
+		}
+	}
+
+	sender, err := NewSender(ctx, &Config{
+		BatchTimeout:    time.Minute,
+		MaxBatchSize:    1,
+		SendConcurrency: concurrency,
+	}, sendFn, log.NewNoopLogger())
+	require.NoError(t, err)
+
+	// send a handful of messages; at least one is the failing id==1.
+	for i := 0; i < concurrency; i++ {
+		id := uint(1)
+		if i > 0 {
+			id = uint(i + 10)
+		}
+		// once a send fails, SendMessage may start returning errSendStopped, so
+		// don't assert on its error here.
+		_ = sender.SendMessage(ctx, NewWALMessage(&mockMessage{id: id}, testCommitPos))
+	}
+
+	require.Eventually(t, func() bool {
+		return errors.Is(sender.getSendErr(), errTest)
+	}, 5*time.Second, time.Millisecond)
+
+	// Close must return the first error and complete without leaking goroutines
+	// or deadlocking.
+	require.ErrorIs(t, sender.Close(), errTest)
+}
+
+// TestNewSender_autoTuneDisabledWithConcurrency verifies that the batch bytes
+// auto-tuner is disabled (not merely ignored) when send concurrency > 1.
+func TestNewSender_autoTuneDisabledWithConcurrency(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	noopSendFn := func(context.Context, *Batch[*mockMessage]) error { return nil }
+
+	t.Run("concurrency > 1 disables auto-tune", func(t *testing.T) {
+		t.Parallel()
+		sender, err := NewSender(ctx, &Config{
+			SendConcurrency: 4,
+			AutoTune:        AutoTuneConfig{Enabled: true},
+		}, noopSendFn, log.NewNoopLogger())
+		require.NoError(t, err)
+		defer sender.Close()
+		require.Nil(t, sender.batchBytesTuner)
+	})
+
+	t.Run("concurrency == 1 keeps auto-tune", func(t *testing.T) {
+		t.Parallel()
+		sender, err := NewSender(ctx, &Config{
+			SendConcurrency: 1,
+			AutoTune:        AutoTuneConfig{Enabled: true},
+		}, noopSendFn, log.NewNoopLogger())
+		require.NoError(t, err)
+		defer sender.Close()
+		require.NotNil(t, sender.batchBytesTuner)
+	})
+}
+
+func TestConfig_GetSendConcurrency(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 1, (&Config{}).GetSendConcurrency())
+	require.Equal(t, 1, (&Config{SendConcurrency: 1}).GetSendConcurrency())
+	require.Equal(t, 8, (&Config{SendConcurrency: 8}).GetSendConcurrency())
 }
 
 func TestSender_CloseAfterSendFailure(t *testing.T) {

--- a/pkg/wal/processor/postgres/postgres_batch_writer.go
+++ b/pkg/wal/processor/postgres/postgres_batch_writer.go
@@ -45,7 +45,14 @@ func NewBatchWriter(ctx context.Context, config *Config, opts ...WriterOption) (
 		dmlAdapter: dml,
 	}
 
-	bw.batchSender, err = batch.NewSender(ctx, &config.BatchConfig, bw.sendBatch, w.logger)
+	// The ordered batch writer (replication path) must send strictly in order,
+	// so it never uses the send-drainer pool, regardless of the SendConcurrency
+	// carried by the shared Config: in snapshot_and_replication mode the
+	// bulk-ingest snapshot writer and this writer are built from the same
+	// postgres.Config, and bulk ingest defaults SendConcurrency to >1.
+	batchConfig := config.BatchConfig
+	batchConfig.SendConcurrency = 1
+	bw.batchSender, err = batch.NewSender(ctx, &batchConfig, bw.sendBatch, w.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
+++ b/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
@@ -24,9 +24,19 @@ type BulkIngestWriter struct {
 
 	batchSenderMap     *synclib.Map[string, queryBatchSender]
 	batchSenderBuilder func(ctx context.Context, schema, table string) (queryBatchSender, error)
+	// copyBudget caps the total number of concurrent COPYs across all tables
+	// (and all their send drainers) so they never exhaust the target
+	// connection pool. It is sized from the same pool max-connections constant,
+	// minus a reserve for the writer's own metadata/type queries.
+	copyBudget synclib.WeightedSemaphore
 }
 
 const bulkIngestWriter = "postgres_bulk_ingest_writer"
+
+// copyBudgetReserve is the number of pool connections kept out of the
+// concurrent-COPY budget, leaving headroom for the writer's adapter
+// metadata/type queries against the same pool.
+const copyBudgetReserve = 5
 
 var errUnexpectedCopiedRows = errors.New("number of rows copied doesn't match the source rows")
 
@@ -46,6 +56,7 @@ func NewBulkIngestWriter(ctx context.Context, config *Config, opts ...WriterOpti
 	biw := &BulkIngestWriter{
 		Writer:         w,
 		batchSenderMap: synclib.NewMap[string, queryBatchSender](),
+		copyBudget:     synclib.NewWeightedSemaphore(int64(pglib.MaxConns - copyBudgetReserve)),
 	}
 
 	biw.batchSenderBuilder = func(ctx context.Context, schema, table string) (queryBatchSender, error) {
@@ -147,6 +158,15 @@ func (w *BulkIngestWriter) sendBatch(ctx context.Context, batch *batch.Batch[*qu
 	}
 
 	w.logger.Trace("bulk writing batch", loglib.Fields{"batch_size": len(queries)})
+
+	// Cap the total number of concurrent COPYs across all tables and their send
+	// drainers so they never exhaust the target connection pool. This is the
+	// single choke point through which every table's COPY flows.
+	if err := w.copyBudget.Acquire(ctx, 1); err != nil {
+		return err
+	}
+	defer w.copyBudget.Release(1)
+
 	return w.copyFromInsertQueries(ctx, queries)
 }
 

--- a/pkg/wal/processor/postgres/postgres_bulk_ingest_writer_test.go
+++ b/pkg/wal/processor/postgres/postgres_bulk_ingest_writer_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -414,6 +415,7 @@ func TestBulkIngestWriter_sendBatch(t *testing.T) {
 					pgConn:          tc.pgConn,
 					disableTriggers: tc.disableTriggers,
 				},
+				copyBudget: synclib.NewWeightedSemaphore(pglib.MaxConns - copyBudgetReserve),
 			}
 
 			err := writer.sendBatch(context.Background(), tc.batch)
@@ -422,4 +424,67 @@ func TestBulkIngestWriter_sendBatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBulkIngestWriter_sendBatch_copyBudget verifies that the global
+// concurrent-COPY budget caps the number of COPYs in flight at once across all
+// concurrent sendBatch calls, regardless of how many callers there are.
+func TestBulkIngestWriter_sendBatch_copyBudget(t *testing.T) {
+	t.Parallel()
+
+	const budget = 2
+	const callers = 8
+
+	testQuery := &query{
+		schema:      "test_schema",
+		table:       "test_table",
+		columnNames: []string{`"id"`},
+		args:        []any{1},
+	}
+
+	var active, maxActive atomic.Int32
+	release := make(chan struct{})
+	pgConn := &pgmocks.Querier{
+		ExecInTxFn: func(ctx context.Context, f func(tx pglib.Tx) error) error {
+			n := active.Add(1)
+			for {
+				m := maxActive.Load()
+				if n <= m || maxActive.CompareAndSwap(m, n) {
+					break
+				}
+			}
+			<-release
+			active.Add(-1)
+			tx := &pgmocks.Tx{
+				CopyFromFn: func(context.Context, string, []string, [][]any) (int64, error) {
+					return 1, nil
+				},
+			}
+			return f(tx)
+		},
+	}
+
+	writer := &BulkIngestWriter{
+		Writer: &Writer{
+			logger: loglib.NewNoopLogger(),
+			pgConn: pgConn,
+		},
+		copyBudget: synclib.NewWeightedSemaphore(budget),
+	}
+
+	eg := errgroup.Group{}
+	for i := 0; i < callers; i++ {
+		eg.Go(func() error {
+			return writer.sendBatch(context.Background(), batch.NewBatch([]*query{testQuery}, nil))
+		})
+	}
+
+	// give the callers time to contend for the budget, then let them drain.
+	require.Eventually(t, func() bool {
+		return maxActive.Load() == budget
+	}, 5*time.Second, time.Millisecond)
+	close(release)
+
+	require.NoError(t, eg.Wait())
+	require.Equal(t, int32(budget), maxActive.Load(), "concurrent COPYs must not exceed the budget")
 }


### PR DESCRIPTION
#### Description

During a pg2pg snapshot, each table's rows are written to the target through a single COPY stream. Once the smaller tables finish, the snapshot spends most of its wall-clock waiting on the largest table draining through that one stream.  Snapshot reads are already parallel (`snapshot.data.table_workers` splits each table into page ranges), but everything funneled into one writer per table, so one big table dictated total snapshot time.


This PR adds a new option to control how many COPY streams write each table to the target in parallel:

```
target:
  postgres:
    url: "postgresql://..."
    bulk_ingest:
      enabled: true
      copy_workers: 8   # default 8; set to 1 for the previous behavior
```

or via environment variable:

`PGSTREAM_POSTGRES_WRITER_BULK_INGEST_COPY_WORKERS=8`

It only applies to the snapshot bulk-ingest path (`bulk_ingest.enabled`: true). Replication is untouched.

##### How it works

Rows read from the source are grouped into batches as before; completed batches are handed to a pool of `copy_workers` senders that each run their own `COPY` into the target table concurrently. This is safe on the snapshot path because bulk ingest handles independent inserts only, indexes and constraints are restored after the data load, and batches carry no ordering requirement. A global cap keeps the total number of concurrent `COPY`s across all tables within the target connection pool, so many small tables can't starve the pool. Batch sizing is adjusted automatically so the memory footprint stays the same as before (one large batch is replaced by `copy_workers` smaller ones). If a batch fails, the first error wins, in-flight COPYs are cancelled, and the usual whole-table retry semantics apply unchanged.

##### Benchmarks

Benchmarks showed 1.7x speedup on smaller tables (it was limited my laptop's bandwidth). I am still running benchmarks for big tables.

Benchmarks with 15GB table:

| workload | `copy_workers=1` | `copy_workers=8` | speedup |
|---|---|---|---|
| 15GB heap / 55.5M rows, data phase | 32.8 min (7.8 MB/s) | 8.9 min (28.7 MB/s) | 3.67x |
| 15GB heap / 55.5M rows, end-to-end | 35m59s | 12m00s | 3.00x |

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
