### PR TITLE
Drop redundant restoreToWAL flag

### DIFF
--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -51,11 +51,10 @@ type SnapshotGenerator struct {
 	// views.
 	refreshMaterializedViews bool
 	// indexConstraintSessionSettings are applied through PGOPTIONS only to
-	// index and constraint restore sessions.
+	// index and constraint restore sessions. They are cleared when restoring to
+	// WAL (see WithRestoreToWAL), since that path converts the dump into WAL
+	// events instead of running a psql/pg_restore session.
 	indexConstraintSessionSettings []string
-	// restoreToWAL indicates that pgRestoreFn converts the dump into WAL events
-	// instead of executing it in a PostgreSQL session.
-	restoreToWAL bool
 }
 
 type snapshotProgressTracker interface {
@@ -213,7 +212,7 @@ func WithProgressTracking(ctx context.Context) Option {
 func WithRestoreToWAL(processor processor.Processor) Option {
 	return func(sg *SnapshotGenerator) {
 		sg.pgRestoreFn = newPGSnapshotWALRestore(processor, sg.sourceQuerier).restoreToWAL
-		sg.restoreToWAL = true
+		sg.indexConstraintSessionSettings = nil
 	}
 }
 
@@ -404,9 +403,7 @@ func isConflictTargetConstraint(block string) bool {
 func (s *SnapshotGenerator) restoreIndicesAndConstraints(ctx context.Context, dump []byte, ss *snapshot.Snapshot) error {
 	s.logger.Info("restoring schema indices and constraints", loglib.Fields{"schemaTables": ss.SchemaTables})
 	opts := s.optionGenerator.pgrestoreOptions()
-	if !s.restoreToWAL {
-		opts.SessionSettings = s.indexConstraintSessionSettings
-	}
+	opts.SessionSettings = s.indexConstraintSessionSettings
 	if s.snapshotTracker != nil {
 		return s.restoreIndicesWithTracking(ctx, opts, dump)
 	}


### PR DESCRIPTION
#### Description

WAL restore mode was tracked twice:
* by swapping pgRestoreFn to the WAL restore function in WithRestoreToWAL
* by a separate restoreToWAL bool in restoreIndicesAndConstraints

The restore function is now the single source of truth for whether session settings apply.

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Drop redundant flag in snapshot phase
-
-

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
