### PR TITLE
Docs: single-instance requirement for snapshot sources

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -27,10 +27,17 @@ This guide explains how to use **pgstream** with **AWS RDS/Aurora databases**, c
 
 #### Quick Checklist
 
+- [ ] Point the source URL at the **writer / single-instance endpoint**, **not** the Aurora reader (`cluster-ro`) or an RDS reader endpoint (see warning below).
 - [ ] Create a source user (**`pgstreamsource`**) with access to required schemas/tables.
 - [ ] For roles without passwords → no special config needed.
 - [ ] Snapshot of roles with passwords is **not supported**.
 - [ ] Update YAML config with correct snapshot settings.
+
+> ⚠️ **Do not snapshot from an Aurora reader (`cluster-ro`) or RDS reader endpoint.** These
+> load-balance across multiple instances, and the parallel data snapshot relies on an
+> instance-local exported transaction snapshot. Worker connections that land on a different
+> reader fail nondeterministically with `snapshot "…" does not exist`. Use the
+> **writer/cluster endpoint** (a single instance). See [Snapshots](snapshots.md#️-the-data-snapshot-source-must-be-a-single-instance) for details; `pgstream check` flags this before a snapshot runs.
 
 #### Steps
 

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -14,4 +14,32 @@ The snapshot implementation is different for schema and data.
 
 ![snapshots sequence](img/pgstream_snapshot_sequence.svg)
 
+## ⚠️ The data snapshot source must be a single instance
+
+The data snapshot exports a transaction snapshot on one connection and imports it
+(`SET TRANSACTION SNAPSHOT`) on the parallel worker connections to give every worker the
+same stable view. An exported snapshot is **instance-local**, so this only works when every
+connection reaches the *same* Postgres instance.
+
+Do **not** point the snapshot source at a load-balanced endpoint that spans multiple
+instances, such as:
+
+- an Amazon **Aurora reader (`cluster-ro`) endpoint** or an **RDS reader endpoint**,
+- a connection **pooler that spreads connections across multiple database instances**.
+
+Against such an endpoint the worker connections can land on a different instance than the
+one that exported the snapshot, and the snapshot fails — nondeterministically, depending on
+how connections happen to be routed — with:
+
+```
+setting transaction snapshot: relation does not exist: snapshot "…" does not exist
+```
+
+Use a **single-instance / writer endpoint** for the snapshot source. A connection pooler in
+front of a *single* instance (e.g. RDS Proxy to one instance, or pgbouncer to one server) is
+fine.
+
+> `pgstream check` includes a preflight check that probes the source and reports a clear
+> error when it detects a load-balanced source, so you can catch this before a snapshot runs.
+
 For more details into the snapshot implementation and performance benchmarking, check out this [blogpost](https://xata.io/blog/behind-the-scenes-speeding-up-pgstream-snapshots-for-postgresql). For details on how to use and configure the snapshot mode, check the [snapshot tutorial](tutorials/postgres_snapshot.md).


### PR DESCRIPTION
#### Description

`snapshots.md` and `aws.md` are updated. The data snapshot source must be a single instance; Aurora/RDS reader endpoints load-balance across instances and are unsupported for snapshots. `pgstream check` flags this before a snapshot runs.

##### Related Issue(s)

- Related to #1012

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup
