### PR TITLE
[Preflight] Do not report custom enums as unsupported types

### DIFF
--- a/pkg/stream/preflight/schema.go
+++ b/pkg/stream/preflight/schema.go
@@ -32,11 +32,14 @@ SELECT
   a.attname,
   tr.resolved_oid::bigint,
   tr.typname,
-  tr.typtype
+  tr.typtype,
+  COALESCE(elem.typtype, '') AS elem_typtype
 FROM pg_attribute a
 JOIN pg_class c ON c.oid = a.attrelid
 JOIN pg_namespace n ON n.oid = c.relnamespace
 JOIN type_resolved tr ON tr.source_oid = a.atttypid AND tr.typtype <> 'd'
+JOIN pg_type rt ON rt.oid = tr.resolved_oid
+LEFT JOIN pg_type elem ON elem.oid = rt.typelem AND rt.typcategory = 'A'
 WHERE c.relkind IN ('r', 'p')
   AND a.attnum > 0
   AND NOT a.attisdropped
@@ -84,10 +87,13 @@ func (c *SchemaTypeCompatibilityCheck) Run(ctx context.Context) ([]Finding, erro
 	var findings []Finding
 	for rows.Next() {
 		var row schemaColumnRow
-		if err := rows.Scan(&row.Schema, &row.Table, &row.Column, &row.BaseOID, &row.TypeName, &row.TypeKind); err != nil {
+		if err := rows.Scan(&row.Schema, &row.Table, &row.Column, &row.BaseOID, &row.TypeName, &row.TypeKind, &row.ElemTypeKind); err != nil {
 			return nil, fmt.Errorf("scanning row: %w", err)
 		}
 		if !c.Selection.IsTableInScope(row.Schema, row.Table) {
+			continue
+		}
+		if row.isEnum() {
 			continue
 		}
 		if _, ok := typeMap.TypeForOID(uint32(row.BaseOID)); ok {
@@ -117,12 +123,20 @@ func pgstreamSupportedTypes() map[string]struct{} {
 }
 
 type schemaColumnRow struct {
-	Schema   string
-	Table    string
-	Column   string
-	BaseOID  int64  // OID of the column's type, with domains resolved to their base
-	TypeName string // name of that resolved type
-	TypeKind string // pg_type.typtype of the resolved type
+	Schema       string
+	Table        string
+	Column       string
+	BaseOID      int64  // OID of the column's type, with domains resolved to their base
+	TypeName     string // name of that resolved type
+	TypeKind     string // pg_type.typtype of the resolved type
+	ElemTypeKind string // pg_type.typtype of the array element type, "" when not an array
+}
+
+// isEnum reports whether the column is an enum or an array of enums. Enum array
+// types are ordinary base types (typtype 'b') whose element carries the enum
+// kind, so the scalar TypeKind alone doesn't catch them.
+func (r schemaColumnRow) isEnum() bool {
+	return r.TypeKind == "e" || r.ElemTypeKind == "e"
 }
 
 func unsupportedColumnTypeMessage(row schemaColumnRow) string {
@@ -170,7 +184,7 @@ func (c *PostgresRangeTypeCheck) Run(ctx context.Context) ([]Finding, error) {
 	var findings []Finding
 	for rows.Next() {
 		var row schemaColumnRow
-		if err := rows.Scan(&row.Schema, &row.Table, &row.Column, &row.BaseOID, &row.TypeName, &row.TypeKind); err != nil {
+		if err := rows.Scan(&row.Schema, &row.Table, &row.Column, &row.BaseOID, &row.TypeName, &row.TypeKind, &row.ElemTypeKind); err != nil {
 			return nil, fmt.Errorf("scanning row: %w", err)
 		}
 		if !c.Selection.IsTableInScope(row.Schema, row.Table) {

--- a/pkg/stream/preflight/schema_test.go
+++ b/pkg/stream/preflight/schema_test.go
@@ -44,7 +44,7 @@ func TestSchemaTypeCompatibilityCheck_Run_UserDefinedTypeReturnsFinding(t *testi
 	check := &SchemaTypeCompatibilityCheck{
 		Source: sourceWithColumns(t, []schemaColumnRow{
 			{Schema: "public", Table: "orders", Column: "id", BaseOID: oidInt4, TypeName: "int4", TypeKind: "b"},
-			{Schema: "public", Table: "orders", Column: "status", BaseOID: oidUnknown, TypeName: "order_status", TypeKind: "e"},
+			{Schema: "public", Table: "orders", Column: "amount", BaseOID: oidUnknown, TypeName: "money_amount", TypeKind: "c"},
 		}),
 	}
 
@@ -52,9 +52,27 @@ func TestSchemaTypeCompatibilityCheck_Run_UserDefinedTypeReturnsFinding(t *testi
 
 	require.NoError(t, err)
 	require.Len(t, findings, 1)
-	require.Contains(t, findings[0].Message, `"public"."orders"."status"`)
-	require.Contains(t, findings[0].Message, `enum type "order_status"`)
+	require.Contains(t, findings[0].Message, `"public"."orders"."amount"`)
+	require.Contains(t, findings[0].Message, `composite type "money_amount"`)
 	require.Contains(t, findings[0].Message, "exclude the table")
+}
+
+func TestSchemaTypeCompatibilityCheck_Run_SkipsEnums(t *testing.T) {
+	t.Parallel()
+	check := &SchemaTypeCompatibilityCheck{
+		Source: sourceWithColumns(t, []schemaColumnRow{
+			{Schema: "public", Table: "orders", Column: "status", BaseOID: oidUnknown, TypeName: "order_status", TypeKind: "e"},
+			{Schema: "public", Table: "orders", Column: "tags", BaseOID: oidUnknown + 1, TypeName: "_order_status", TypeKind: "b", ElemTypeKind: "e"},
+			{Schema: "public", Table: "orders", Column: "amount", BaseOID: oidUnknown + 2, TypeName: "money_amount", TypeKind: "c"},
+		}),
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Message, `"public"."orders"."amount"`)
+	require.Contains(t, findings[0].Message, "composite type")
 }
 
 func TestSchemaTypeCompatibilityCheck_Run_PgstreamExtraTypesPass(t *testing.T) {
@@ -634,7 +652,7 @@ func schemaColumnRows(t *testing.T, rows []schemaColumnRow) postgres.Rows {
 			return int(i) <= len(rows)
 		},
 		ScanFn: func(i uint, dest ...any) error {
-			require.Len(t, dest, 6)
+			require.Len(t, dest, 7)
 			row := rows[i-1]
 			schema, ok := dest[0].(*string)
 			require.True(t, ok)
@@ -648,12 +666,15 @@ func schemaColumnRows(t *testing.T, rows []schemaColumnRow) postgres.Rows {
 			require.True(t, ok)
 			typeKind, ok := dest[5].(*string)
 			require.True(t, ok)
+			elemTypeKind, ok := dest[6].(*string)
+			require.True(t, ok)
 			*schema = row.Schema
 			*table = row.Table
 			*column = row.Column
 			*baseOID = row.BaseOID
 			*typeName = row.TypeName
 			*typeKind = row.TypeKind
+			*elemTypeKind = row.ElemTypeKind
 			return nil
 		},
 		ErrFn: func() error { return nil },


### PR DESCRIPTION
#### Description

Previously, `pgstream check` flagged every user-defined enum column as an unsupported type, e.g.:

```
schema_type_compatibility: "table_name"."column_name"."type": enum type "enum_name" unknown type; Cast the column to a supported type or exclude the table from the migration.
  ```

This is a false positive. The check only recognizes types that  pgx 's static type map knows by OID, and enum OIDs are database-specific, so enums never resolve. But the Postgres target replicates enum values as text (with the enum type itself replicated via `CREATE TYPE`), so they migrate fine.

`SchemaTypeCompatibilityCheck` now skips enum columns. This covers both scalar enums (typtype = 'e') and arrays of enums (typtype = 'b') whose element carries the enum kind.

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
