### PR TITLE
Fix two false-result preflight checks (wal2json, replica_identity)

### DIFF
--- a/pkg/stream/config.go
+++ b/pkg/stream/config.go
@@ -274,8 +274,9 @@ func (c *Config) RequiredTables() []string {
 }
 
 // TableSelection captures the include/exclude filter pgstream applies to the
-// WAL stream. Empty include means "every user table is in scope"; exclude
-// names tables to skip. Include and exclude are mutually exclusive at the
+// WAL stream including plugin fitlters. Empty include means "every user table
+// is in scope"; exclude names tables to skip.
+// Include and exclude are mutually exclusive at the
 // source-config level (validated by the filter package).
 type TableSelection struct {
 	include       []string
@@ -283,6 +284,7 @@ type TableSelection struct {
 	includeMap    pglib.SchemaTableMap
 	excludeMap    pglib.SchemaTableMap
 	schemaOnlyMap pglib.SchemaTableMap
+	plugin        *TableSelection
 }
 
 func NewTableSelection(include, exclude []string) (TableSelection, error) {
@@ -303,14 +305,28 @@ func NewTableSelection(include, exclude []string) (TableSelection, error) {
 	return s, nil
 }
 
+// IsUnfiltered reports whether the selection places no table out of scope.
+// Note the weakened invariant since plugin scoping was added: a plugin-only
+// selection is NOT unfiltered even though Include() and Exclude() are both
+// empty. Consumers must not assume "!IsUnfiltered() ⇒ include or exclude is
+// non-empty" — check IsTableInScope per table instead.
 func (s TableSelection) IsUnfiltered() bool {
+	if s.plugin != nil && !s.plugin.IsUnfiltered() {
+		return false
+	}
 	return len(s.include) == 0 && len(s.exclude) == 0
 }
 
 // IsTableInScope mirrors the precedence the wal filter applies to data (DML)
 // events: exclude beats everything, an exact include entry beats a schema-only
-// match, and a schema-only match beats a wildcard include.
+// match, and a schema-only match beats a wildcard include. When wal2json
+// plugin-level scoping is configured it is applied first as an AND gate — a
+// table the plugin never emits WAL for is never in scope, regardless of the
+// modifiers.filter lists.
 func (s TableSelection) IsTableInScope(schema, table string) bool {
+	if s.plugin != nil && !s.plugin.IsTableInScope(schema, table) {
+		return false
+	}
 	if s.excludeMap.ContainsSchemaTable(schema, table) {
 		return false
 	}
@@ -345,19 +361,50 @@ func (c *Config) SnapshotTableSelection() TableSelection {
 }
 
 func (c *Config) ReplicationTableSelection() TableSelection {
-	if c.Processor.Filter == nil {
-		return TableSelection{}
+	var sel TableSelection
+	if c.Processor.Filter != nil {
+		// IsValid is the gate that catches malformed entries; if a caller skipped
+		// it the constructor error is swallowed and the lazy fallback in
+		// IsTableInScope produces a defined (over-permissive) answer.
+		// Schema-only tables have their data events filtered out, so they don't
+		// need a replica identity; IsTableInScope applies the same per-table
+		// precedence as the wal filter.
+		filter := c.Processor.Filter
+		sel, _ = NewTableSelection(filter.IncludeTables, filter.ExcludeTables)
+		sel.schemaOnlyMap, _ = pglib.NewSchemaTableMap(filter.SchemaOnlyTables)
 	}
-	// IsValid is the gate that catches malformed entries; if a caller skipped
-	// it the constructor error is swallowed and the lazy fallback in
-	// IsTableInScope produces a defined (over-permissive) answer.
-	// Schema-only tables have their data events filtered out, so they don't
-	// need a replica identity; IsTableInScope applies the same per-table
-	// precedence as the wal filter.
-	filter := c.Processor.Filter
-	sel, _ := NewTableSelection(filter.IncludeTables, filter.ExcludeTables)
-	sel.schemaOnlyMap, _ = pglib.NewSchemaTableMap(filter.SchemaOnlyTables)
+	// pgstream has two independent table-scoping mechanisms: the processor
+	// filter above, and the wal2json plugin
+	sel.plugin = c.pluginTableSelection()
 	return sel
+}
+
+func (c *Config) pluginTableSelection() *TableSelection {
+	if c.Listener.Postgres == nil {
+		return nil
+	}
+	args := c.Listener.Postgres.Replication.PluginArguments
+	addTables := splitPluginTables(args.AddTables)
+	filterTables := splitPluginTables(args.FilterTables)
+	if len(addTables) == 0 && len(filterTables) == 0 {
+		return nil
+	}
+	plugin, _ := NewTableSelection(addTables, filterTables)
+	return &plugin
+}
+
+func splitPluginTables(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func (c *Config) AccessTableSelection() TableSelection {

--- a/pkg/stream/config_test.go
+++ b/pkg/stream/config_test.go
@@ -10,22 +10,26 @@ import (
 	"github.com/xataio/pgstream/pkg/wal/listener/snapshot/adapter"
 	snapshotbuilder "github.com/xataio/pgstream/pkg/wal/listener/snapshot/builder"
 	"github.com/xataio/pgstream/pkg/wal/processor/filter"
+	pgreplication "github.com/xataio/pgstream/pkg/wal/replication/postgres"
 )
 
 func TestConfig_ReplicationTableSelection(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		cfg            *Config
-		wantInclude    []string
-		wantExclude    []string
-		wantInScope    [][2]string
-		wantOutOfScope [][2]string
+		name              string
+		cfg               *Config
+		wantInclude       []string
+		wantExclude       []string
+		wantUnfiltered    bool
+		wantNotUnfiltered bool
+		wantInScope       [][2]string
+		wantOutOfScope    [][2]string
 	}{
 		{
-			name: "no filter configured returns unfiltered selection",
-			cfg:  &Config{},
+			name:           "no filter configured returns unfiltered selection",
+			cfg:            &Config{},
+			wantUnfiltered: true,
 		},
 		{
 			name: "empty filter returns unfiltered selection",
@@ -93,6 +97,72 @@ func TestConfig_ReplicationTableSelection(t *testing.T) {
 			wantInScope:    [][2]string{{"public", "users"}},
 			wantOutOfScope: [][2]string{{"public", "audit_log"}},
 		},
+		{
+			name: "listener present but no plugin scoping stays unfiltered",
+			cfg: &Config{
+				Listener: ListenerConfig{Postgres: &PostgresListenerConfig{}},
+			},
+			wantUnfiltered: true,
+			wantInScope:    [][2]string{{"public", "anything"}},
+		},
+		{
+			name: "plugin add_tables scopes replication (filter unset)",
+			cfg: &Config{
+				Listener: ListenerConfig{Postgres: &PostgresListenerConfig{
+					Replication: pgreplication.Config{
+						PluginArguments: pgreplication.PluginArguments{AddTables: "someschema.*"},
+					},
+				}},
+			},
+			// plugin-only scoping doesn't populate the filter include/exclude
+			// lists, but the selection is no longer unfiltered.
+			wantNotUnfiltered: true,
+			wantInScope:       [][2]string{{"someschema", "foo"}},
+			wantOutOfScope:    [][2]string{{"public", "typeorm_metadata"}, {"public", "users"}},
+		},
+		{
+			name: "plugin filter_tables scopes replication (filter unset)",
+			cfg: &Config{
+				Listener: ListenerConfig{Postgres: &PostgresListenerConfig{
+					Replication: pgreplication.Config{
+						PluginArguments: pgreplication.PluginArguments{FilterTables: "public.*"},
+					},
+				}},
+			},
+			wantNotUnfiltered: true,
+			wantInScope:       [][2]string{{"labs", "onboarding"}},
+			wantOutOfScope:    [][2]string{{"public", "typeorm_metadata"}},
+		},
+		{
+			name: "plugin filter_tables with multiple comma-separated schemas",
+			cfg: &Config{
+				Listener: ListenerConfig{Postgres: &PostgresListenerConfig{
+					Replication: pgreplication.Config{
+						PluginArguments: pgreplication.PluginArguments{FilterTables: "pipelines.* , private.*"},
+					},
+				}},
+			},
+			wantInScope:    [][2]string{{"public", "users"}},
+			wantOutOfScope: [][2]string{{"pipelines", "runs"}, {"private", "secrets"}},
+		},
+		{
+			name: "plugin add_tables AND modifiers.filter both apply",
+			cfg: &Config{
+				Listener: ListenerConfig{Postgres: &PostgresListenerConfig{
+					Replication: pgreplication.Config{
+						PluginArguments: pgreplication.PluginArguments{AddTables: "app.*"},
+					},
+				}},
+				Processor: ProcessorConfig{
+					Filter: &filter.Config{ExcludeTables: []string{"app.secrets"}},
+				},
+			},
+			wantExclude: []string{"app.secrets"},
+			wantInScope: [][2]string{{"app", "users"}},
+			// app.secrets excluded by the filter; anything outside app.* excluded
+			// by the plugin add_tables whitelist.
+			wantOutOfScope: [][2]string{{"app", "secrets"}, {"other", "t"}},
+		},
 	}
 
 	for _, tc := range tests {
@@ -101,6 +171,12 @@ func TestConfig_ReplicationTableSelection(t *testing.T) {
 			got := tc.cfg.ReplicationTableSelection()
 			require.Equal(t, tc.wantInclude, got.Include())
 			require.Equal(t, tc.wantExclude, got.Exclude())
+			if tc.wantUnfiltered {
+				require.True(t, got.IsUnfiltered(), "expected selection to be unfiltered")
+			}
+			if tc.wantNotUnfiltered {
+				require.False(t, got.IsUnfiltered(), "expected selection to be filtered (plugin scoping present)")
+			}
 			for _, st := range tc.wantInScope {
 				require.True(t, got.IsTableInScope(st[0], st[1]), "expected %s.%s to be in scope", st[0], st[1])
 			}

--- a/pkg/stream/preflight/replica_identity_test.go
+++ b/pkg/stream/preflight/replica_identity_test.go
@@ -3,9 +3,15 @@
 package preflight
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/postgres/mocks"
+	"github.com/xataio/pgstream/pkg/stream"
+	pgreplication "github.com/xataio/pgstream/pkg/wal/replication/postgres"
 )
 
 func TestAssessReplicaIdentity(t *testing.T) {
@@ -65,6 +71,100 @@ func TestAssessReplicaIdentity(t *testing.T) {
 			}
 			for _, sub := range tc.wantSubs {
 				require.Contains(t, got, sub)
+			}
+		})
+	}
+}
+
+// replicaIdentitySource returns an AcquireFunc whose Querier serves the given
+// replica-identity rows from Query, matching the 5-column scan order of
+// replicaIdentityQuery.
+func replicaIdentitySource(t *testing.T, rows []replicaIdentityRow) postgres.AcquireFunc {
+	t.Helper()
+	return func(context.Context) (postgres.Querier, error) {
+		return &mocks.Querier{
+			QueryFn: func(context.Context, uint, string, ...any) (postgres.Rows, error) {
+				return &mocks.Rows{
+					NextFn: func(i uint) bool { return int(i) <= len(rows) },
+					ScanFn: func(i uint, dest ...any) error {
+						require.Len(t, dest, 5)
+						row := rows[i-1]
+						for idx, val := range []string{row.Schema, row.Name, row.Relreplident} {
+							p, ok := dest[idx].(*string)
+							require.True(t, ok)
+							*p = val
+						}
+						for idx, val := range []bool{row.HasPK, row.ReplidentOK} {
+							p, ok := dest[3+idx].(*bool)
+							require.True(t, ok)
+							*p = val
+						}
+						return nil
+					},
+					ErrFn: func() error { return nil },
+				}, nil
+			},
+		}, nil
+	}
+}
+
+// TestReplicaIdentityCheck_Run_PluginScoping proves the check honours wal2json
+// plugin-level table scoping: a public table the plugin filters out is not
+// flagged, while the same table is flagged when nothing scopes it out.
+func TestReplicaIdentityCheck_Run_PluginScoping(t *testing.T) {
+	t.Parallel()
+
+	// public.typeorm_metadata has REPLICA IDENTITY default and no PRIMARY KEY —
+	// a finding unless it's out of replication scope. labs.staff_member_onboarding
+	// is in scope and has the same problem, so it must always be flagged.
+	rows := []replicaIdentityRow{
+		{Schema: "public", Name: "typeorm_metadata", Relreplident: "d", HasPK: false},
+		{Schema: "labs", Name: "staff_member_onboarding", Relreplident: "d", HasPK: false},
+	}
+
+	tests := []struct {
+		name           string
+		cfg            *stream.Config
+		wantFlagged    []string // "schema.name" substrings expected in findings
+		wantNotFlagged []string
+	}{
+		{
+			name: "filter_tables public.* skips public tables, still flags in-scope table",
+			cfg: &stream.Config{Listener: stream.ListenerConfig{Postgres: &stream.PostgresListenerConfig{
+				Replication: pgreplication.Config{
+					PluginArguments: pgreplication.PluginArguments{FilterTables: "public.*"},
+				},
+			}}},
+			wantFlagged:    []string{`"labs"."staff_member_onboarding"`},
+			wantNotFlagged: []string{"typeorm_metadata"},
+		},
+		{
+			name:           "nothing scopes it out - public table is flagged (true positive)",
+			cfg:            &stream.Config{},
+			wantFlagged:    []string{`"public"."typeorm_metadata"`, `"labs"."staff_member_onboarding"`},
+			wantNotFlagged: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			check := &ReplicaIdentityCheck{
+				Source:    replicaIdentitySource(t, rows),
+				Selection: tc.cfg.ReplicationTableSelection(),
+			}
+			findings, err := check.Run(context.Background())
+			require.NoError(t, err)
+
+			joined := ""
+			for _, f := range findings {
+				joined += f.Message + "\n"
+			}
+			for _, sub := range tc.wantFlagged {
+				require.Contains(t, joined, sub)
+			}
+			for _, sub := range tc.wantNotFlagged {
+				require.NotContains(t, joined, sub)
 			}
 		})
 	}

--- a/pkg/stream/preflight/replication.go
+++ b/pkg/stream/preflight/replication.go
@@ -4,7 +4,14 @@ package preflight
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/xataio/pgstream/internal/postgres"
 )
@@ -37,11 +44,26 @@ func (c *WALLevelCheck) Run(ctx context.Context) ([]Finding, error) {
 
 // WAL2JSONCheck verifies that the wal2json output plugin is installed and
 // loadable on the source. pgstream decodes WAL through wal2json.
+//
+// wal2json is a logical-decoding output plugin, not a SQL extension, so it
+// never appears in pg_available_extensions and there is no catalog that lists
+// installed output plugins. The only way to detect it with pgstream's
+// privileges (a non-superuser REPLICATION role) is to probe actual behaviour:
+// create a temporary logical replication slot with the plugin and inspect the
+// outcome. The temporary slot is released automatically at session end, and is
+// dropped explicitly on success so it never counts against slot headroom.
 type WAL2JSONCheck struct {
 	Source postgres.AcquireFunc
 }
 
 func (c *WAL2JSONCheck) Name() string { return "wal2json" }
+
+// wal2jsonProbeTimeout bounds the slot-creation probe. Creating a logical slot
+// builds a consistent snapshot, which waits for in-flight write transactions on
+// the source to finish; on a busy primary with a long-running transaction that
+// wait is unbounded. Cap it so `pgstream check` reports an actionable error
+// instead of hanging the whole preflight run.
+const wal2jsonProbeTimeout = 30 * time.Second
 
 func (c *WAL2JSONCheck) Run(ctx context.Context) ([]Finding, error) {
 	conn, err := c.Source(ctx)
@@ -49,16 +71,99 @@ func (c *WAL2JSONCheck) Run(ctx context.Context) ([]Finding, error) {
 		return nil, fmt.Errorf("connecting to source: %w", err)
 	}
 
-	var present int
-	if err := conn.QueryRow(ctx, []any{&present}, "SELECT count(*)::int FROM pg_available_extensions WHERE name = 'wal2json'"); err != nil {
-		return nil, fmt.Errorf("querying pg_available_extensions: %w", err)
+	slotName, err := wal2jsonProbeSlotName()
+	if err != nil {
+		return nil, fmt.Errorf("generating probe slot name: %w", err)
 	}
-	if present == 0 {
+
+	probeCtx, cancel := context.WithTimeout(ctx, wal2jsonProbeTimeout)
+	defer cancel()
+
+	var ok bool
+	probeErr := conn.QueryRow(probeCtx, []any{&ok},
+		"SELECT lsn IS NOT NULL FROM pg_create_logical_replication_slot($1, 'wal2json', true)",
+		slotName)
+	if probeErr == nil {
+		// Plugin is installed and loadable. Drop the temporary slot explicitly
+		// so it doesn't count against replication_slot_headroom; the temporary
+		// flag auto-drops it at session end regardless. Best-effort: the slot is
+		// temporary, so a failed drop is released when the session closes.
+		_, _ = conn.Exec(ctx, "SELECT pg_drop_replication_slot($1)", slotName)
+		return nil, nil
+	}
+
+	switch {
+	case isWAL2JSONMissing(probeErr):
 		return []Finding{{
-			Message: "wal2json output plugin not available on source; install the wal2json package and verify it appears in pg_available_extensions",
+			Message: "wal2json output plugin not available on source; install the wal2json package so the wal2json shared library is loadable as a logical-decoding output plugin",
 		}}, nil
+	case isProbePreconditionUnmet(probeErr):
+		// The probe needs wal_level=logical, the REPLICATION role attribute and a
+		// free slot to run at all, and must run against a primary. Those are owned
+		// by the dedicated wal_level / replication_role_attr / slot-headroom checks
+		// (or aren't a plugin problem), so returning inconclusive here avoids a
+		// false "wal2json missing" finding.
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("probing wal2json plugin: %w", probeErr)
 	}
-	return nil, nil
+}
+
+// wal2jsonProbeSlotName returns a valid, collision-resistant temporary slot
+// name for the wal2json probe. The random suffix guards against concurrent
+// `pgstream check` runs racing on the same slot name.
+func wal2jsonProbeSlotName() (string, error) {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return "pgstream_wal2json_probe_" + hex.EncodeToString(b[:]), nil
+}
+
+// isWAL2JSONMissing reports whether the probe error indicates the wal2json
+// shared library could not be found/loaded — the one error that confidently
+// means the plugin is not installed. Postgres raises SQLSTATE 58P01
+// (undefined_file) for a missing output-plugin library; the message check is a
+// locale-fragile fallback for the rare case the code is not surfaced.
+func isWAL2JSONMissing(err error) bool {
+	if pgErrCodeIs(err, "58P01") {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "could not access file") ||
+		(strings.Contains(msg, "could not load library") && strings.Contains(msg, "wal2json"))
+}
+
+// isProbePreconditionUnmet reports whether the probe failed for a reason owned
+// by a sibling check or otherwise not indicative of a missing plugin, so the
+// wal2json check should stay silent (inconclusive). Classification keys on
+// stable SQLSTATE codes (via internal/postgres.MapError's typed errors and the
+// raw pgconn code) rather than server-localised message text.
+func isProbePreconditionUnmet(err error) bool {
+	// 55000 object_not_in_prerequisite_state: wal_level<logical (owned by the
+	// wal_level check) or the source is in recovery (a standby).
+	var precondition *postgres.ErrPreconditionFailed
+	if errors.As(err, &precondition) {
+		return true
+	}
+	// 42501 insufficient_privilege: role lacks REPLICATION (owned by the
+	// replication_role_attr check).
+	var permission *postgres.ErrPermissionDenied
+	if errors.As(err, &permission) {
+		return true
+	}
+	// 53400 configuration_limit_exceeded: no free replication slots (owned by
+	// the replication_slot_headroom check).
+	return pgErrCodeIs(err, "53400")
+}
+
+// pgErrCodeIs reports whether err carries a raw Postgres error with the given
+// SQLSTATE code. Only errors MapError leaves untyped (e.g. 58P01, 53400) still
+// expose the pgconn.PgError; the mapped classes are matched via their typed
+// errors instead.
+func pgErrCodeIs(err error, code string) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == code
 }
 
 // ReplicationSlotHeadroomCheck reports whether the source has at least one

--- a/pkg/stream/preflight/replication_integration_test.go
+++ b/pkg/stream/preflight/replication_integration_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/testcontainers"
+	"github.com/xataio/pgstream/pkg/stream"
+	pgreplication "github.com/xataio/pgstream/pkg/wal/replication/postgres"
+)
+
+// TestWAL2JSONCheck_Run_Integration exercises the temporary-slot probe against
+// real Postgres servers: one that ships wal2json (debezium image) and one that
+// does not (pgvector image with logical WAL enabled).
+func TestWAL2JSONCheck_Run_Integration(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx := context.Background()
+
+	t.Run("wal2json present - probe succeeds and leaves no replication slot", func(t *testing.T) {
+		var pgURL string
+		// debezium/postgres:14-alpine ships wal2json.so and defaults to
+		// wal_level=logical (the 17-alpine variant does not bundle wal2json).
+		cleanup, err := testcontainers.SetupPostgresContainer(ctx, &pgURL, testcontainers.Postgres14)
+		require.NoError(t, err)
+		defer cleanup()
+
+		check := &WAL2JSONCheck{Source: func(ctx context.Context) (pglib.Querier, error) {
+			return pglib.NewConn(ctx, pgURL)
+		}}
+
+		findings, err := check.Run(ctx)
+		require.NoError(t, err)
+		require.Empty(t, findings, "wal2json is present, no finding expected")
+
+		// The probe must not leak a replication slot (it would otherwise count
+		// against the replication_slot_headroom check that runs after it).
+		adminConn, err := pglib.NewConn(ctx, pgURL)
+		require.NoError(t, err)
+		defer adminConn.Close(ctx)
+		var slots int
+		require.NoError(t, adminConn.QueryRow(ctx, []any{&slots},
+			"SELECT count(*)::int FROM pg_replication_slots"))
+		require.Equal(t, 0, slots, "temporary probe slot must be dropped")
+	})
+
+	t.Run("wal2json absent with wal_level=logical - reports missing finding", func(t *testing.T) {
+		var pgURL string
+		// pgvector image does not ship wal2json; the config enables logical WAL
+		// so the probe reaches the plugin-load stage and fails on the missing lib.
+		cleanup, err := testcontainers.SetupPostgresContainer(ctx, &pgURL, testcontainers.PgvectorPostgres17, "testdata/wal_level_logical.conf")
+		require.NoError(t, err)
+		defer cleanup()
+
+		check := &WAL2JSONCheck{Source: func(ctx context.Context) (pglib.Querier, error) {
+			return pglib.NewConn(ctx, pgURL)
+		}}
+
+		findings, err := check.Run(ctx)
+		require.NoError(t, err)
+		require.Len(t, findings, 1)
+		require.Contains(t, findings[0].Message, "wal2json output plugin not available")
+	})
+}
+
+// TestReplicaIdentityCheck_Run_Integration_PluginScoping proves end-to-end that
+// a table filtered out by the wal2json plugin options is not flagged for a
+// missing replica identity, while an in-scope table with the same problem is.
+func TestReplicaIdentityCheck_Run_Integration_PluginScoping(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx := context.Background()
+
+	var pgURL string
+	cleanup, err := testcontainers.SetupPostgresContainer(ctx, &pgURL, testcontainers.Postgres17)
+	require.NoError(t, err)
+	defer cleanup()
+
+	adminConn, err := pglib.NewConn(ctx, pgURL)
+	require.NoError(t, err)
+	defer adminConn.Close(ctx)
+
+	// public.typeorm_metadata: no PK, default replica identity -> a finding
+	// unless scoped out. labs.staff_member_onboarding: same problem, in scope.
+	_, err = adminConn.Exec(ctx, `CREATE TABLE public.typeorm_metadata (id int, name text)`)
+	require.NoError(t, err)
+	_, err = adminConn.Exec(ctx, `CREATE SCHEMA labs`)
+	require.NoError(t, err)
+	_, err = adminConn.Exec(ctx, `CREATE TABLE labs.staff_member_onboarding (id int, name text)`)
+	require.NoError(t, err)
+
+	source := func(ctx context.Context) (pglib.Querier, error) {
+		return pglib.NewConn(ctx, pgURL)
+	}
+
+	t.Run("filter_tables public.* scopes out public tables", func(t *testing.T) {
+		cfg := &stream.Config{Listener: stream.ListenerConfig{Postgres: &stream.PostgresListenerConfig{
+			Replication: pgreplication.Config{
+				PluginArguments: pgreplication.PluginArguments{FilterTables: "public.*"},
+			},
+		}}}
+		check := &ReplicaIdentityCheck{Source: source, Selection: cfg.ReplicationTableSelection()}
+
+		findings, err := check.Run(ctx)
+		require.NoError(t, err)
+
+		joined := ""
+		for _, f := range findings {
+			joined += f.Message + "\n"
+		}
+		require.Contains(t, joined, `"labs"."staff_member_onboarding"`)
+		require.NotContains(t, joined, "typeorm_metadata", "public.* is filtered out at the plugin level")
+	})
+
+	t.Run("no scoping flags the public table too", func(t *testing.T) {
+		check := &ReplicaIdentityCheck{Source: source, Selection: (&stream.Config{}).ReplicationTableSelection()}
+
+		findings, err := check.Run(ctx)
+		require.NoError(t, err)
+
+		joined := ""
+		for _, f := range findings {
+			joined += f.Message + "\n"
+		}
+		require.Contains(t, joined, `"public"."typeorm_metadata"`)
+		require.Contains(t, joined, `"labs"."staff_member_onboarding"`)
+	})
+}

--- a/pkg/stream/preflight/replication_test.go
+++ b/pkg/stream/preflight/replication_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+
+	"github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/postgres/mocks"
+)
+
+func TestWAL2JSONCheck_Run(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// probeErr is returned by pg_create_logical_replication_slot.
+		probeErr error
+
+		wantHit     bool
+		wantErr     bool
+		wantSubs    []string
+		wantDropped bool
+	}{
+		{
+			name:        "plugin present - slot created, then dropped, no finding",
+			probeErr:    nil,
+			wantDropped: true,
+		},
+		{
+			// 58P01 undefined_file is left untyped by MapError, so it arrives as a
+			// raw pgconn.PgError and is matched by SQLSTATE.
+			name:     "plugin missing - 58P01 undefined_file",
+			probeErr: &pgconn.PgError{Code: "58P01", Message: `could not access file "wal2json": No such file or directory`},
+			wantHit:  true,
+			wantSubs: []string{"wal2json output plugin not available", "install the wal2json package"},
+		},
+		{
+			// message-only fallback when the code isn't surfaced.
+			name:     "plugin missing - message fallback (no SQLSTATE)",
+			probeErr: errors.New(`ERROR: could not access file "wal2json": No such file or directory`),
+			wantHit:  true,
+			wantSubs: []string{"wal2json output plugin not available"},
+		},
+		{
+			// 55000 is mapped to ErrPreconditionFailed by MapError.
+			name:     "wal_level not logical - inconclusive, not a wal2json finding",
+			probeErr: &postgres.ErrPreconditionFailed{Details: `logical decoding requires "wal_level" >= "logical"`},
+			// wal_level check owns this: neither a finding nor an error here.
+		},
+		{
+			// 42501 is mapped to ErrPermissionDenied by MapError.
+			name:     "role lacks REPLICATION - inconclusive, not a wal2json finding",
+			probeErr: &postgres.ErrPermissionDenied{Details: "must be superuser or replication role to use replication slots"},
+			// replication_role_attr check owns this.
+		},
+		{
+			// 53400 configuration_limit_exceeded is left untyped by MapError.
+			name:     "no free slots - inconclusive, headroom check owns it",
+			probeErr: &pgconn.PgError{Code: "53400", Message: "all replication slots are in use"},
+		},
+		{
+			name:     "unexpected error - check could not run",
+			probeErr: errors.New("connection reset by peer"),
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var dropped bool
+			conn := &mocks.Querier{
+				QueryRowFn: func(_ context.Context, dest []any, query string, args ...any) error {
+					require.Contains(t, query, "pg_create_logical_replication_slot")
+					require.Contains(t, query, "wal2json")
+					// slot name must be a valid, temporary probe slot name
+					require.Len(t, args, 1)
+					slotName, ok := args[0].(string)
+					require.True(t, ok)
+					require.True(t, strings.HasPrefix(slotName, "pgstream_wal2json_probe_"))
+					require.NoError(t, postgres.IsValidReplicationSlotName(slotName))
+					if tc.probeErr != nil {
+						return tc.probeErr
+					}
+					b, ok := dest[0].(*bool)
+					require.True(t, ok)
+					*b = true
+					return nil
+				},
+				ExecFn: func(_ context.Context, _ uint, query string, args ...any) (postgres.CommandTag, error) {
+					require.Contains(t, query, "pg_drop_replication_slot")
+					require.Len(t, args, 1)
+					dropped = true
+					return postgres.CommandTag{}, nil
+				},
+			}
+
+			check := &WAL2JSONCheck{Source: func(context.Context) (postgres.Querier, error) {
+				return conn, nil
+			}}
+
+			findings, err := check.Run(context.Background())
+
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Empty(t, findings)
+				return
+			}
+			require.NoError(t, err)
+			if tc.wantHit {
+				require.Len(t, findings, 1)
+				for _, sub := range tc.wantSubs {
+					require.Contains(t, findings[0].Message, sub)
+				}
+			} else {
+				require.Empty(t, findings)
+			}
+			require.Equal(t, tc.wantDropped, dropped)
+		})
+	}
+}
+
+func TestWAL2JSONProbeSlotName(t *testing.T) {
+	t.Parallel()
+
+	name1, err := wal2jsonProbeSlotName()
+	require.NoError(t, err)
+	name2, err := wal2jsonProbeSlotName()
+	require.NoError(t, err)
+
+	require.NotEqual(t, name1, name2, "probe slot names must be collision-resistant")
+	require.True(t, strings.HasPrefix(name1, "pgstream_wal2json_probe_"))
+	require.NoError(t, postgres.IsValidReplicationSlotName(name1))
+	require.NoError(t, postgres.IsValidReplicationSlotName(name2))
+}

--- a/pkg/stream/preflight/testdata/wal_level_logical.conf
+++ b/pkg/stream/preflight/testdata/wal_level_logical.conf
@@ -1,0 +1,9 @@
+# Minimal logical-replication config WITHOUT preloading wal2json, used to test
+# the wal2json preflight probe against a server where the plugin is absent.
+# CONNECTION
+listen_addresses = '*'
+
+# REPLICATION
+wal_level = logical
+max_wal_senders = 4
+max_replication_slots = 4


### PR DESCRIPTION
#### Description

The `wal2json` check queried the wrong catalog. wal2json is a logical-decoding output plugin, not a SQL extension, so it never appears in pg_available_extensions. Tthe check reported it missing on essentially every correctly-configured source. This PR replaces the catalog query with a temporary logical replication slot probe (`pg_create_logical_replication_slot(..., 'wal2json', true)`) is the only detection that works with pgstream's non-superuser REPLICATION privileges. The temporary slot is dropped explicitly so it never counts against `replication_slot_headroom`.

Previously, `replica_identity` ignored `wal2json` plugin-level table scoping.  `ReplicationTableSelection()` read only the processor filter (`modifiers.filter`), so a source scoped via `plugin.add_tables`/`filter_tables` looked "unfiltered" and every table was walked, producing false missing- replica-identity findings for tables that never emit WAL.

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

-
-
-

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
