### PR TITLE
Downgrade error on restoring comment to warning

### DIFF
--- a/internal/postgres/errors.go
+++ b/internal/postgres/errors.go
@@ -32,6 +32,14 @@ func (e *ErrConstraintViolation) Error() string {
 	return fmt.Sprintf("constraint violation: %s", e.Details)
 }
 
+type ErrCommentOwnership struct {
+	Details string
+}
+
+func (e *ErrCommentOwnership) Error() string {
+	return fmt.Sprintf("comment not restored, requires object ownership: %s", e.Details)
+}
+
 type ErrPermissionDenied struct {
 	Details string
 }

--- a/internal/postgres/pg_restore.go
+++ b/internal/postgres/pg_restore.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os/exec"
 	"strings"
+	"unicode/utf8"
 )
 
 const (
@@ -133,9 +134,15 @@ func parsePgRestoreOutputErrs(out []byte) error {
 	errs := &PGRestoreErrors{}
 	scanner := bufio.NewScanner(bytes.NewReader(out))
 	var currentErr error
+	inStatement := false
 	for scanner.Scan() {
 		line := scanner.Text()
 		switch {
+		case inStatement:
+			// continuation of a multi-line statement echo: consume until the
+			// terminating semicolon so echoed SQL text (which can contain
+			// "ERROR" or other keywords) is never parsed as new records
+			inStatement = !endsStatement(line)
 		case isStatementLine(line):
 			if currentErr != nil {
 				if isOwnershipError(currentErr) && isCommentStatement(line) {
@@ -143,6 +150,7 @@ func parsePgRestoreOutputErrs(out []byte) error {
 				}
 				currentErr = fmt.Errorf("%w: %s", currentErr, truncateStatement(line))
 			}
+			inStatement = !endsStatement(line)
 		case isErrorLine(line):
 			// Save any pending error before processing new one
 			if currentErr != nil {
@@ -167,22 +175,35 @@ func parsePgRestoreOutputErrs(out []byte) error {
 	return errs
 }
 
-// isDetailLine checks if a line contains detail information
+// isDetailLine checks if a line starts a detail record
 func isDetailLine(line string) bool {
-	return strings.Contains(line, "DETAIL:")
+	return strings.HasPrefix(strings.TrimSpace(line), "DETAIL:")
+}
+
+var statementPrefixes = []string{"STATEMENT:", "Command was:"}
+
+func stripStatementPrefix(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	for _, prefix := range statementPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(trimmed, prefix)), true
+		}
+	}
+	return "", false
 }
 
 func isStatementLine(line string) bool {
-	trimmed := strings.TrimSpace(line)
-	return strings.HasPrefix(trimmed, "STATEMENT:") || strings.HasPrefix(trimmed, "Command was:")
+	_, ok := stripStatementPrefix(line)
+	return ok
 }
 
 func isCommentStatement(line string) bool {
-	stmt := strings.TrimSpace(line)
-	for _, prefix := range []string{"STATEMENT:", "Command was:"} {
-		stmt = strings.TrimSpace(strings.TrimPrefix(stmt, prefix))
-	}
-	return strings.HasPrefix(stmt, "COMMENT ON ")
+	stmt, ok := stripStatementPrefix(line)
+	return ok && strings.HasPrefix(stmt, "COMMENT ON ")
+}
+
+func endsStatement(line string) bool {
+	return strings.HasSuffix(strings.TrimSpace(line), ";")
 }
 
 func isOwnershipError(err error) bool {
@@ -193,15 +214,26 @@ func truncateStatement(line string) string {
 	if len(line) <= maxStatementLen {
 		return line
 	}
-	return line[:maxStatementLen] + "..."
+	truncated := line[:maxStatementLen]
+	// don't leave a partial multibyte rune at the cut point
+	for len(truncated) > 0 {
+		if r, size := utf8.DecodeLastRuneInString(truncated); r != utf8.RuneError || size > 1 {
+			break
+		}
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated + "..."
 }
 
-// isErrorLine checks if a line contains an error indicator
+// isErrorLine checks if a line starts an error record. Anchored on line
+// prefixes rather than substring matches so that echoed SQL containing
+// keywords like "ERROR" is not mistaken for a new error.
 func isErrorLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
 	switch {
-	case strings.Contains(line, "pg_restore: error:"),
-		strings.Contains(line, "ERROR"),
-		strings.Contains(line, "psql: error:"):
+	case strings.HasPrefix(trimmed, "ERROR"),
+		strings.HasPrefix(trimmed, "pg_restore: error:"),
+		strings.HasPrefix(trimmed, "psql: error:"):
 		return true
 	default:
 		return false

--- a/internal/postgres/pg_restore.go
+++ b/internal/postgres/pg_restore.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	pgRestoreCmd = "pg_restore"
-	psqlCmd      = "psql"
-	postgres     = "postgres"
+	pgRestoreCmd    = "pg_restore"
+	psqlCmd         = "psql"
+	postgres        = "postgres"
+	maxStatementLen = 500
 )
 
 type PGRestoreOptions struct {
@@ -57,7 +58,7 @@ func (opts PGRestoreOptions) toArgs() []string {
 }
 
 func (opts PGRestoreOptions) toPSQLArgs() []string {
-	return []string{opts.ConnectionString}
+	return []string{"--echo-errors", opts.ConnectionString}
 }
 
 // Func RunPGRestore runs pg_restore command with the given options and returns
@@ -135,6 +136,13 @@ func parsePgRestoreOutputErrs(out []byte) error {
 	for scanner.Scan() {
 		line := scanner.Text()
 		switch {
+		case isStatementLine(line):
+			if currentErr != nil {
+				if isOwnershipError(currentErr) && isCommentStatement(line) {
+					currentErr = &ErrCommentOwnership{Details: currentErr.Error()}
+				}
+				currentErr = fmt.Errorf("%w: %s", currentErr, truncateStatement(line))
+			}
 		case isErrorLine(line):
 			// Save any pending error before processing new one
 			if currentErr != nil {
@@ -162,6 +170,30 @@ func parsePgRestoreOutputErrs(out []byte) error {
 // isDetailLine checks if a line contains detail information
 func isDetailLine(line string) bool {
 	return strings.Contains(line, "DETAIL:")
+}
+
+func isStatementLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "STATEMENT:") || strings.HasPrefix(trimmed, "Command was:")
+}
+
+func isCommentStatement(line string) bool {
+	stmt := strings.TrimSpace(line)
+	for _, prefix := range []string{"STATEMENT:", "Command was:"} {
+		stmt = strings.TrimSpace(strings.TrimPrefix(stmt, prefix))
+	}
+	return strings.HasPrefix(stmt, "COMMENT ON ")
+}
+
+func isOwnershipError(err error) bool {
+	return strings.Contains(err.Error(), "must be owner of")
+}
+
+func truncateStatement(line string) string {
+	if len(line) <= maxStatementLen {
+		return line
+	}
+	return line[:maxStatementLen] + "..."
 }
 
 // isErrorLine checks if a line contains an error indicator
@@ -236,11 +268,13 @@ func (e *PGRestoreErrors) addError(err error) {
 	var errConstraintViolation *ErrConstraintViolation
 	var errPermissionDenied *ErrPermissionDenied
 	var errDoesNotExist *ErrRelationDoesNotExist
+	var errCommentOwnership *ErrCommentOwnership
 	switch {
 	case errors.As(err, &errAlreadyExists),
 		errors.As(err, &errConstraintViolation),
 		errors.As(err, &errPermissionDenied),
-		errors.As(err, &errDoesNotExist):
+		errors.As(err, &errDoesNotExist),
+		errors.As(err, &errCommentOwnership):
 		e.ignoredErrs = append(e.ignoredErrs, err)
 	default:
 		e.criticalErrs = append(e.criticalErrs, err)

--- a/internal/postgres/pg_restore_test.go
+++ b/internal/postgres/pg_restore_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -227,6 +228,34 @@ STATEMENT:  CREATE TABLE public.t_multi(
 
 			wantErrs: nil,
 		},
+		{
+			name: "multi-line comment echo containing ERROR text stays ignorable",
+			output: `ERROR:  must be owner of schema public
+STATEMENT:  COMMENT ON SCHEMA public IS 'status codes:
+ERROR means failure
+DETAIL: none';`,
+
+			wantErrs: &PGRestoreErrors{
+				ignoredErrs: []error{
+					fmt.Errorf("%w: %s", &ErrCommentOwnership{Details: "ERROR:  must be owner of schema public"}, "STATEMENT:  COMMENT ON SCHEMA public IS 'status codes:"),
+				},
+			},
+		},
+		{
+			name: "error following a multi-line statement echo is still parsed",
+			output: `ERROR:  must be owner of schema public
+STATEMENT:  COMMENT ON SCHEMA public IS 'first
+line';
+ERROR:  relation "users" already exists
+STATEMENT:  CREATE TABLE public.users (id integer);`,
+
+			wantErrs: &PGRestoreErrors{
+				ignoredErrs: []error{
+					fmt.Errorf("%w: %s", &ErrCommentOwnership{Details: "ERROR:  must be owner of schema public"}, "STATEMENT:  COMMENT ON SCHEMA public IS 'first"),
+					fmt.Errorf("%w: %s", &ErrRelationAlreadyExists{Details: `ERROR:  relation "users" already exists`}, "STATEMENT:  CREATE TABLE public.users (id integer);"),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -309,6 +338,8 @@ func TestIsErrorLine(t *testing.T) {
 		{"pg_restore: processing data for table", false},
 		{"DETAIL:  some detail", false},
 		{"INFO:  some info", false},
+		{"'ERROR means failure';", false},
+		{"comment text mentioning ERROR mid-line", false},
 		{"", false},
 	}
 
@@ -389,6 +420,12 @@ func TestTruncateStatement(t *testing.T) {
 	long := "STATEMENT:  CREATE VIEW public.v AS SELECT " + strings.Repeat("a", maxStatementLen)
 	truncated := truncateStatement(long)
 	assert.Len(t, truncated, maxStatementLen+len("..."))
+	assert.True(t, strings.HasSuffix(truncated, "..."))
+
+	// the two-byte 'é' straddles the cut point and must not be split
+	multibyte := strings.Repeat("a", maxStatementLen-1) + "éllo wörld"
+	truncated = truncateStatement(multibyte)
+	assert.True(t, utf8.ValidString(truncated))
 	assert.True(t, strings.HasSuffix(truncated, "..."))
 }
 

--- a/internal/postgres/pg_restore_test.go
+++ b/internal/postgres/pg_restore_test.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -149,6 +150,83 @@ pg_restore: finished`,
 				},
 			},
 		},
+		{
+			name: "ownership error on comment statement is ignorable",
+			output: `ERROR:  must be owner of schema public
+STATEMENT:  COMMENT ON SCHEMA public IS 'standard public schema';`,
+
+			wantErrs: &PGRestoreErrors{
+				ignoredErrs: []error{
+					fmt.Errorf("%w: %s", &ErrCommentOwnership{Details: "ERROR:  must be owner of schema public"}, "STATEMENT:  COMMENT ON SCHEMA public IS 'standard public schema';"),
+				},
+			},
+		},
+		{
+			name: "ownership error on comment statement from pg_restore is ignorable",
+			output: `pg_restore: error: could not execute query: ERROR:  must be owner of extension plpgsql
+Command was: COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';`,
+
+			wantErrs: &PGRestoreErrors{
+				ignoredErrs: []error{
+					fmt.Errorf("%w: %s", &ErrCommentOwnership{Details: "pg_restore: error: could not execute query: ERROR:  must be owner of extension plpgsql"}, "Command was: COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';"),
+				},
+			},
+		},
+		{
+			name: "ownership error on non-comment statement stays critical",
+			output: `ERROR:  must be owner of table users
+STATEMENT:  ALTER TABLE public.users OWNER TO admin;`,
+
+			wantErrs: &PGRestoreErrors{
+				criticalErrs: []error{
+					fmt.Errorf("%w: %s", errors.New("ERROR:  must be owner of table users"), "STATEMENT:  ALTER TABLE public.users OWNER TO admin;"),
+				},
+			},
+		},
+		{
+			name: "error with command was line from pg_restore",
+			output: `pg_restore: error: could not execute query: ERROR:  relation "users" already exists
+Command was: CREATE TABLE public.users (id integer);`,
+
+			wantErrs: &PGRestoreErrors{
+				ignoredErrs: []error{
+					fmt.Errorf("%w: %s", &ErrRelationAlreadyExists{Details: `pg_restore: error: could not execute query: ERROR:  relation "users" already exists`}, "Command was: CREATE TABLE public.users (id integer);"),
+				},
+			},
+		},
+		{
+			name: "statement echo containing ERROR keyword is not a new error",
+			output: `ERROR:  must be owner of table error_log
+STATEMENT:  COMMENT ON TABLE error_log IS 'ERROR entries';`,
+
+			wantErrs: &PGRestoreErrors{
+				ignoredErrs: []error{
+					fmt.Errorf("%w: %s", &ErrCommentOwnership{Details: "ERROR:  must be owner of table error_log"}, "STATEMENT:  COMMENT ON TABLE error_log IS 'ERROR entries';"),
+				},
+			},
+		},
+		{
+			name: "multi-line statement echo keeps first line only",
+			output: `ERROR:  permission denied for schema public
+LINE 1: CREATE TABLE public.t_multi(
+                     ^
+STATEMENT:  CREATE TABLE public.t_multi(
+  id int,
+  name text
+);`,
+
+			wantErrs: &PGRestoreErrors{
+				criticalErrs: []error{
+					fmt.Errorf("%w: %s", errors.New("ERROR:  permission denied for schema public"), "STATEMENT:  CREATE TABLE public.t_multi("),
+				},
+			},
+		},
+		{
+			name:   "statement line without preceding error is ignored",
+			output: "STATEMENT:  COMMENT ON SCHEMA public IS 'standard public schema';\n",
+
+			wantErrs: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -260,6 +338,58 @@ func TestIsDetailLine(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestIsStatementLine(t *testing.T) {
+	tests := []struct {
+		line     string
+		expected bool
+	}{
+		{"STATEMENT:  COMMENT ON SCHEMA public IS 'standard public schema';", true},
+		{"Command was: CREATE TABLE public.users (id integer);", true},
+		{"    Command was: CREATE TABLE public.users (id integer);", true},
+		{"ERROR:  must be owner of schema public", false},
+		{"DETAIL:  some detail", false},
+		{"  id int,", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			result := isStatementLine(tt.line)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsCommentStatement(t *testing.T) {
+	tests := []struct {
+		line     string
+		expected bool
+	}{
+		{"STATEMENT:  COMMENT ON SCHEMA public IS 'standard public schema';", true},
+		{"Command was: COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';", true},
+		{"STATEMENT:  ALTER TABLE public.users OWNER TO admin;", false},
+		{"STATEMENT:  CREATE TABLE public.comment_on (id int);", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			result := isCommentStatement(tt.line)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTruncateStatement(t *testing.T) {
+	short := "STATEMENT:  COMMENT ON SCHEMA public IS 'standard public schema';"
+	assert.Equal(t, short, truncateStatement(short))
+
+	long := "STATEMENT:  CREATE VIEW public.v AS SELECT " + strings.Repeat("a", maxStatementLen)
+	truncated := truncateStatement(long)
+	assert.Len(t, truncated, maxStatementLen+len("..."))
+	assert.True(t, strings.HasSuffix(truncated, "..."))
 }
 
 func TestParseErrorLine(t *testing.T) {


### PR DESCRIPTION
#### Description

Previously snapshot restores failed with "must be owner of schema public" when the target user doesn't own the commented object, since `pg_dump` includes `CREATE SCHEMA`/`COMMENT ON` statements for explicitly selected schemas.

From now on, we run `psql` with `--echo-errors` and capture the failed statement into the restore error, so ownership errors on `COMMENT ON` statements can be classified as ignorable. The comment is restored when the snapshot user owns the target object, and skipped with a warning otherwise.

##### Related Issue(s)

- Fixes #1004

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- run `psql` with `--echo-errors` so we can tell what statement failed exactly
- comments are only restored if the target user owns the target schema

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
