### PR TITLE
Add encrypted_aes_siv transformer

### DIFF
--- a/docs/examples/transformer_rules.yaml
+++ b/docs/examples/transformer_rules.yaml
@@ -9,3 +9,9 @@ transformations:
           dynamic_parameters:
             gender:
               column: sex
+        document_path:
+          name: encrypted_aes_siv
+          parameters:
+            # example key only — generate your own with `openssl rand -hex 64`
+            key_hex: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+            associated_data: "public.test.document_path"

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -1109,6 +1109,52 @@ transformations:
 
 </details>
 
+ <details>
+  <summary>encrypted_aes_siv</summary>
+
+**Description:** Encrypts values with AES-SIV (RFC 5297), a deterministic authenticated encryption scheme. The same input, key and associated data always produce the same token, so equality relationships between column values are preserved across rows, tables and runs — while remaining reversible by holders of the key, unlike hashing. Tokens are authenticated: tampered or forged values fail decryption. The output is the ciphertext encoded as unpadded base64url, safe for URLs and file names.
+
+| Supported PostgreSQL types                   |
+| -------------------------------------------- |
+| `text`, `varchar`, `char`, `bpchar`, `bytea` |
+
+| Parameter       | Type   | Default | Required |
+| --------------- | ------ | ------- | -------- |
+| key_hex         | string | N/A     | Yes      |
+| associated_data | string | ""      | No       |
+
+`key_hex` is the 64-byte AES-SIV key, hex-encoded (128 characters), e.g. generated with `openssl rand -hex 64`. AES-SIV requires the full 64-byte key (RFC 5297); shorter keys are rejected.
+
+`associated_data` is authenticated but not encrypted: a token minted with one associated data value fails decryption under another. Use it to bind tokens to a context (such as a table/column name) so they cannot be replayed elsewhere.
+
+**Security note:** the encryption is deterministic by design — equal inputs produce equal tokens, which reveals equality (and only equality) of the underlying values. Anyone holding the key can decrypt the tokens, so the anonymization guarantee is key custody: load the key from a secret manager and never store it alongside the transformed data.
+
+**Example Configuration:**
+
+```yaml
+transformations:
+  table_transformers:
+    - schema: public
+      table: orders
+      column_transformers:
+        file_path:
+          name: encrypted_aes_siv
+          parameters:
+            # example key only — generate your own and load it from a secret store
+            key_hex: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+            associated_data: "public.orders.file_path"
+```
+
+**Input-Output Examples:**
+
+| Input         | Configuration Parameters                  | Output                                 |
+| ------------- | ----------------------------------------- | -------------------------------------- |
+| `hello world` | `key_hex: "000102…3e3f"` (example above, no associated data) | `Hc5d96xIxu2ute1RbFuenEftGxw-P__m1Vv_` |
+
+Every run with the same key and parameters produces the same output. Tokens can be decrypted with any RFC 5297 AES-SIV implementation, for example Tink's `daead/subtle` package in Go.
+
+</details>
+
 ### Transformation rules
 
 The rules for the transformers are defined in a dedicated yaml file with the following format:

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -1118,6 +1118,10 @@ transformations:
 | -------------------------------------------- |
 | `text`, `varchar`, `char`, `bpchar`, `bytea` |
 
+**Note on length-constrained columns:** the token is always longer than the input — `ceil(4 × (input_length + 16) / 3)` characters (36 for an 11-character input, 22 minimum). Length-constrained columns (`varchar(n)`, `char(n)`) must be wide enough to hold the expanded token or writes to the target will fail; prefer `text` columns.
+
+For `bytea` columns the raw bytes are encrypted (the transformer normalizes the hex-text form delivered during replication and the raw bytes delivered during snapshots to the same plaintext), and the token is stored as the ASCII bytes of the base64url text.
+
 | Parameter       | Type   | Default | Required |
 | --------------- | ------ | ------- | -------- |
 | key_hex         | string | N/A     | Yes      |
@@ -1147,9 +1151,10 @@ transformations:
 
 **Input-Output Examples:**
 
-| Input         | Configuration Parameters                  | Output                                 |
-| ------------- | ----------------------------------------- | -------------------------------------- |
-| `hello world` | `key_hex: "000102…3e3f"` (example above, no associated data) | `Hc5d96xIxu2ute1RbFuenEftGxw-P__m1Vv_` |
+| Input         | Configuration Parameters                                                             | Output                                 |
+| ------------- | ------------------------------------------------------------------------------------ | -------------------------------------- |
+| `hello world` | `key_hex: "000102…3e3f"`, no `associated_data`                                        | `Hc5d96xIxu2ute1RbFuenEftGxw-P__m1Vv_` |
+| `hello world` | `key_hex: "000102…3e3f"`, `associated_data: "public.orders.file_path"` (example above) | `AsC2hoq-Y9V0iqK6JmNIxq0Fsr3SFPo27QNq` |
 
 Every run with the same key and parameters produces the same output. Tokens can be decrypted with any RFC 5297 AES-SIV implementation, for example Tink's `daead/subtle` package in Go.
 

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
 	github.com/tidwall/gjson v1.19.0
 	github.com/tidwall/sjson v1.2.5
+	github.com/tink-crypto/tink-go/v2 v2.7.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/bytedance/sonic v1.15.1 h1:nJD5PmM0vY7J8CT6MxoqbVAAMhkSmV2HgRAUrrpLoO
 github.com/bytedance/sonic v1.15.1/go.mod h1:mT2NbXunuaEbnZ+mRIX/vYqKISmgEuHFDI4UzmKx2SA=
 github.com/bytedance/sonic/loader v0.5.1 h1:Ygpfa9zwRCCKSlrp5bBP/b/Xzc3VxsAW+5NIYXrOOpI=
 github.com/bytedance/sonic/loader v0.5.1/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/c2sp/wycheproof v0.0.0-20260105152342-fca0d3ba9f12 h1:C34LW7dhWgjAaAOdNB8z2UCyJsXDjC6UTILljHuqOlI=
+github.com/c2sp/wycheproof v0.0.0-20260105152342-fca0d3ba9f12/go.mod h1:U1QjrC6KepOmtVmJn3QsKOTd9HliGr/da5afPEhLRnk=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -463,6 +465,8 @@ github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tilinna/z85 v1.0.0 h1:uqFnJBlD01dosSeo5sK1G1YGbPuwqVHqR+12OJDRjUw=
 github.com/tilinna/z85 v1.0.0/go.mod h1:EfpFU/DUY4ddEy6CRvk2l+UQNEzHbh+bqBQS+04Nkxs=
+github.com/tink-crypto/tink-go/v2 v2.7.0 h1:k7QnUXJ1cRDpvoy/5l1FimZqMAArRff8vjUqzi5N04o=
+github.com/tink-crypto/tink-go/v2 v2.7.0/go.mod h1:cWNpQ/yAT/QHzAV0kBGMOSJzzYTKofDZdJaUqOPPWCI=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/pkg/transformers/builder/transformer_builder.go
+++ b/pkg/transformers/builder/transformer_builder.go
@@ -84,6 +84,12 @@ var TransformersMap = map[transformers.TransformerType]struct {
 			return transformers.NewStringTransformer(cfg.Parameters)
 		},
 	},
+	transformers.EncryptedAESSIV: {
+		Definition: transformers.EncryptedAESSIVTransformerDefinition(),
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return transformers.NewEncryptedAESSIVTransformer(cfg.Parameters)
+		},
+	},
 	// Greenmask transformers
 	transformers.GreenmaskString: {
 		Definition: greenmask.StringTransformerDefinition(),

--- a/pkg/transformers/builder/transformer_concurrency_test.go
+++ b/pkg/transformers/builder/transformer_concurrency_test.go
@@ -78,6 +78,18 @@ func TestTransformers_ConcurrentTransform(t *testing.T) {
 		transformers.String: {
 			input: "hello world",
 		},
+		transformers.EncryptedAESSIV: {
+			params: transformers.ParameterValues{
+				// bytes 0x00..0x3f — a fixed, obviously-test 64-byte key
+				"key_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+			},
+			input: "hello world",
+			validate: func(t *testing.T, got any) {
+				// AES-SIV is deterministic: every call from every goroutine
+				// must produce this exact token
+				require.Equal(t, "Hc5d96xIxu2ute1RbFuenEftGxw-P__m1Vv_", got)
+			},
+		},
 		transformers.GreenmaskString: {
 			params:             transformers.ParameterValues{"min_length": 2, "max_length": 12},
 			input:              "hello world",

--- a/pkg/transformers/encrypted_aes_siv_transformer.go
+++ b/pkg/transformers/encrypted_aes_siv_transformer.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/tink-crypto/tink-go/v2/daead/subtle"
+)
+
+// EncryptedAESSIVTransformer encrypts values with AES-SIV (RFC 5297), a
+// deterministic authenticated encryption scheme: the same input, key and
+// associated data always produce the same token, so equality relationships
+// between column values are preserved across rows, tables and runs. Unlike
+// hashing, the transformation is reversible by holders of the key, and
+// tampered or forged tokens fail authenticated decryption. Tokens are
+// base64url-encoded (no padding), safe for URLs and file names.
+type EncryptedAESSIVTransformer struct {
+	siv *subtle.AESSIV
+	aad []byte
+}
+
+var (
+	errEncryptedAESSIVKeyNotFound = errors.New("encrypted_aes_siv_transformer: key_hex parameter not found")
+	errEncryptedAESSIVKeyInvalid  = fmt.Errorf("encrypted_aes_siv_transformer: key_hex must be %d hex-encoded bytes", subtle.AESSIVKeySize)
+
+	encryptedAESSIVCompatibleTypes = []SupportedDataType{
+		StringDataType,
+		ByteArrayDataType,
+	}
+	encryptedAESSIVParams = []Parameter{
+		{
+			Name:          "key_hex",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      true,
+		},
+		{
+			Name:          "associated_data",
+			SupportedType: "string",
+			Default:       "",
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+)
+
+func NewEncryptedAESSIVTransformer(params ParameterValues) (*EncryptedAESSIVTransformer, error) {
+	keyHex, found, err := FindParameter[string](params, "key_hex")
+	if err != nil {
+		return nil, fmt.Errorf("encrypted_aes_siv_transformer: key_hex must be a string: %w", err)
+	}
+	if !found {
+		return nil, errEncryptedAESSIVKeyNotFound
+	}
+	key, err := hex.DecodeString(keyHex)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errEncryptedAESSIVKeyInvalid, err)
+	}
+	if len(key) != subtle.AESSIVKeySize {
+		return nil, fmt.Errorf("%w, got %d", errEncryptedAESSIVKeyInvalid, len(key))
+	}
+	siv, err := subtle.NewAESSIV(key)
+	if err != nil {
+		return nil, fmt.Errorf("encrypted_aes_siv_transformer: %w", err)
+	}
+
+	aad, err := FindParameterWithDefault(params, "associated_data", "")
+	if err != nil {
+		return nil, fmt.Errorf("encrypted_aes_siv_transformer: associated_data must be a string: %w", err)
+	}
+
+	return &EncryptedAESSIVTransformer{
+		siv: siv,
+		aad: []byte(aad),
+	}, nil
+}
+
+func (est *EncryptedAESSIVTransformer) Transform(_ context.Context, v Value) (any, error) {
+	switch val := v.TransformValue.(type) {
+	case string:
+		return est.transform(val)
+	case []byte:
+		return est.transform(string(val))
+	default:
+		return nil, fmt.Errorf("expected string, got %T: %w", v.TransformValue, ErrUnsupportedValueType)
+	}
+}
+
+func (est *EncryptedAESSIVTransformer) transform(str string) (string, error) {
+	ciphertext, err := est.siv.EncryptDeterministically([]byte(str), est.aad)
+	if err != nil {
+		return "", fmt.Errorf("encrypted_aes_siv_transformer: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(ciphertext), nil
+}
+
+func (est *EncryptedAESSIVTransformer) CompatibleTypes() []SupportedDataType {
+	return encryptedAESSIVCompatibleTypes
+}
+
+func (est *EncryptedAESSIVTransformer) Type() TransformerType {
+	return EncryptedAESSIV
+}
+
+func (est *EncryptedAESSIVTransformer) IsDynamic() bool {
+	return false
+}
+
+func (est *EncryptedAESSIVTransformer) Close() error {
+	return nil
+}
+
+func EncryptedAESSIVTransformerDefinition() *Definition {
+	return &Definition{
+		SupportedTypes: encryptedAESSIVCompatibleTypes,
+		Parameters:     encryptedAESSIVParams,
+	}
+}

--- a/pkg/transformers/encrypted_aes_siv_transformer.go
+++ b/pkg/transformers/encrypted_aes_siv_transformer.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/tink-crypto/tink-go/v2/daead/subtle"
 )
@@ -18,7 +19,10 @@ import (
 // between column values are preserved across rows, tables and runs. Unlike
 // hashing, the transformation is reversible by holders of the key, and
 // tampered or forged tokens fail authenticated decryption. Tokens are
-// base64url-encoded (no padding), safe for URLs and file names.
+// base64url-encoded (no padding), safe for URLs and file names. For bytea
+// columns the raw bytes are encrypted regardless of how the value arrives
+// (raw during snapshots, hex-text during replication) and the token is
+// returned as bytes.
 type EncryptedAESSIVTransformer struct {
 	siv *subtle.AESSIV
 	aad []byte
@@ -27,6 +31,7 @@ type EncryptedAESSIVTransformer struct {
 var (
 	errEncryptedAESSIVKeyNotFound = errors.New("encrypted_aes_siv_transformer: key_hex parameter not found")
 	errEncryptedAESSIVKeyInvalid  = fmt.Errorf("encrypted_aes_siv_transformer: key_hex must be %d hex-encoded bytes", subtle.AESSIVKeySize)
+	errEncryptedAESSIVByteaNotHex = errors.New(`encrypted_aes_siv_transformer: bytea value is not in postgres hex format ("\x..."); the source must use bytea_output=hex`)
 
 	encryptedAESSIVCompatibleTypes = []SupportedDataType{
 		StringDataType,
@@ -62,12 +67,9 @@ func NewEncryptedAESSIVTransformer(params ParameterValues) (*EncryptedAESSIVTran
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", errEncryptedAESSIVKeyInvalid, err)
 	}
-	if len(key) != subtle.AESSIVKeySize {
-		return nil, fmt.Errorf("%w, got %d", errEncryptedAESSIVKeyInvalid, len(key))
-	}
 	siv, err := subtle.NewAESSIV(key)
 	if err != nil {
-		return nil, fmt.Errorf("encrypted_aes_siv_transformer: %w", err)
+		return nil, fmt.Errorf("%w: %w", errEncryptedAESSIVKeyInvalid, err)
 	}
 
 	aad, err := FindParameterWithDefault(params, "associated_data", "")
@@ -81,23 +83,58 @@ func NewEncryptedAESSIVTransformer(params ParameterValues) (*EncryptedAESSIVTran
 	}, nil
 }
 
+const byteaType = "bytea"
+
 func (est *EncryptedAESSIVTransformer) Transform(_ context.Context, v Value) (any, error) {
 	switch val := v.TransformValue.(type) {
 	case string:
-		return est.transform(val)
+		// bytea values arrive as raw bytes during snapshots (pgx) but as their
+		// hex-text form ("\x...") during replication (wal2json); decode so both
+		// paths encrypt the same plaintext and produce the same token
+		if v.TransformType == byteaType {
+			plaintext, err := decodeByteaHex(val)
+			if err != nil {
+				return nil, err
+			}
+			return est.transformToBytes(plaintext)
+		}
+		return est.transform([]byte(val))
 	case []byte:
-		return est.transform(string(val))
+		return est.transformToBytes(val)
 	default:
-		return nil, fmt.Errorf("expected string, got %T: %w", v.TransformValue, ErrUnsupportedValueType)
+		return nil, fmt.Errorf("expected string or []byte, got %T: %w", v.TransformValue, ErrUnsupportedValueType)
 	}
 }
 
-func (est *EncryptedAESSIVTransformer) transform(str string) (string, error) {
-	ciphertext, err := est.siv.EncryptDeterministically([]byte(str), est.aad)
+func (est *EncryptedAESSIVTransformer) transform(plaintext []byte) (string, error) {
+	ciphertext, err := est.siv.EncryptDeterministically(plaintext, est.aad)
 	if err != nil {
 		return "", fmt.Errorf("encrypted_aes_siv_transformer: %w", err)
 	}
 	return base64.RawURLEncoding.EncodeToString(ciphertext), nil
+}
+
+// transformToBytes returns the token as bytes for bytea columns: pgx can
+// binary-encode []byte into bytea (required by COPY during bulk-ingest
+// snapshots) but not a plain string.
+func (est *EncryptedAESSIVTransformer) transformToBytes(plaintext []byte) ([]byte, error) {
+	token, err := est.transform(plaintext)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(token), nil
+}
+
+func decodeByteaHex(val string) ([]byte, error) {
+	hexStr, found := strings.CutPrefix(val, `\x`)
+	if !found {
+		return nil, errEncryptedAESSIVByteaNotHex
+	}
+	decoded, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errEncryptedAESSIVByteaNotHex, err)
+	}
+	return decoded, nil
 }
 
 func (est *EncryptedAESSIVTransformer) CompatibleTypes() []SupportedDataType {

--- a/pkg/transformers/encrypted_aes_siv_transformer_test.go
+++ b/pkg/transformers/encrypted_aes_siv_transformer_test.go
@@ -104,6 +104,15 @@ func TestEncryptedAESSIVTransformer_Transform(t *testing.T) {
 		require.True(t, ok, "expected string token, got %T", got)
 		return token
 	}
+	// bytea columns return the token as []byte so pgx can binary-encode it
+	transformBytea := func(t *testing.T, est *EncryptedAESSIVTransformer, input any) string {
+		t.Helper()
+		got, err := est.Transform(context.Background(), Value{TransformValue: input, TransformType: "bytea"})
+		require.NoError(t, err)
+		token, ok := got.([]byte)
+		require.True(t, ok, "expected []byte token, got %T", got)
+		return string(token)
+	}
 	newSIV := func(t *testing.T) *subtle.AESSIV {
 		t.Helper()
 		key, err := hex.DecodeString(testEncryptedAESSIVKeyHex)
@@ -125,9 +134,33 @@ func TestEncryptedAESSIVTransformer_Transform(t *testing.T) {
 	t.Run("ok - deterministic and []byte parity", func(t *testing.T) {
 		t.Parallel()
 		fromString := transform(t, est, "orders/1234/scan_8842.stl")
-		fromBytes := transform(t, est, []byte("orders/1234/scan_8842.stl"))
+		fromBytes := transformBytea(t, est, []byte("orders/1234/scan_8842.stl"))
 		require.Equal(t, fromString, fromBytes)
 		require.Equal(t, fromString, transform(t, est, "orders/1234/scan_8842.stl"))
+	})
+
+	t.Run("ok - bytea snapshot and replication parity", func(t *testing.T) {
+		t.Parallel()
+		// snapshots deliver bytea as raw []byte (pgx), replication as the
+		// hex-text form (wal2json); both must produce the same token
+		raw := []byte{0x00, 0x01, 0xfe, 0xff}
+		fromSnapshot := transformBytea(t, est, raw)
+		fromReplication := transformBytea(t, est, `\x0001feff`)
+		require.Equal(t, fromSnapshot, fromReplication)
+
+		ciphertext, err := base64.RawURLEncoding.DecodeString(fromSnapshot)
+		require.NoError(t, err)
+		plaintext, err := newSIV(t).DecryptDeterministically(ciphertext, nil)
+		require.NoError(t, err)
+		require.Equal(t, raw, plaintext)
+	})
+
+	t.Run("error - bytea string value not in hex format", func(t *testing.T) {
+		t.Parallel()
+		_, err := est.Transform(context.Background(), Value{TransformValue: "no hex prefix", TransformType: "bytea"})
+		require.ErrorIs(t, err, errEncryptedAESSIVByteaNotHex)
+		_, err = est.Transform(context.Background(), Value{TransformValue: `\xnothex`, TransformType: "bytea"})
+		require.ErrorIs(t, err, errEncryptedAESSIVByteaNotHex)
 	})
 
 	t.Run("ok - round trip", func(t *testing.T) {
@@ -159,6 +192,8 @@ func TestEncryptedAESSIVTransformer_Transform(t *testing.T) {
 		})
 		token := transform(t, estAAD, "hello world")
 		require.NotEqual(t, transform(t, est, "hello world"), token)
+		// golden token: pinned so the docs example stays accurate
+		require.Equal(t, "AsC2hoq-Y9V0iqK6JmNIxq0Fsr3SFPo27QNq", token)
 
 		ciphertext, err := base64.RawURLEncoding.DecodeString(token)
 		require.NoError(t, err)

--- a/pkg/transformers/encrypted_aes_siv_transformer_test.go
+++ b/pkg/transformers/encrypted_aes_siv_transformer_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tink-crypto/tink-go/v2/daead/subtle"
+)
+
+// bytes 0x00..0x3f — a fixed, obviously-test 64-byte key
+const testEncryptedAESSIVKeyHex = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f" +
+	"202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+
+func TestEncryptedAESSIVTransformer(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		params  ParameterValues
+		wantErr error
+	}{
+		{
+			name: "ok - valid key",
+			params: ParameterValues{
+				"key_hex": testEncryptedAESSIVKeyHex,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ok - valid key with associated data",
+			params: ParameterValues{
+				"key_hex":         testEncryptedAESSIVKeyHex,
+				"associated_data": "public.orders.file_path",
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "error - key_hex missing",
+			params:  ParameterValues{},
+			wantErr: errEncryptedAESSIVKeyNotFound,
+		},
+		{
+			name: "error - key_hex not a string",
+			params: ParameterValues{
+				"key_hex": 123,
+			},
+			wantErr: ErrInvalidParameters,
+		},
+		{
+			name: "error - key_hex not valid hex",
+			params: ParameterValues{
+				"key_hex": strings.Repeat("zx", subtle.AESSIVKeySize),
+			},
+			wantErr: errEncryptedAESSIVKeyInvalid,
+		},
+		{
+			name: "error - key_hex wrong length",
+			params: ParameterValues{
+				"key_hex": strings.Repeat("ab", 32),
+			},
+			wantErr: errEncryptedAESSIVKeyInvalid,
+		},
+		{
+			name: "error - associated_data not a string",
+			params: ParameterValues{
+				"key_hex":         testEncryptedAESSIVKeyHex,
+				"associated_data": 1,
+			},
+			wantErr: ErrInvalidParameters,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			est, err := NewEncryptedAESSIVTransformer(tc.params)
+			require.ErrorIs(t, err, tc.wantErr)
+			if tc.wantErr != nil {
+				return
+			}
+			require.NotNil(t, est)
+		})
+	}
+}
+
+func TestEncryptedAESSIVTransformer_Transform(t *testing.T) {
+	t.Parallel()
+
+	newTransformer := func(t *testing.T, params ParameterValues) *EncryptedAESSIVTransformer {
+		t.Helper()
+		est, err := NewEncryptedAESSIVTransformer(params)
+		require.NoError(t, err)
+		return est
+	}
+	transform := func(t *testing.T, est *EncryptedAESSIVTransformer, input any) string {
+		t.Helper()
+		got, err := est.Transform(context.Background(), Value{TransformValue: input})
+		require.NoError(t, err)
+		token, ok := got.(string)
+		require.True(t, ok, "expected string token, got %T", got)
+		return token
+	}
+	newSIV := func(t *testing.T) *subtle.AESSIV {
+		t.Helper()
+		key, err := hex.DecodeString(testEncryptedAESSIVKeyHex)
+		require.NoError(t, err)
+		siv, err := subtle.NewAESSIV(key)
+		require.NoError(t, err)
+		return siv
+	}
+
+	est := newTransformer(t, ParameterValues{"key_hex": testEncryptedAESSIVKeyHex})
+
+	t.Run("ok - golden token", func(t *testing.T) {
+		t.Parallel()
+		// pins the token format (AES-SIV ciphertext, unpadded base64url) so
+		// accidental format changes break loudly: consumers decrypt tokens
+		require.Equal(t, "Hc5d96xIxu2ute1RbFuenEftGxw-P__m1Vv_", transform(t, est, "hello world"))
+	})
+
+	t.Run("ok - deterministic and []byte parity", func(t *testing.T) {
+		t.Parallel()
+		fromString := transform(t, est, "orders/1234/scan_8842.stl")
+		fromBytes := transform(t, est, []byte("orders/1234/scan_8842.stl"))
+		require.Equal(t, fromString, fromBytes)
+		require.Equal(t, fromString, transform(t, est, "orders/1234/scan_8842.stl"))
+	})
+
+	t.Run("ok - round trip", func(t *testing.T) {
+		t.Parallel()
+		token := transform(t, est, "orders/1234/scan_8842.stl")
+		ciphertext, err := base64.RawURLEncoding.DecodeString(token)
+		require.NoError(t, err)
+		plaintext, err := newSIV(t).DecryptDeterministically(ciphertext, nil)
+		require.NoError(t, err)
+		require.Equal(t, "orders/1234/scan_8842.stl", string(plaintext))
+	})
+
+	t.Run("ok - empty string is encrypted too", func(t *testing.T) {
+		t.Parallel()
+		token := transform(t, est, "")
+		require.NotEmpty(t, token)
+		ciphertext, err := base64.RawURLEncoding.DecodeString(token)
+		require.NoError(t, err)
+		plaintext, err := newSIV(t).DecryptDeterministically(ciphertext, nil)
+		require.NoError(t, err)
+		require.Empty(t, plaintext)
+	})
+
+	t.Run("ok - associated_data binds the token", func(t *testing.T) {
+		t.Parallel()
+		estAAD := newTransformer(t, ParameterValues{
+			"key_hex":         testEncryptedAESSIVKeyHex,
+			"associated_data": "public.orders.file_path",
+		})
+		token := transform(t, estAAD, "hello world")
+		require.NotEqual(t, transform(t, est, "hello world"), token)
+
+		ciphertext, err := base64.RawURLEncoding.DecodeString(token)
+		require.NoError(t, err)
+		siv := newSIV(t)
+		// decryption without the matching associated data must fail...
+		_, err = siv.DecryptDeterministically(ciphertext, nil)
+		require.Error(t, err)
+		// ...and succeed with it
+		plaintext, err := siv.DecryptDeterministically(ciphertext, []byte("public.orders.file_path"))
+		require.NoError(t, err)
+		require.Equal(t, "hello world", string(plaintext))
+	})
+
+	t.Run("error - tampered token fails decryption", func(t *testing.T) {
+		t.Parallel()
+		token := transform(t, est, "hello world")
+		ciphertext, err := base64.RawURLEncoding.DecodeString(token)
+		require.NoError(t, err)
+		ciphertext[0] ^= 0x01
+		_, err = newSIV(t).DecryptDeterministically(ciphertext, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("error - unsupported type", func(t *testing.T) {
+		t.Parallel()
+		_, err := est.Transform(context.Background(), Value{TransformValue: 1})
+		require.ErrorIs(t, err, ErrUnsupportedValueType)
+	})
+}

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -59,6 +59,7 @@ const (
 	JSON                   TransformerType = "json"
 	Hstore                 TransformerType = "hstore"
 	PGAnonymizer           TransformerType = "pg_anonymizer"
+	EncryptedAESSIV        TransformerType = "encrypted_aes_siv"
 )
 
 type SupportedDataType string

--- a/transformers-definition.json
+++ b/transformers-definition.json
@@ -32,6 +32,29 @@
       ]
     },
     {
+      "name": "encrypted_aes_siv",
+      "supported_types": [
+        "string",
+        "byte_array"
+      ],
+      "parameters": [
+        {
+          "name": "key_hex",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": true
+        },
+        {
+          "name": "associated_data",
+          "supported_type": "string",
+          "default": "",
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
       "name": "greenmask_boolean",
       "supported_types": [
         "boolean",


### PR DESCRIPTION
#### Description

Adds a new `encrypted_aes_siv` transformer that encrypts column values with AES-SIV (RFC 5297), a deterministic authenticated encryption scheme. Unlike hashing, the transformation is reversible by holders of the key, while still preserving equality relationships between values across rows, tables and runs (same input + key + associated data always produces the same token). Tokens are unpadded base64url, and an optional `associated_data` parameter binds tokens to a context (e.g. a table/column name) so they cannot be replayed elsewhere.

Supported types: `text`, `varchar`, `char`, `bpchar`, `bytea`.

For `bytea` columns, values are normalized before encryption so that snapshots (raw bytes via pgx) and replication (wal2json hex-text form `\x...`) encrypt the same plaintext and produce the same token; the token is returned as `[]byte` so pgx can binary-encode it during bulk-ingest COPY.

##### Related Issue(s)

N/A

#### Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

#### Changes Made

- New `EncryptedAESSIVTransformer` in `pkg/transformers`, backed by tink-go's `daead/subtle` AES-SIV implementation, with `key_hex` (required, 64-byte key) and `associated_data` (optional) parameters
- Registered in the transformer builder and `transformers-definition.json`
- bytea handling: hex-text values from wal2json are decoded to raw bytes before encryption, and tokens for bytea columns are returned as bytes (binary-encodable by COPY)
- Documentation in `docs/transformers.md` with example configuration, golden input/output examples, a security note on determinism/key custody, and a warning about token length expansion for length-constrained columns (`varchar(n)`/`char(n)`)

#### Testing

- [x] Unit tests added/updated
- [x] All existing tests pass

Tests pin the token format with golden values (with and without associated data), and cover determinism, string/bytes parity, snapshot/replication parity for bytea, round-trip decryption, tampered-token rejection, and parameter validation.

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary

#### Additional Notes

The encryption is deterministic by design: equal inputs produce equal tokens, which reveals equality (and only equality) of the underlying values. The anonymization guarantee is key custody.