### PR TITLE
[Preflight] Option to run only source side checks

### DIFF
--- a/cli-definition.json
+++ b/cli-definition.json
@@ -43,6 +43,11 @@
           "default": "false"
         },
         {
+          "name": "source",
+          "description": "Run only checks that query the source database (ignores the configured target)",
+          "default": "false"
+        },
+        {
           "name": "target-url",
           "description": "Target URL to run checks against",
           "default": ""

--- a/cmd/check_cmd.go
+++ b/cmd/check_cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/xataio/pgstream/cmd/config"
+	"github.com/xataio/pgstream/pkg/stream"
 	"github.com/xataio/pgstream/pkg/stream/preflight"
 )
 
@@ -29,6 +30,14 @@ func selectedCategories(cmd *cobra.Command) []preflight.Category {
 	return selected
 }
 
+// applySourceScope restricts the run to checks that only query the source when
+// srcOnly is set.
+func applySourceScope(cfg *stream.Config, srcOnly bool) {
+	if srcOnly && cfg.Processor.Postgres != nil {
+		cfg.Processor.Postgres.BatchWriter.URL = ""
+	}
+}
+
 var checkCmd = &cobra.Command{
 	Use:     "check",
 	Short:   "Runs pre-migration checks to catch blocking issues before snapshot/run",
@@ -44,6 +53,9 @@ var checkCmd = &cobra.Command{
 			if err := streamConfig.IsValid(); err != nil {
 				return fmt.Errorf("validating stream config: %w", err)
 			}
+
+			srcOnly, _ := cmd.Flags().GetBool("source")
+			applySourceScope(streamConfig, srcOnly)
 
 			checks, cleanup := preflight.BuildChecks(streamConfig, selectedCategories(cmd))
 			defer func() {

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -122,6 +122,7 @@ func Prepare() *cobra.Command {
 	checkCmd.Flags().String("postgres-url", "", "Source postgres URL to run checks against")
 	checkCmd.Flags().String("target-url", "", "Target URL to run checks against")
 	checkCmd.Flags().Bool("json", false, "Output the check report in JSON format")
+	checkCmd.Flags().Bool("source", false, "Run only checks that query the source database (ignores the configured target)")
 	checkCmd.Flags().Bool("connectivity", false, "Run connectivity checks against the configured source and target")
 	checkCmd.Flags().Bool("replication", false, "Run replication checks against the source (requires replication slot configured)")
 	checkCmd.Flags().Bool("access", false, "Run access and privilege checks against the source")


### PR DESCRIPTION
#### Description

This PR adds a new flag named `--source` that only runs checks against the source database.

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- New flag added to check command
-
-

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
