### PR TITLE
Honor context cancellation in pg_restore && soften timeout examples

### DIFF
--- a/config_template.yaml
+++ b/config_template.yaml
@@ -46,9 +46,10 @@ source:
           index_constraint_session_settings: # optional PostgreSQL name=value session settings applied only while restoring indexes and constraints. Each entry must be a whitespace-free name=value pair. Unset or empty preserves existing behavior
             - maintenance_work_mem=4GB
             - max_parallel_maintenance_workers=4
-            - synchronous_commit=off
-            - statement_timeout=0
-            - lock_timeout=0
+            # statement_timeout=0 and lock_timeout=0 disable the server-side limits that would otherwise bound a stuck restore; the restore then relies on client-side cancellation. Omit them to keep those safety limits.
+            # - statement_timeout=0
+            # - lock_timeout=0
+            # - synchronous_commit=off # faster restore, but a target crash right after the restore can lose the final index/constraint commits
           dump_file: pg_dump.sql # name of the file where the contents of the schema pg_dump command and output will be written for debugging purposes.
     replication: # when mode is replication or snapshot_and_replication
       replication_slot: "pgstream_mydatabase_slot"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,9 +47,10 @@ source:
           index_constraint_session_settings: # optional PostgreSQL name=value session settings applied only while restoring indexes and constraints. Each entry must be a whitespace-free name=value pair. Unset or empty preserves existing behavior
             - maintenance_work_mem=4GB
             - max_parallel_maintenance_workers=4
-            - synchronous_commit=off
-            - statement_timeout=0
-            - lock_timeout=0
+            # statement_timeout=0 and lock_timeout=0 disable the server-side limits that would otherwise bound a stuck restore; the restore then relies on client-side cancellation. Omit them to keep those safety limits.
+            # - statement_timeout=0
+            # - lock_timeout=0
+            # - synchronous_commit=off # faster restore, but a target crash right after the restore can lose the final index/constraint commits
           dump_file: pg_dump.sql # name of the file where the contents of the schema pg_dump command and output will be written for debugging purposes.
       disable_progress_tracking: false # whether to disable progress tracking for the snapshot. Defaults to false
     replication: # when mode is replication or snapshot_and_replication

--- a/internal/postgres/pg_restore.go
+++ b/internal/postgres/pg_restore.go
@@ -91,9 +91,9 @@ func RunPGRestore(ctx context.Context, opts PGRestoreOptions, dump []byte) (stri
 	}
 	switch opts.Format {
 	case "c":
-		cmd = exec.Command(pgRestoreCmd, opts.toArgs()...) //nolint:gosec
+		cmd = exec.CommandContext(ctx, pgRestoreCmd, opts.toArgs()...) //nolint:gosec
 	default:
-		cmd = exec.Command(psqlCmd, opts.toPSQLArgs()...) //nolint:gosec
+		cmd = exec.CommandContext(ctx, psqlCmd, opts.toPSQLArgs()...) //nolint:gosec
 	}
 	if len(opts.SessionSettings) > 0 {
 		cmd.Env = append(cmd.Environ(), "PGOPTIONS="+opts.toPGOptions(os.Getenv("PGOPTIONS")))


### PR DESCRIPTION
#### Description

RunPGRestore received a context but built the command with `exec.Command`, so a cancelled context could not stop a stuck `psql`/`pg_restore` process. This is especially dangerous with the documented session settings statement_timeout=0 and lock_timeout=0, which disable the server-side limits that would otherwise bound a restore would hang.

Use `exec.CommandContext` so cancellation terminates the subprocess, and annotate the config examples to note that statement_timeout=0/lock_timeout=0 remove server-side guardrails (the restore then relies on client-side cancellation) and synchronous_commit=off trades durability for speed.

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Change the documentation and example settings for restore phase settings
- Honor context cancel
-

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
