### PR TITLE
[Preflight] Detect load-balanced snapshot sources

### DIFF
--- a/internal/postgres/pg_snapshot_probe.go
+++ b/internal/postgres/pg_snapshot_probe.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+var (
+	ErrLoadBalancedSource = errors.New("the source appears to be load-balanced across multiple Postgres instances " +
+		"(e.g. an Aurora/RDS reader endpoint, or a pooler spanning instances); parallel snapshotting requires every " +
+		"connection to reach the same instance — use a single-instance / writer endpoint")
+
+	ErrSnapshotExportFailed = errors.New("could not export a transaction snapshot on the source")
+
+	// snapshotProbeTxOptions mirrors the data snapshot generator's tx options: an
+	// imported snapshot requires REPEATABLE READ (or SERIALIZABLE), and the probe
+	// only reads.
+	snapshotProbeTxOptions = TxOptions{
+		IsolationLevel: RepeatableRead,
+		AccessMode:     ReadOnly,
+	}
+
+	// snapshotIDPattern matches the shape Postgres' pg_export_snapshot() returns
+	// Example: "00000027-000019C2-1"
+	snapshotIDPattern = regexp.MustCompile(`^[0-9A-Fa-f]+-[0-9A-Fa-f]+-\d+$`)
+)
+
+// IsExportedSnapshotMissing reports whether err (from importing an exported
+// snapshot via SET TRANSACTION SNAPSHOT) indicates the snapshot is not visible
+// on the instance the connection landed on.
+func IsExportedSnapshotMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	var relErr *ErrRelationDoesNotExist
+	if errors.As(err, &relErr) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "snapshot") && strings.Contains(msg, "does not exist")
+}
+
+// ProbeExportedSnapshotVisibility reproduces the parallel data snapshot's core
+// requirement: it exports a transaction snapshot on one connection, holds that
+// connection open, and tries to import it (SET TRANSACTION SNAPSHOT) on `probes`
+// concurrent connections. An exported snapshot is instance-local, so on a
+// load-balanced source some probe connections land on a different instance and
+// fail with "snapshot does not exist".
+//
+// The probe is probabilistic: a run that happens to route every connection to
+// the exporting instance reports missing == 0. It is weakest for pure DNS
+// round-robin endpoints, where a cached resolver answer can pin every dial in
+// the burst to one instance.
+func ProbeExportedSnapshotVisibility(ctx context.Context, dial func(context.Context) (Querier, error), probes int) (missing int, err error) {
+	if probes < 1 {
+		return 0, fmt.Errorf("snapshot visibility probe needs at least one probe connection, got %d", probes)
+	}
+	snapshotID, release, done, err := exportHeldSnapshot(ctx, dial)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		close(release)
+		<-done
+	}()
+	return probeSnapshotImport(ctx, dial, snapshotID, probes)
+}
+
+func exportHeldSnapshot(ctx context.Context, dial func(context.Context) (Querier, error)) (snapshotID string, release, done chan struct{}, err error) {
+	conn, err := dial(ctx)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("%w: connecting to source: %w", ErrSnapshotExportFailed, err)
+	}
+
+	idCh := make(chan string, 1)
+	release = make(chan struct{})
+	done = make(chan struct{})
+	txErr := make(chan error, 1)
+
+	go func() {
+		defer close(done)
+		defer conn.Close(context.Background())
+		txErr <- conn.ExecInTxWithOptions(ctx, func(tx Tx) error {
+			var id string
+			if err := tx.QueryRow(ctx, []any{&id}, "SELECT pg_export_snapshot()"); err != nil {
+				return err
+			}
+			idCh <- id
+			<-release // hold the snapshot alive while the probes import it
+			return nil
+		}, snapshotProbeTxOptions)
+	}()
+
+	select {
+	case id := <-idCh:
+		if !snapshotIDPattern.MatchString(id) {
+			close(release)
+			<-done
+			return "", nil, nil, fmt.Errorf("%w: unexpected snapshot id %q from source", ErrSnapshotExportFailed, id)
+		}
+		return id, release, done, nil
+	case err := <-txErr:
+		close(release)
+		<-done
+		if err == nil {
+			err = errors.New("exporter transaction returned no snapshot id")
+		}
+		return "", nil, nil, fmt.Errorf("%w: %w", ErrSnapshotExportFailed, err)
+	case <-ctx.Done():
+		close(release)
+		<-done
+		return "", nil, nil, fmt.Errorf("%w: %w", ErrSnapshotExportFailed, ctx.Err())
+	}
+}
+
+func probeSnapshotImport(ctx context.Context, dial func(context.Context) (Querier, error), snapshotID string, probes int) (missing int, firstErr error) {
+	type result struct {
+		missing bool
+		err     error
+	}
+	results := make([]result, probes)
+	var wg sync.WaitGroup
+	for i := 0; i < probes; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			conn, err := dial(ctx)
+			if err != nil {
+				results[i] = result{err: fmt.Errorf("connecting to source: %w", err)}
+				return
+			}
+			defer conn.Close(context.Background())
+			err = conn.ExecInTxWithOptions(ctx, func(tx Tx) error {
+				// SET TRANSACTION SNAPSHOT must be the first statement in the tx.
+				_, execErr := tx.Exec(ctx, fmt.Sprintf("SET TRANSACTION SNAPSHOT '%s'", snapshotID))
+				return execErr
+			}, snapshotProbeTxOptions)
+			switch {
+			case err == nil:
+			case IsExportedSnapshotMissing(err):
+				results[i] = result{missing: true}
+			default:
+				results[i] = result{err: err}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	succeeded := false
+	for _, r := range results {
+		switch {
+		case r.missing:
+			missing++
+		case r.err != nil:
+			if firstErr == nil {
+				firstErr = r.err
+			}
+		default:
+			succeeded = true
+		}
+	}
+	// If at least one probe imported the snapshot cleanly and none reported it
+	// missing, the source is a single instance.
+	if missing == 0 && succeeded {
+		firstErr = nil
+	}
+	return missing, firstErr
+}

--- a/internal/postgres/pg_snapshot_probe_test.go
+++ b/internal/postgres/pg_snapshot_probe_test.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	postgres "github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/postgres/mocks"
+)
+
+// snapshotMissingErr is what MapError produces for SQLSTATE 42704 on a SET
+// TRANSACTION SNAPSHOT against a load-balanced source.
+var snapshotMissingErr = &postgres.ErrRelationDoesNotExist{Details: `snapshot "00000D0E-0000001A-1" does not exist`}
+
+func exporterMock(snapshotID string, queryErr error) *mocks.Querier {
+	return &mocks.Querier{
+		ExecInTxWithOptionsFn: func(ctx context.Context, _ uint, fn func(tx postgres.Tx) error, _ postgres.TxOptions) error {
+			return fn(&mocks.Tx{
+				QueryRowFn: func(_ context.Context, dest []any, _ string, _ ...any) error {
+					if queryErr != nil {
+						return queryErr
+					}
+					if ptr, ok := dest[0].(*string); ok {
+						*ptr = snapshotID
+					}
+					return nil
+				},
+			})
+		},
+	}
+}
+
+// errWhen returns err when cond holds, else nil — used to pick a per-importer
+// outcome by index.
+func errWhen(cond bool, err error) error {
+	if cond {
+		return err
+	}
+	return nil
+}
+
+func importerMock(execErr error) *mocks.Querier {
+	return &mocks.Querier{
+		ExecInTxWithOptionsFn: func(ctx context.Context, _ uint, fn func(tx postgres.Tx) error, _ postgres.TxOptions) error {
+			return fn(&mocks.Tx{
+				ExecFn: func(_ context.Context, _ uint, _ string, _ ...any) (postgres.CommandTag, error) {
+					return postgres.CommandTag{}, execErr
+				},
+			})
+		},
+	}
+}
+
+// dialer hands out the exporter on the first call and an importer built by
+// importerFor on every subsequent (concurrent) call.
+func dialer(exporter *mocks.Querier, importerFor func(importerIdx int) *mocks.Querier) func(context.Context) (postgres.Querier, error) {
+	var calls int32
+	return func(context.Context) (postgres.Querier, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			return exporter, nil
+		}
+		return importerFor(int(n) - 2), nil
+	}
+}
+
+func TestProbeExportedSnapshotVisibility(t *testing.T) {
+	t.Parallel()
+
+	otherErr := errors.New("boom")
+
+	tests := []struct {
+		name            string
+		probes          int
+		exporter        *mocks.Querier
+		importerFor     func(int) *mocks.Querier
+		dial            func(context.Context) (postgres.Querier, error)
+		wantMissing     int
+		wantErr         bool
+		wantExportError bool
+	}{
+		{
+			name:        "single instance - all importers succeed",
+			probes:      4,
+			exporter:    exporterMock("0000004D-00001943-1", nil),
+			importerFor: func(int) *mocks.Querier { return importerMock(nil) },
+		},
+		{
+			name:        "load balanced - all importers report snapshot missing",
+			probes:      4,
+			exporter:    exporterMock("0000004D-00001943-1", nil),
+			importerFor: func(int) *mocks.Querier { return importerMock(snapshotMissingErr) },
+			wantMissing: 4,
+		},
+		{
+			name:     "load balanced - only some importers land elsewhere",
+			probes:   4,
+			exporter: exporterMock("0000004D-00001943-1", nil),
+			importerFor: func(i int) *mocks.Querier {
+				return importerMock(errWhen(i%2 == 0, snapshotMissingErr))
+			},
+			wantMissing: 2,
+		},
+		{
+			name:        "non-snapshot error on one probe is ignored when another succeeds",
+			probes:      4,
+			exporter:    exporterMock("0000004D-00001943-1", nil),
+			importerFor: func(i int) *mocks.Querier { return importerMock(errWhen(i == 0, otherErr)) },
+		},
+		{
+			name:        "all probes fail for a non-snapshot reason - error",
+			probes:      3,
+			exporter:    exporterMock("0000004D-00001943-1", nil),
+			importerFor: func(int) *mocks.Querier { return importerMock(otherErr) },
+			wantErr:     true,
+		},
+		{
+			name:            "exporter cannot export a snapshot - export failed error",
+			probes:          3,
+			exporter:        exporterMock("", otherErr),
+			importerFor:     func(int) *mocks.Querier { return importerMock(nil) },
+			wantErr:         true,
+			wantExportError: true,
+		},
+		{
+			name:            "malformed snapshot id - export failed error",
+			probes:          3,
+			exporter:        exporterMock("not a snapshot id", nil),
+			importerFor:     func(int) *mocks.Querier { return importerMock(nil) },
+			wantErr:         true,
+			wantExportError: true,
+		},
+		{
+			name:            "dial failure - export failed error",
+			probes:          4,
+			dial:            func(context.Context) (postgres.Querier, error) { return nil, errors.New("connection refused") },
+			wantErr:         true,
+			wantExportError: true,
+		},
+		{
+			name:    "no probes requested - error",
+			probes:  0,
+			dial:    func(context.Context) (postgres.Querier, error) { return exporterMock("0000004D-00001943-1", nil), nil },
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dial := tt.dial
+			if dial == nil {
+				dial = dialer(tt.exporter, tt.importerFor)
+			}
+			missing, err := postgres.ProbeExportedSnapshotVisibility(context.Background(), dial, tt.probes)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.wantExportError, errors.Is(err, postgres.ErrSnapshotExportFailed))
+			require.Equal(t, tt.wantMissing, missing)
+		})
+	}
+}
+
+func TestIsExportedSnapshotMissing(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		// SET TRANSACTION SNAPSHOT only produces 42704 for a missing snapshot, so
+		// the mapped ErrRelationDoesNotExist is matched regardless of message
+		// locale.
+		{name: "mapped ErrRelationDoesNotExist (localized message)", err: &postgres.ErrRelationDoesNotExist{Details: `no existe el snapshot «00000D0E-0000001A-1»`}, want: true},
+		{name: "mapped ErrRelationDoesNotExist (english)", err: snapshotMissingErr, want: true},
+		{name: "raw english text not mapped", err: errors.New(`ERROR: snapshot "00000D0E-0000001A-1" does not exist (SQLSTATE 42704)`), want: true},
+		{name: "different error type", err: &postgres.ErrPermissionDenied{Details: "permission denied"}, want: false},
+		{name: "unrelated error", err: errors.New("connection refused"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, postgres.IsExportedSnapshotMissing(tt.err))
+		})
+	}
+}

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator.go
@@ -506,6 +506,11 @@ func (sg *SnapshotGenerator) exportSnapshot(ctx context.Context, tx pglib.Tx) (s
 func (sg *SnapshotGenerator) setTransactionSnapshot(ctx context.Context, tx pglib.Tx, snapshotID string) error {
 	_, err := tx.Exec(ctx, fmt.Sprintf("SET TRANSACTION SNAPSHOT '%s'", snapshotID))
 	if err != nil {
+		// An instance-local exported snapshot that a worker connection can't see
+		// means the source spans multiple instances; join the actionable cause.
+		if pglib.IsExportedSnapshotMissing(err) {
+			return fmt.Errorf("setting transaction snapshot: %w: %w", err, pglib.ErrLoadBalancedSource)
+		}
 		return fmt.Errorf("setting transaction snapshot: %w", err)
 	}
 	return nil

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_loadbalanced_test.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_loadbalanced_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	pgmocks "github.com/xataio/pgstream/internal/postgres/mocks"
+)
+
+func TestSnapshotGenerator_setTransactionSnapshot(t *testing.T) {
+	t.Parallel()
+
+	snapshotMissing := &pglib.ErrRelationDoesNotExist{Details: `snapshot "abc" does not exist`}
+	otherErr := errors.New("some other failure")
+
+	tests := []struct {
+		name          string
+		execErr       error
+		wantErr       bool
+		wantExplained bool // load-balanced hint joined onto the error
+	}{
+		{name: "success", execErr: nil, wantErr: false},
+		{name: "snapshot missing enriched", execErr: snapshotMissing, wantErr: true, wantExplained: true},
+		{name: "other error not enriched", execErr: otherErr, wantErr: true, wantExplained: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sg := &SnapshotGenerator{}
+			tx := &pgmocks.Tx{
+				ExecFn: func(context.Context, uint, string, ...any) (pglib.CommandTag, error) {
+					return pglib.CommandTag{}, tt.execErr
+				},
+			}
+			err := sg.setTransactionSnapshot(context.Background(), tx, "abc")
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.execErr)
+			require.Equal(t, tt.wantExplained, errors.Is(err, pglib.ErrLoadBalancedSource))
+		})
+	}
+}

--- a/pkg/stream/preflight/builder.go
+++ b/pkg/stream/preflight/builder.go
@@ -61,6 +61,16 @@ func BuildConnectivityChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 	checks := []Check{}
 	if url := cfg.SourcePostgresURL(); url != "" {
 		checks = append(checks, &ConnectivityCheck{Label: "source", URL: url})
+		if demand, ok := cfg.SnapshotConnectionDemand(); ok {
+			checks = append(checks, &SourceSnapshotInstanceCheck{
+				Probe: func(ctx context.Context, probes int) (int, error) {
+					return postgres.ProbeExportedSnapshotVisibility(ctx, func(ctx context.Context) (postgres.Querier, error) {
+						return postgres.NewConn(ctx, url)
+					}, probes)
+				},
+				Probes: snapshotInstanceProbes(demand),
+			})
+		}
 	}
 	if cfg.Processor.Postgres != nil {
 		if url := cfg.Processor.Postgres.BatchWriter.URL; url != "" {
@@ -68,6 +78,18 @@ func BuildConnectivityChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 		}
 	}
 	return checks, nil
+}
+
+func snapshotInstanceProbes(demand uint) int {
+	const minProbes, maxProbes = 4, 16
+	switch {
+	case demand < minProbes:
+		return minProbes
+	case demand > maxProbes:
+		return maxProbes
+	default:
+		return int(demand)
+	}
 }
 
 // BuildReplicationChecks returns the replication-preflight checks applicable

--- a/pkg/stream/preflight/snapshot_source_instance.go
+++ b/pkg/stream/preflight/snapshot_source_instance.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+)
+
+// SourceSnapshotInstanceCheck verifies the source URL resolves to a single
+// Postgres instance, which parallel data snapshotting requires. The data
+// snapshot generator exports a transaction snapshot on one connection and
+// imports it (SET TRANSACTION SNAPSHOT) on other connections; an exported
+// snapshot is instance-local, so a load-balanced source (an Aurora/RDS reader
+// endpoint, or a pooler spanning instances) that routes some connections to a
+// different instance fails with `snapshot "…" does not exist`.
+//
+// The probe is probabilistic (see ProbeExportedSnapshotVisibility): a run that
+// happens to route every probe connection to the exporting instance reports no
+// finding.
+type SourceSnapshotInstanceCheck struct {
+	Probe  func(ctx context.Context, probes int) (missing int, err error)
+	Probes int
+}
+
+func (c *SourceSnapshotInstanceCheck) Name() string {
+	return "source_snapshot_single_instance"
+}
+
+func (c *SourceSnapshotInstanceCheck) Run(ctx context.Context) ([]Finding, error) {
+	missing, err := c.Probe(ctx, c.Probes)
+	if missing > 0 {
+		return []Finding{{Message: fmt.Sprintf(
+			"source appears to be load-balanced across multiple Postgres instances: an exported "+
+				"snapshot was not visible on %d of %d probe connections. Parallel data snapshotting "+
+				"requires every connection to reach the same instance — point the source at a "+
+				"single-instance / writer endpoint (Aurora/RDS reader endpoints and instance-spanning "+
+				"poolers are unsupported for snapshots).",
+			missing, c.Probes,
+		)}}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("running snapshot instance probe: %w", err)
+	}
+	return nil, nil
+}

--- a/pkg/stream/preflight/snapshot_source_instance_test.go
+++ b/pkg/stream/preflight/snapshot_source_instance_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceSnapshotInstanceCheck_Run(t *testing.T) {
+	t.Parallel()
+
+	probeErr := errors.New("boom")
+
+	tests := []struct {
+		name         string
+		probe        func(ctx context.Context, probes int) (int, error)
+		wantFindings int
+		wantErr      bool
+	}{
+		{
+			name:         "single instance - no finding",
+			probe:        func(context.Context, int) (int, error) { return 0, nil },
+			wantFindings: 0,
+		},
+		{
+			name:         "load balanced - one finding",
+			probe:        func(context.Context, int) (int, error) { return 3, nil },
+			wantFindings: 1,
+		},
+		{
+			name:    "probe could not run - check error",
+			probe:   func(context.Context, int) (int, error) { return 0, probeErr },
+			wantErr: true,
+		},
+		{
+			name:         "detection wins over a probe error",
+			probe:        func(context.Context, int) (int, error) { return 2, probeErr },
+			wantFindings: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			check := &SourceSnapshotInstanceCheck{Probe: tt.probe, Probes: 8}
+			findings, err := check.Run(context.Background())
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Len(t, findings, tt.wantFindings)
+		})
+	}
+}


### PR DESCRIPTION
#### Description

The parallel data snapshot exports a transaction snapshot on one connection and imports it (`SET TRANSACTION SNAPSHOT`) on the worker connections. An exported snapshot is instance-local, so against a load-balanced source (an Aurora/RDS reader endpoint or an instance-spanning pooler) workers that land on a different instance fail with `snapshot "..." does not exist`.

This PR adds a preflight connectivity check that can warn the user about this. The check is non deterministic, because the probes might land on the same instance.

In the future when we implement https://github.com/xataio/pgstream/issues/601, we can ask the user to switch to PK based snapshots.

##### Related Issue(s)

- Related to #1012

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
