### PR TITLE
Fix/defer parse validated schema objects

### DIFF
--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -562,21 +561,19 @@ func (s *SnapshotGenerator) parseDump(d []byte) *dump {
 			skipLegacyPLPGSQLHandlerFunction = !strings.HasSuffix(line, ";")
 			continue
 		case functionParser.inProgress || isSQLFunctionStart(line):
-			if functionParser.addLine(line) {
-				statement := strings.Join(functionParser.lines, "\n")
-				if functionParser.sqlStandardBody {
+			if statement, deferred, done := functionParser.addLine(line); done {
+				if deferred {
 					// functions with SQL-standard bodies (BEGIN ATOMIC/RETURN)
 					// are parsed and validated at creation time, so they can
 					// rely on indices and constraints existing (e.g. GROUP BY
 					// primary key functional dependency) and must be restored
 					// after them, along with the views
-					viewsDump.WriteString(statement)
+					viewsDump.WriteString(strings.Join(statement, "\n"))
 					viewsDump.WriteString("\n\n")
 				} else {
-					filteredDump.WriteString(statement)
+					filteredDump.WriteString(strings.Join(statement, "\n"))
 					filteredDump.WriteString("\n")
 				}
-				functionParser.reset()
 			}
 		case strings.HasPrefix(line, "SECURITY LABEL") &&
 			isSecurityLabelForExcludedProvider(line, s.excludedSecurityLabels):
@@ -773,76 +770,70 @@ func isSQLFunctionStart(line string) bool {
 		strings.HasPrefix(line, "CREATE OR REPLACE PROCEDURE ")
 }
 
-var dollarQuoteRegex = regexp.MustCompile(`\$[A-Za-z_0-9]*\$`)
-
-// sqlFunctionParser buffers a CREATE FUNCTION/PROCEDURE statement to
-// determine where it needs to be restored. Functions with SQL-standard bodies
-// (BEGIN ATOMIC or RETURN) are parsed and validated at creation time, unlike
-// classic string-quoted bodies which are only parsed on execution.
+// sqlFunctionParser buffers the beginning of a CREATE FUNCTION/PROCEDURE
+// statement until pg_dump's body introduction reveals its style:
+//
+//   - `AS ...` (classic string/dollar quoted body): the body is only parsed
+//     on execution, so the statement can be restored in place. The parser
+//     stops and hands the buffered lines back; the rest of the statement
+//     doesn't need buffering and flows through the regular dump parsing,
+//     unchanged.
+//   - `BEGIN ATOMIC <statements> END;` or `RETURN <expression>;`
+//     (SQL-standard body): the body is parsed and validated at creation time,
+//     so it can rely on indices and constraints existing (e.g. GROUP BY
+//     primary key functional dependency) and must be deferred. These bodies
+//     are deparsed plain SQL with no quoting, so the statement end can be
+//     detected without tracking dollar quotes.
+//
+// The lines between the header and the body introduction are attribute lines
+// (LANGUAGE, IMMUTABLE, SET, COST, ...) and cannot contain quoted bodies.
 type sqlFunctionParser struct {
-	inProgress      bool
-	lines           []string
-	inDollarQuotes  bool
-	dollarQuoteTag  string
-	atomicBody      bool
-	sqlStandardBody bool
+	inProgress bool
+	lines      []string
+	atomicBody bool
+	returnBody bool
 }
 
-// addLine buffers the line, returning true once the statement is complete.
-func (p *sqlFunctionParser) addLine(line string) (done bool) {
+// addLine buffers the line and reports whether the parser is finished with
+// the statement. Once done, statement holds the buffered lines and deferred
+// indicates whether they are a SQL-standard body function that needs to be
+// restored after indices and constraints.
+func (p *sqlFunctionParser) addLine(line string) (statement []string, deferred, done bool) {
 	p.inProgress = true
 	p.lines = append(p.lines, line)
-	p.updateDollarQuoteState(line)
-	if p.inDollarQuotes {
-		// the statement can only end outside of a dollar quoted body
-		return false
-	}
-
 	trimmedLine := strings.TrimSpace(line)
 	switch {
 	case p.atomicBody:
-		// SQL-standard body `BEGIN ATOMIC <statements> END;`; pg_dump places
-		// the closing END on its own line
-		return trimmedLine == "END;"
+		// pg_dump places the closing END of the atomic body on its own line
+		if trimmedLine == "END;" {
+			return p.finish(true)
+		}
+	case p.returnBody:
+		if strings.HasSuffix(line, ";") {
+			return p.finish(true)
+		}
 	case trimmedLine == "BEGIN ATOMIC":
 		p.atomicBody = true
-		p.sqlStandardBody = true
-		return false
-	default:
-		if strings.HasPrefix(trimmedLine, "RETURN ") || strings.HasPrefix(trimmedLine, "RETURN(") {
-			// SQL-standard body `RETURN <expression>;`
-			p.sqlStandardBody = true
+	case strings.HasPrefix(trimmedLine, "RETURN ") || strings.HasPrefix(trimmedLine, "RETURN("):
+		// the RETURNS clause of the header cannot match, since the first line
+		// of the statement always starts with CREATE
+		if strings.HasSuffix(line, ";") {
+			return p.finish(true)
 		}
-		return strings.HasSuffix(line, ";")
+		p.returnBody = true
+	case strings.HasPrefix(trimmedLine, "AS "),
+		strings.HasSuffix(line, ";"):
+		// classic quoted body or end of statement without a recognized
+		// SQL-standard body: restore in place
+		return p.finish(false)
 	}
+	return nil, false, false
 }
 
-func (p *sqlFunctionParser) reset() {
+func (p *sqlFunctionParser) finish(deferred bool) ([]string, bool, bool) {
+	statement := p.lines
 	*p = sqlFunctionParser{}
-}
-
-// updateDollarQuoteState tracks whether the parser is inside a dollar quoted
-// function body (e.g. $$...$$ or $_$...$_$) across lines.
-func (p *sqlFunctionParser) updateDollarQuoteState(line string) {
-	rest := line
-	for {
-		if p.inDollarQuotes {
-			idx := strings.Index(rest, p.dollarQuoteTag)
-			if idx == -1 {
-				return
-			}
-			rest = rest[idx+len(p.dollarQuoteTag):]
-			p.inDollarQuotes = false
-			continue
-		}
-		loc := dollarQuoteRegex.FindStringIndex(rest)
-		if loc == nil {
-			return
-		}
-		p.dollarQuoteTag = rest[loc[0]:loc[1]]
-		p.inDollarQuotes = true
-		rest = rest[loc[1]:]
-	}
+	return statement, deferred, true
 }
 
 func isLegacyPLPGSQLHandlerFunctionStart(line string) bool {

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -86,10 +87,14 @@ type Config struct {
 type Option func(s *SnapshotGenerator)
 
 type dump struct {
-	full                      []byte
-	filtered                  []byte
-	cleanupPart               []byte
-	indicesAndConstraints     []byte
+	full                  []byte
+	filtered              []byte
+	cleanupPart           []byte
+	indicesAndConstraints []byte
+	// views holds the statements that are validated against the catalog at
+	// creation time and can rely on indices and constraints existing (views,
+	// materialized views, _RETURN rules and functions with SQL-standard
+	// bodies), so they are restored after the indices and constraints.
 	views                     []byte
 	materializedViewRefreshes []byte
 	sequences                 []string
@@ -539,7 +544,10 @@ func (s *SnapshotGenerator) parseDump(d []byte) *dump {
 	materializedViews := []string{}
 	alterTable := ""
 	createEventTrigger := ""
-	createView := ""
+	createView := []string{}
+	createViewIsMaterialized := false
+	createRule := []string{}
+	functionParser := &sqlFunctionParser{}
 	materializedViewNames := map[string]struct{}{}
 	skipLegacyPLPGSQLHandlerFunction := false
 	for scanner.Scan() {
@@ -553,6 +561,23 @@ func (s *SnapshotGenerator) parseDump(d []byte) *dump {
 		case isLegacyPLPGSQLHandlerFunctionStart(line):
 			skipLegacyPLPGSQLHandlerFunction = !strings.HasSuffix(line, ";")
 			continue
+		case functionParser.inProgress || isSQLFunctionStart(line):
+			if functionParser.addLine(line) {
+				statement := strings.Join(functionParser.lines, "\n")
+				if functionParser.sqlStandardBody {
+					// functions with SQL-standard bodies (BEGIN ATOMIC/RETURN)
+					// are parsed and validated at creation time, so they can
+					// rely on indices and constraints existing (e.g. GROUP BY
+					// primary key functional dependency) and must be restored
+					// after them, along with the views
+					viewsDump.WriteString(statement)
+					viewsDump.WriteString("\n\n")
+				} else {
+					filteredDump.WriteString(statement)
+					filteredDump.WriteString("\n")
+				}
+				functionParser.reset()
+			}
 		case strings.HasPrefix(line, "SECURITY LABEL") &&
 			isSecurityLabelForExcludedProvider(line, s.excludedSecurityLabels):
 			// skip security labels if configured to do so for the specified providers
@@ -586,23 +611,44 @@ func (s *SnapshotGenerator) parseDump(d []byte) *dump {
 			eventTriggersDump.WriteString(line)
 			eventTriggersDump.WriteString("\n")
 
-		case strings.HasPrefix(line, "CREATE VIEW"),
-			strings.HasPrefix(line, "CREATE MATERIALIZED VIEW"):
-			if name, ok := materializedViewName(line); ok {
-				materializedViewNames[name] = struct{}{}
-				materializedViews = append(materializedViews, name)
+		case len(createView) > 0 || isViewStatementStart(line):
+			if len(createView) == 0 {
+				if name, ok := materializedViewName(line); ok {
+					materializedViewNames[name] = struct{}{}
+					materializedViews = append(materializedViews, name)
+				}
+				createViewIsMaterialized = strings.HasPrefix(line, "CREATE MATERIALIZED VIEW")
 			}
-			createView = line
-			fallthrough
-		case createView != "":
+			createView = append(createView, line)
 			if strings.HasSuffix(line, ";") {
-				viewsDump.WriteString(line)
-				viewsDump.WriteString("\n\n")
-				createView = ""
-				continue
+				statement := strings.Join(createView, "\n")
+				if !createViewIsMaterialized && isDummyViewStatement(createView) {
+					// pg_dump breaks circular view dependencies by emitting a
+					// dummy view (a bare SELECT of NULL casts with no FROM
+					// clause) upfront and the real definition (CREATE OR
+					// REPLACE VIEW) at the end of the dump. The dummy must be
+					// restored early so that objects in the main schema dump
+					// referencing the view row type (e.g. functions) can be
+					// created; it cannot depend on indices or constraints.
+					filteredDump.WriteString(statement)
+					filteredDump.WriteString("\n")
+				} else {
+					viewsDump.WriteString(statement)
+					viewsDump.WriteString("\n\n")
+				}
+				createView = []string{}
 			}
-			viewsDump.WriteString(line)
-			viewsDump.WriteString("\n")
+		case len(createRule) > 0 || strings.HasPrefix(line, `CREATE RULE "_RETURN" AS`):
+			// older pg_dump versions break circular view dependencies with a
+			// dummy table converted into a view by a _RETURN rule; the rule
+			// body is validated at creation time, so it is restored along
+			// with the views, after indices and constraints
+			createRule = append(createRule, line)
+			if strings.HasSuffix(line, ";") {
+				viewsDump.WriteString(strings.Join(createRule, "\n"))
+				viewsDump.WriteString("\n\n")
+				createRule = []string{}
+			}
 
 		case strings.Contains(line, `\connect`):
 			connectStatements = append(connectStatements, line)
@@ -691,6 +737,112 @@ func (s *SnapshotGenerator) parseDump(d []byte) *dump {
 
 func isClusterOnAlterTable(line string) bool {
 	return strings.Contains(line, " CLUSTER ON ")
+}
+
+func isViewStatementStart(line string) bool {
+	return strings.HasPrefix(line, "CREATE VIEW ") ||
+		strings.HasPrefix(line, "CREATE OR REPLACE VIEW ") ||
+		strings.HasPrefix(line, "CREATE MATERIALIZED VIEW ")
+}
+
+// isDummyViewStatement returns true if the view statement matches the
+// placeholder pg_dump emits to break circular view dependencies: a bare
+// SELECT of NULL-cast columns with no FROM clause, e.g.
+//
+//	CREATE VIEW public.v AS
+//	SELECT
+//	    NULL::integer AS id,
+//	    NULL::text AS name;
+func isDummyViewStatement(lines []string) bool {
+	if len(lines) < 3 || strings.TrimSpace(lines[1]) != "SELECT" {
+		return false
+	}
+	for _, line := range lines[2:] {
+		column := strings.TrimSpace(strings.TrimRight(line, ";,"))
+		if !strings.HasPrefix(column, "NULL::") {
+			return false
+		}
+	}
+	return true
+}
+
+func isSQLFunctionStart(line string) bool {
+	return strings.HasPrefix(line, "CREATE FUNCTION ") ||
+		strings.HasPrefix(line, "CREATE OR REPLACE FUNCTION ") ||
+		strings.HasPrefix(line, "CREATE PROCEDURE ") ||
+		strings.HasPrefix(line, "CREATE OR REPLACE PROCEDURE ")
+}
+
+var dollarQuoteRegex = regexp.MustCompile(`\$[A-Za-z_0-9]*\$`)
+
+// sqlFunctionParser buffers a CREATE FUNCTION/PROCEDURE statement to
+// determine where it needs to be restored. Functions with SQL-standard bodies
+// (BEGIN ATOMIC or RETURN) are parsed and validated at creation time, unlike
+// classic string-quoted bodies which are only parsed on execution.
+type sqlFunctionParser struct {
+	inProgress      bool
+	lines           []string
+	inDollarQuotes  bool
+	dollarQuoteTag  string
+	atomicBody      bool
+	sqlStandardBody bool
+}
+
+// addLine buffers the line, returning true once the statement is complete.
+func (p *sqlFunctionParser) addLine(line string) (done bool) {
+	p.inProgress = true
+	p.lines = append(p.lines, line)
+	p.updateDollarQuoteState(line)
+	if p.inDollarQuotes {
+		// the statement can only end outside of a dollar quoted body
+		return false
+	}
+
+	trimmedLine := strings.TrimSpace(line)
+	switch {
+	case p.atomicBody:
+		// SQL-standard body `BEGIN ATOMIC <statements> END;`; pg_dump places
+		// the closing END on its own line
+		return trimmedLine == "END;"
+	case trimmedLine == "BEGIN ATOMIC":
+		p.atomicBody = true
+		p.sqlStandardBody = true
+		return false
+	default:
+		if strings.HasPrefix(trimmedLine, "RETURN ") || strings.HasPrefix(trimmedLine, "RETURN(") {
+			// SQL-standard body `RETURN <expression>;`
+			p.sqlStandardBody = true
+		}
+		return strings.HasSuffix(line, ";")
+	}
+}
+
+func (p *sqlFunctionParser) reset() {
+	*p = sqlFunctionParser{}
+}
+
+// updateDollarQuoteState tracks whether the parser is inside a dollar quoted
+// function body (e.g. $$...$$ or $_$...$_$) across lines.
+func (p *sqlFunctionParser) updateDollarQuoteState(line string) {
+	rest := line
+	for {
+		if p.inDollarQuotes {
+			idx := strings.Index(rest, p.dollarQuoteTag)
+			if idx == -1 {
+				return
+			}
+			rest = rest[idx+len(p.dollarQuoteTag):]
+			p.inDollarQuotes = false
+			continue
+		}
+		loc := dollarQuoteRegex.FindStringIndex(rest)
+		if loc == nil {
+			return
+		}
+		p.dollarQuoteTag = rest[loc[0]:loc[1]]
+		p.inDollarQuotes = true
+		rest = rest[loc[1]:]
+	}
 }
 
 func isLegacyPLPGSQLHandlerFunctionStart(line string) bool {

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
@@ -1662,6 +1662,125 @@ CREATE FUNCTION public.keep_me() RETURNS integer
 	require.Contains(t, string(dump.filtered), "CREATE FUNCTION public.keep_me() RETURNS integer")
 }
 
+func TestSnapshotGenerator_parseDumpDefersSQLStandardFunctionBodies(t *testing.T) {
+	t.Parallel()
+
+	dumpBytes := []byte(`CREATE FUNCTION public.atomic_fn() RETURNS TABLE(id integer, name text)
+    LANGUAGE sql
+    BEGIN ATOMIC
+ SELECT c.id,
+     c.name
+    FROM public.customers c
+   GROUP BY c.id;
+END;
+
+CREATE FUNCTION public.return_fn() RETURNS bigint
+    LANGUAGE sql
+    RETURN (SELECT count(*) AS count FROM public.customers);
+
+CREATE FUNCTION public.classic_fn(integer[]) RETURNS integer
+    LANGUAGE sql IMMUTABLE
+    AS $_$
+  SELECT val
+  FROM unnest($1) val
+  -- END; and RETURN inside a dollar quoted body must not confuse the parser
+  LIMIT 1;
+$_$;
+
+CREATE FUNCTION public.trigger_fn() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN NULL;
+END;
+$$;
+
+CREATE TABLE public.customers (
+    id integer NOT NULL
+);
+`)
+
+	dump := (&SnapshotGenerator{}).parseDump(dumpBytes)
+
+	filtered := string(dump.filtered)
+	views := string(dump.views)
+
+	// SQL-standard bodies are validated at creation time and can depend on
+	// constraints, so they are deferred along with the views
+	require.Contains(t, views, "CREATE FUNCTION public.atomic_fn()")
+	require.Contains(t, views, "CREATE FUNCTION public.return_fn()")
+	require.NotContains(t, filtered, "atomic_fn")
+	require.NotContains(t, filtered, "return_fn")
+
+	// classic quoted bodies stay in the main schema dump
+	require.Contains(t, filtered, "CREATE FUNCTION public.classic_fn(integer[])")
+	require.Contains(t, filtered, "CREATE FUNCTION public.trigger_fn()")
+	require.Contains(t, filtered, "CREATE TABLE public.customers")
+	require.NotContains(t, views, "classic_fn")
+	require.NotContains(t, views, "trigger_fn")
+}
+
+func TestSnapshotGenerator_parseDumpCircularDependencyViews(t *testing.T) {
+	t.Parallel()
+
+	// pg_dump breaks circular view dependencies by emitting a dummy view
+	// upfront and the real definition (CREATE OR REPLACE VIEW, or CREATE RULE
+	// "_RETURN" in older versions) at the end of the dump
+	dumpBytes := []byte(`CREATE VIEW public.circ_view AS
+SELECT
+    NULL::integer AS id,
+    NULL::text AS name;
+
+CREATE FUNCTION public.circ_fn() RETURNS SETOF public.circ_view
+    LANGUAGE sql STABLE
+    AS $$ SELECT id, name FROM circ_view $$;
+
+CREATE TABLE public.circ_base (
+    id integer NOT NULL,
+    name text NOT NULL
+);
+
+CREATE VIEW public.regular_view AS
+ SELECT c.id,
+    c.name
+   FROM public.circ_base c
+  GROUP BY c.id;
+
+CREATE OR REPLACE VIEW public.circ_view AS
+ SELECT c.id,
+    c.name
+   FROM public.circ_base c
+  WHERE (c.id IN ( SELECT circ_fn.id
+           FROM public.circ_fn() circ_fn(id, name)))
+  GROUP BY c.id;
+
+CREATE RULE "_RETURN" AS
+    ON SELECT TO public.legacy_view DO INSTEAD
+ SELECT c.id,
+    c.name
+   FROM public.circ_base c
+  GROUP BY c.id;
+`)
+
+	dump := (&SnapshotGenerator{}).parseDump(dumpBytes)
+
+	filtered := string(dump.filtered)
+	views := string(dump.views)
+
+	// the dummy view must be restored early so that the function referencing
+	// the view row type can be created
+	require.Contains(t, filtered, "CREATE VIEW public.circ_view AS\nSELECT\n    NULL::integer AS id,\n    NULL::text AS name;")
+	require.Contains(t, filtered, "CREATE FUNCTION public.circ_fn()")
+
+	// the real definitions are validated at creation time and are deferred
+	require.Contains(t, views, "CREATE OR REPLACE VIEW public.circ_view AS")
+	require.Contains(t, views, `CREATE RULE "_RETURN" AS`)
+	require.Contains(t, views, "CREATE VIEW public.regular_view AS")
+	require.NotContains(t, filtered, "CREATE OR REPLACE VIEW")
+	require.NotContains(t, filtered, "_RETURN")
+	require.NotContains(t, filtered, "regular_view")
+}
+
 func TestSnapshotGenerator_parseDumpRefreshesMaterializedViewsInCreationOrder(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/stream/integration/snapshot_pg_integration_test.go
+++ b/pkg/stream/integration/snapshot_pg_integration_test.go
@@ -835,6 +835,137 @@ func Test_SnapshotToPostgres_SkipsLegacyPLPGSQLHandlers(t *testing.T) {
 	require.Equal(t, 42, got)
 }
 
+// Test_SnapshotToPostgres_SQLStandardFunctionBodies verifies that functions
+// with SQL-standard bodies (LANGUAGE sql BEGIN ATOMIC / RETURN), whose bodies
+// are parsed and validated at creation time, are restored after indices and
+// constraints. A body such as `SELECT c.id, c.name ... GROUP BY c.id` is only
+// valid while the primary key on c exists (functional dependency); pgstream
+// defers primary key creation until after the data load, so creating the
+// function in the initial schema phase fails with `column "c.name" must
+// appear in the GROUP BY clause or be used in an aggregate function`.
+func Test_SnapshotToPostgres_SQLStandardFunctionBodies(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	var snapshotPGURL string
+	pgcleanup, err := testcontainers.SetupPostgresContainer(context.Background(), &snapshotPGURL, testcontainers.Postgres14, "config/postgresql.conf")
+	require.NoError(t, err)
+	defer pgcleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	suffix := time.Now().UnixNano()
+	testTable := fmt.Sprintf("atomic_fn_customers_%d", suffix)
+	atomicFunction := fmt.Sprintf("atomic_fn_names_%d", suffix)
+	returnFunction := fmt.Sprintf("return_fn_count_%d", suffix)
+
+	execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+		`CREATE TABLE %s(id integer PRIMARY KEY, name text NOT NULL)`, testTable))
+	execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+		`INSERT INTO %s(id, name) VALUES (1, 'a'),(2, 'b')`, testTable))
+	// both function bodies rely on the primary key of the table for the GROUP
+	// BY functional dependency and are validated at creation time
+	execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+		`CREATE FUNCTION %s() RETURNS TABLE(id integer, name text)
+		LANGUAGE sql
+		BEGIN ATOMIC
+			SELECT c.id, c.name FROM %s c GROUP BY c.id;
+		END`, atomicFunction, testTable))
+	execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+		`CREATE FUNCTION %s() RETURNS bigint
+		LANGUAGE sql
+		RETURN (SELECT count(*) FROM (SELECT c.id, c.name FROM %s c GROUP BY c.id) sub)`,
+		returnFunction, testTable))
+
+	cfg := &stream.Config{
+		Listener:  testPostgresListenerCfgWithSnapshot(snapshotPGURL, targetPGURL, []string{"public.*"}),
+		Processor: testPostgresProcessorCfg(),
+	}
+	require.NoError(t, stream.Snapshot(ctx, testLogger(), cfg, nil))
+
+	targetConn, err := pglib.NewConn(ctx, targetPGURL)
+	require.NoError(t, err)
+	defer targetConn.Close(ctx)
+
+	rows := getIDNameRows(t, ctx, targetConn, fmt.Sprintf("SELECT id, name FROM %s() ORDER BY id", atomicFunction))
+	require.Equal(t, []idNameRow{{id: 1, name: "a"}, {id: 2, name: "b"}}, rows)
+
+	var count int64
+	err = targetConn.QueryRow(ctx, []any{&count}, fmt.Sprintf("SELECT %s()", returnFunction))
+	require.NoError(t, err)
+	require.Equal(t, int64(2), count)
+}
+
+// Test_SnapshotToPostgres_CircularDependencyView verifies that views involved
+// in a circular dependency (view -> function -> view) are restored correctly.
+// pg_dump breaks the cycle by emitting a dummy `CREATE VIEW ... SELECT
+// NULL::...` (no FROM clause) upfront and a `CREATE OR REPLACE VIEW` with the
+// real definition at the end of the dump. The real definition is validated at
+// creation time: when it relies on the base table's primary key for the GROUP
+// BY functional dependency, it must be restored after indices and constraints.
+// The dummy view, on the other hand, must be restored early so that functions
+// referencing the view's row type can be created.
+func Test_SnapshotToPostgres_CircularDependencyView(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	var snapshotPGURL string
+	pgcleanup, err := testcontainers.SetupPostgresContainer(context.Background(), &snapshotPGURL, testcontainers.Postgres14, "config/postgresql.conf")
+	require.NoError(t, err)
+	defer pgcleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	suffix := time.Now().UnixNano()
+	baseTable := fmt.Sprintf("circ_base_%d", suffix)
+	viewName := fmt.Sprintf("circ_view_%d", suffix)
+	fnName := fmt.Sprintf("circ_fn_%d", suffix)
+
+	execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+		`CREATE TABLE %s(id integer PRIMARY KEY, name text NOT NULL)`, baseTable))
+	execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+		`INSERT INTO %s(id, name) VALUES (1, 'a'),(2, 'b')`, baseTable))
+	execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+		`CREATE VIEW %s AS SELECT c.id, c.name FROM %s c GROUP BY c.id`, viewName, baseTable))
+	// the function depends on the view through its return type only, so
+	// querying it doesn't recurse
+	execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+		`CREATE FUNCTION %s() RETURNS SETOF %s LANGUAGE sql STABLE AS $$ SELECT id, name FROM %s $$`,
+		fnName, viewName, baseTable))
+	// make the view depend on the function to close the cycle; the GROUP BY
+	// relies on the base table's primary key (functional dependency)
+	execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+		`CREATE OR REPLACE VIEW %s AS
+			SELECT c.id, c.name FROM %s c
+			WHERE c.id IN (SELECT id FROM %s())
+			GROUP BY c.id`, viewName, baseTable, fnName))
+
+	cfg := &stream.Config{
+		Listener:  testPostgresListenerCfgWithSnapshot(snapshotPGURL, targetPGURL, []string{"public.*"}),
+		Processor: testPostgresProcessorCfg(),
+	}
+	require.NoError(t, stream.Snapshot(ctx, testLogger(), cfg, nil))
+
+	targetConn, err := pglib.NewConn(ctx, targetPGURL)
+	require.NoError(t, err)
+	defer targetConn.Close(ctx)
+
+	// the view must hold the real definition, not pg_dump's dummy NULL
+	// placeholder, and must return the snapshotted base table rows
+	var viewDef string
+	err = targetConn.QueryRow(ctx, []any{&viewDef},
+		fmt.Sprintf("SELECT pg_get_viewdef('public.%s'::regclass)", viewName))
+	require.NoError(t, err)
+	require.Contains(t, viewDef, "GROUP BY")
+
+	rows := getIDNameRows(t, ctx, targetConn, fmt.Sprintf("SELECT id, name FROM %s ORDER BY id", viewName))
+	require.Equal(t, []idNameRow{{id: 1, name: "a"}, {id: 2, name: "b"}}, rows)
+}
+
 // Test_SnapshotToPostgres_IdentityAndGeneratedColumns verifies that identity
 // columns have their values preserved while generated (stored) columns are
 // correctly excluded from inserts and recomputed by the target database.


### PR DESCRIPTION
While sorting DDL statements in the schema, the code was missing two kinds:
- `CREATE OR REPLACE VIEW` (instead of just `CREATE VIEW`) which is used by pg_dump for circular views
- SQL functions with `BEGIN ATOMIC / RETURN (...)`

There are two integration tests added that each were reproducing one the two cases above. 
- `Test_SnapshotToPostgres_CircularDependencyView`
- `Test_SnapshotToPostgres_SQLStandardFunctionBodies`


#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup


#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

#### Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Code is well-commented
- [ ] Documentation updated where necessary


#### Additional Notes

<!-- Any context or special instructions for reviewers -->
