### PR TITLE
Copy user defined enum columns

### DIFF
--- a/pkg/stream/integration/snapshot_pg_integration_test.go
+++ b/pkg/stream/integration/snapshot_pg_integration_test.go
@@ -1295,3 +1295,126 @@ func Test_SnapshotToPostgres_LargeIntegerPrecision(t *testing.T) {
 		run("batch")
 	})
 }
+
+// Test_SnapshotToPostgres_EnumColumn verifies that a table with user-defined
+// enum columns snapshots correctly under bulk ingest. pgx's binary COPY has no
+// codec registered for database-specific enum OIDs, so the writer must fall
+// back to text-format COPY for such columns, where each value is written as its
+// postgres text representation and parsed by the target's type input function.
+// Before the fix, bulk ingest failed on enum columns with "unable to encode ...
+// into binary format ... cannot find encode plan", and disabling bulk ingest was
+// the only workaround.
+//
+// All four shapes the schema observer reports are covered: a scalar enum, an
+// array of enums, a domain over an enum, and a domain over an array of enums.
+func Test_SnapshotToPostgres_EnumColumn(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	var snapshotPGURL string
+	pgcleanup, err := testcontainers.SetupPostgresContainer(context.Background(), &snapshotPGURL, testcontainers.Postgres14, "config/postgresql.conf")
+	require.NoError(t, err)
+	defer pgcleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	run := func(suffix string, opts ...option) {
+		enumType := fmt.Sprintf("mood_%s", suffix)
+		testTable := fmt.Sprintf("enum_%s", suffix)
+
+		domainType := fmt.Sprintf("mood_domain_%s", suffix)
+		arrayDomainType := fmt.Sprintf("mood_arr_domain_%s", suffix)
+
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(`CREATE TYPE %s AS ENUM ('happy','sad','neutral')`, enumType))
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(`CREATE DOMAIN %s AS %s`, domainType, enumType))
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(`CREATE DOMAIN %s AS %s[]`, arrayDomainType, enumType))
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+			`CREATE TABLE %s(id int PRIMARY KEY, mood %s NOT NULL, note %s, moods %s[], dom %s, dom_arr %s)`,
+			testTable, enumType, enumType, enumType, domainType, arrayDomainType))
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+			`INSERT INTO %s(id, mood, note, moods, dom, dom_arr) VALUES
+				(1,'happy','neutral','{happy,sad}','happy','{neutral}'),
+				(2,'sad',NULL,NULL,NULL,NULL),
+				(3,'neutral','happy','{}','sad','{happy,sad}')`, testTable))
+
+		cfg := &stream.Config{
+			Listener:  testPostgresListenerCfgWithSnapshot(snapshotPGURL, targetPGURL, []string{testTable}),
+			Processor: testPostgresProcessorCfg(opts...),
+		}
+		initStream(t, ctx, snapshotPGURL)
+		runSnapshot(t, ctx, cfg)
+
+		targetConn, err := pglib.NewConn(ctx, targetPGURL)
+		require.NoError(t, err)
+		sourceConn, err := pglib.NewConn(ctx, snapshotPGURL)
+		require.NoError(t, err)
+
+		timer := time.NewTimer(20 * time.Second)
+		defer timer.Stop()
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		type row struct {
+			id     int
+			mood   string
+			note   *string
+			moods  *string
+			dom    *string
+			domArr *string
+		}
+		query := fmt.Sprintf(
+			"SELECT id, mood::text, note::text, moods::text, dom::text, dom_arr::text FROM %s ORDER BY id",
+			testTable)
+		fetch := func(conn pglib.Querier) ([]row, error) {
+			rows, err := conn.Query(ctx, query)
+			if err != nil {
+				return nil, err
+			}
+			defer rows.Close()
+			out := []row{}
+			for rows.Next() {
+				var r row
+				if err := rows.Scan(&r.id, &r.mood, &r.note, &r.moods, &r.dom, &r.domArr); err != nil {
+					return nil, err
+				}
+				out = append(out, r)
+			}
+			return out, rows.Err()
+		}
+
+		want, err := fetch(sourceConn)
+		require.NoError(t, err)
+		require.Len(t, want, 3)
+
+		validation := func() bool {
+			got, err := fetch(targetConn)
+			if err != nil || len(got) != len(want) {
+				return false
+			}
+			require.Equal(t, want, got)
+			return true
+		}
+
+		for {
+			select {
+			case <-timer.C:
+				cancel()
+				t.Error("timeout waiting for enum snapshot sync")
+				return
+			case <-ticker.C:
+				if validation() {
+					return
+				}
+			}
+		}
+	}
+
+	t.Run("bulk ingest", func(t *testing.T) {
+		run("bulk", withBulkIngestionEnabled())
+	})
+	t.Run("batch writer", func(t *testing.T) {
+		run("batch")
+	})
+}

--- a/pkg/wal/processor/postgres/helper_test.go
+++ b/pkg/wal/processor/postgres/helper_test.go
@@ -29,27 +29,17 @@ func (m *mockAdapter) close() error {
 }
 
 type mockSchemaObserver struct {
-	getGeneratedColumnNamesFn      func(ctx context.Context, schema, table string) (map[string]struct{}, error)
-	getAlwaysIdentityColumnNamesFn func(ctx context.Context, schema, table string) (map[string]struct{}, error)
-	getSequenceColumnsFn           func(ctx context.Context, schema, table string) (map[string]string, error)
-	isMaterializedViewFn           func(schema, table string) bool
-	updateFn                       func(ddlEvent *wal.DDLEvent)
-	closeFn                        func() error
+	getSchemaInfoFn      func(ctx context.Context, schema, table string) (schemaInfo, error)
+	isMaterializedViewFn func(schema, table string) bool
+	updateFn             func(ddlEvent *wal.DDLEvent)
+	closeFn              func() error
 }
 
-func (m *mockSchemaObserver) getGeneratedColumnNames(ctx context.Context, schema, table string) (map[string]struct{}, error) {
-	return m.getGeneratedColumnNamesFn(ctx, schema, table)
-}
-
-func (m *mockSchemaObserver) getAlwaysIdentityColumnNames(ctx context.Context, schema, table string) (map[string]struct{}, error) {
-	if m.getAlwaysIdentityColumnNamesFn == nil {
-		return nil, nil
+func (m *mockSchemaObserver) getSchemaInfo(ctx context.Context, schema, table string) (schemaInfo, error) {
+	if m.getSchemaInfoFn == nil {
+		return schemaInfo{}, nil
 	}
-	return m.getAlwaysIdentityColumnNamesFn(ctx, schema, table)
-}
-
-func (m *mockSchemaObserver) getSequenceColumns(ctx context.Context, schema, table string) (map[string]string, error) {
-	return m.getSequenceColumnsFn(ctx, schema, table)
+	return m.getSchemaInfoFn(ctx, schema, table)
 }
 
 func (m *mockSchemaObserver) isMaterializedView(ctx context.Context, schema, table string) bool {

--- a/pkg/wal/processor/postgres/postgres_schema_observer.go
+++ b/pkg/wal/processor/postgres/postgres_schema_observer.go
@@ -5,12 +5,20 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
+	"time"
 
 	pglib "github.com/xataio/pgstream/internal/postgres"
+	pglibretrier "github.com/xataio/pgstream/internal/postgres/retrier"
 	synclib "github.com/xataio/pgstream/internal/sync"
 	loglib "github.com/xataio/pgstream/pkg/log"
 	"github.com/xataio/pgstream/pkg/wal"
 )
+
+// schemaQueryTimeout bounds each catalog lookup. Without it a hung target
+// blocks the listener goroutine indefinitely, which stops standby status
+// updates and makes the source retain WAL until its disk fills.
+const schemaQueryTimeout = 30 * time.Second
 
 // pgSchemaObserver keeps track of schema metadata including generated column
 // names and materialized views for tables. It uses a cache to reduce the number
@@ -29,23 +37,48 @@ type pgSchemaObserver struct {
 	materializedViews *synclib.Map[string, map[string]struct{}]
 	// columnTableSequences is a map of schema.table to a map of sequence column names.
 	columnTableSequences *synclib.Map[string, map[string]string]
+	// enumTableColumns is a map of schema.table to a set of quoted column names
+	// whose type is a user-defined enum.
+	enumTableColumns *synclib.Map[string, map[string]struct{}]
+	// enumCacheEpoch is bumped by every enum invalidation. Unlike its sibling
+	// caches, enumTableColumns is repopulated by a live query rather than from
+	// the DDL event payload, so a lookup that started before an invalidation
+	// could otherwise write its stale answer back and outlive the eviction
+	// meant to drop it. Lookups record the epoch before querying and only
+	// cache the result if it has not moved.
+	enumCacheEpoch atomic.Uint64
 }
 
 // newPGSchemaObserver returns a postgres observer that tracks schemas,
 // including generated table columns and materialized views. It keeps a cache to
 // reduce the number of calls to postgres, and it updates the state whenever a
 // DDL event is received through the WAL.
-func newPGSchemaObserver(ctx context.Context, pgURL string, logger loglib.Logger) (*pgSchemaObserver, error) {
-	pgConn, err := pglib.NewConnPool(ctx, pgURL)
+func newPGSchemaObserver(ctx context.Context, cfg *Config, logger loglib.Logger) (*pgSchemaObserver, error) {
+	newConnPool := func(ctx context.Context) (pglib.Querier, error) {
+		return pglib.NewConnPool(ctx, cfg.URL)
+	}
+
+	// the observer sits on the hot path: an unretried transient failure here
+	// propagates all the way up and terminates the pipeline, so use the same
+	// retry policy as the writer unless retries are disabled.
+	var pgConn pglib.Querier
+	var err error
+	if cfg.RetryPolicy.DisableRetries {
+		pgConn, err = newConnPool(ctx)
+	} else {
+		pgConn, err = pglibretrier.NewQuerier(ctx, cfg.retryPolicy(), newConnPool, logger)
+	}
 	if err != nil {
 		return nil, err
 	}
+
 	return &pgSchemaObserver{
 		pgConn:                     pgConn,
 		generatedTableColumns:      synclib.NewMap[string, map[string]struct{}](),
 		alwaysIdentityTableColumns: synclib.NewMap[string, map[string]struct{}](),
 		materializedViews:          synclib.NewMap[string, map[string]struct{}](),
 		columnTableSequences:       synclib.NewMap[string, map[string]string](),
+		enumTableColumns:           synclib.NewMap[string, map[string]struct{}](),
 		logger:                     logger,
 	}, nil
 }
@@ -131,6 +164,64 @@ func (o *pgSchemaObserver) getSequenceColumns(ctx context.Context, schema, table
 	return seqColMap, nil
 }
 
+// getEnumColumnNames returns the set of quoted column names for the given
+// schema.table whose type is a user-defined enum. If not cached, it queries
+// postgres.
+func (o *pgSchemaObserver) getEnumColumnNames(ctx context.Context, schema, table string) (map[string]struct{}, error) {
+	key := pglib.QuoteQualifiedIdentifier(schema, table)
+
+	columns, found := o.enumTableColumns.Get(key)
+	if found {
+		return columns, nil
+	}
+
+	epoch := o.enumCacheEpoch.Load()
+	colNames, err := o.queryEnumColumnNames(ctx, schema, table)
+	if err != nil {
+		return nil, err
+	}
+
+	// drop the result instead of caching it if a DDL invalidated enum state
+	// while the query was in flight: it may predate the DDL, and caching it
+	// would survive the eviction that was meant to remove it.
+	if o.enumCacheEpoch.Load() == epoch {
+		o.enumTableColumns.Set(key, colNames)
+	}
+	return colNames, nil
+}
+
+// getSchemaInfo returns the schema metadata needed to build DML queries for the
+// given schema.table, served from the internal caches and falling back to
+// postgres for whatever is missing.
+func (o *pgSchemaObserver) getSchemaInfo(ctx context.Context, schema, table string) (schemaInfo, error) {
+	generatedColumns, err := o.getGeneratedColumnNames(ctx, schema, table)
+	if err != nil {
+		return schemaInfo{}, err
+	}
+
+	alwaysIdentityColumns, err := o.getAlwaysIdentityColumnNames(ctx, schema, table)
+	if err != nil {
+		return schemaInfo{}, err
+	}
+
+	sequenceColumns, err := o.getSequenceColumns(ctx, schema, table)
+	if err != nil {
+		return schemaInfo{}, err
+	}
+
+	enumColumns, err := o.getEnumColumnNames(ctx, schema, table)
+	if err != nil {
+		return schemaInfo{}, err
+	}
+
+	return schemaInfo{
+		generatedColumns:      generatedColumns,
+		alwaysIdentityColumns: alwaysIdentityColumns,
+		sequenceColumns:       sequenceColumns,
+		enumColumns:           enumColumns,
+	}, nil
+}
+
 func (o *pgSchemaObserver) update(ddlEvent *wal.DDLEvent) {
 	if ddlEvent == nil {
 		return
@@ -139,6 +230,7 @@ func (o *pgSchemaObserver) update(ddlEvent *wal.DDLEvent) {
 	tableObjects := append(ddlEvent.GetTableObjects(), ddlEvent.GetTableColumnObjects()...)
 	o.updateGeneratedColumnNames(tableObjects)
 	o.updateColumnSequences(tableObjects)
+	o.invalidateEnumColumns(tableObjects)
 	mvObjects := ddlEvent.GetMaterializedViewObjects()
 	if len(mvObjects) > 0 {
 		o.updateMaterializedViews(ddlEvent, mvObjects)
@@ -214,12 +306,35 @@ func (o *pgSchemaObserver) updateColumnSequences(tables []wal.DDLObject) {
 	}
 }
 
+// invalidateEnumColumns drops the cached enum-column set for the affected
+// tables so it is re-queried lazily. The DDL event does not carry the type
+// category needed to recompute enum membership in-memory, so a DDL that alters
+// a column type (to or from an enum) simply evicts the stale entry.
+//
+// The table name must come from GetTable() rather than GetName(): the input
+// mixes table objects ("schema.table") with table column objects
+// ("schema.table.column"), and for the latter GetName() returns the column
+// name, which would evict a key that never existed and leave the real entry
+// stale.
+func (o *pgSchemaObserver) invalidateEnumColumns(tables []wal.DDLObject) {
+	// bump before deleting so a lookup racing this invalidation cannot cache a
+	// pre-DDL answer after its key has been evicted.
+	o.enumCacheEpoch.Add(1)
+	for _, table := range tables {
+		key := pglib.QuoteQualifiedIdentifier(table.Schema, table.GetTable())
+		o.enumTableColumns.Delete(key)
+	}
+}
+
 const generatedTableColumnsQuery = `SELECT attname FROM pg_attribute
 		WHERE attnum > 0
 		AND attrelid = (SELECT c.oid FROM pg_class c JOIN pg_namespace n ON c.relnamespace=n.oid WHERE c.relname=$1 and n.nspname=$2)
 		AND attgenerated != ''`
 
 func (o *pgSchemaObserver) queryGeneratedColumnNames(ctx context.Context, schemaName, tableName string) (map[string]struct{}, error) {
+	ctx, cancel := context.WithTimeout(ctx, schemaQueryTimeout)
+	defer cancel()
+
 	columnNames := map[string]struct{}{}
 	// filter out generated columns (excluding identities) since they will
 	// be generated automatically, and they can't be overwriten.
@@ -250,6 +365,9 @@ const alwaysIdentityTableColumnsQuery = `SELECT attname FROM pg_attribute
 		AND attidentity = 'a'`
 
 func (o *pgSchemaObserver) queryAlwaysIdentityColumnNames(ctx context.Context, schemaName, tableName string) (map[string]struct{}, error) {
+	ctx, cancel := context.WithTimeout(ctx, schemaQueryTimeout)
+	defer cancel()
+
 	columnNames := map[string]struct{}{}
 	rows, err := o.pgConn.Query(ctx, alwaysIdentityTableColumnsQuery, tableName, schemaName)
 	if err != nil {
@@ -272,9 +390,64 @@ func (o *pgSchemaObserver) queryAlwaysIdentityColumnNames(ctx context.Context, s
 	return columnNames, nil
 }
 
+// enumTableColumnsQuery returns the columns of a table whose type resolves to a
+// user-defined enum. pgx registers no binary codec for such database-specific
+// OIDs, so these columns force text-format COPY, where the value is written as
+// the literal postgres text representation and parsed by the target's type
+// input function.
+//
+// Four shapes are covered: a scalar enum, an array of enums, a domain over an
+// enum, and a domain over an array of enums. A domain over a domain is not
+// resolved (it would need a recursive walk of typbasetype) and still takes the
+// binary path.
+const enumTableColumnsQuery = `SELECT a.attname
+	FROM pg_attribute a
+	JOIN pg_class c ON c.oid = a.attrelid
+	JOIN pg_namespace n ON n.oid = c.relnamespace
+	JOIN pg_type t ON t.oid = a.atttypid
+	LEFT JOIN pg_type elem ON elem.oid = t.typelem
+	LEFT JOIN pg_type base ON base.oid = t.typbasetype
+	LEFT JOIN pg_type baseelem ON baseelem.oid = base.typelem
+	WHERE n.nspname = $1 AND c.relname = $2
+	AND a.attnum > 0 AND NOT a.attisdropped
+	AND (
+		t.typtype = 'e'
+		OR (t.typtype = 'b' AND elem.typtype = 'e')
+		OR (t.typtype = 'd' AND (base.typtype = 'e' OR baseelem.typtype = 'e'))
+	)`
+
+func (o *pgSchemaObserver) queryEnumColumnNames(ctx context.Context, schemaName, tableName string) (map[string]struct{}, error) {
+	ctx, cancel := context.WithTimeout(ctx, schemaQueryTimeout)
+	defer cancel()
+
+	columnNames := map[string]struct{}{}
+	rows, err := o.pgConn.Query(ctx, enumTableColumnsQuery, schemaName, tableName)
+	if err != nil {
+		return nil, fmt.Errorf("getting table enum column names for table %s.%s: %w", schemaName, tableName, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var columnName string
+		if err := rows.Scan(&columnName); err != nil {
+			return nil, fmt.Errorf("scanning table enum column name: %w", err)
+		}
+		columnNames[pglib.QuoteIdentifier(columnName)] = struct{}{}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return columnNames, nil
+}
+
 const materializedViewsQuery = `SELECT matviewname FROM pg_matviews WHERE schemaname = $1`
 
 func (o *pgSchemaObserver) queryMaterializedViews(ctx context.Context, schemaName string) (map[string]struct{}, error) {
+	ctx, cancel := context.WithTimeout(ctx, schemaQueryTimeout)
+	defer cancel()
+
 	mvNames := make(map[string]struct{})
 	rows, err := o.pgConn.Query(ctx, materializedViewsQuery, schemaName)
 	if err != nil {
@@ -315,6 +488,9 @@ WHERE t.relkind = 'r'
     AND NOT a.attisdropped;`
 
 func (o *pgSchemaObserver) queryTableSequences(ctx context.Context, conn pglib.Querier, schemaName, tableName string) (map[string]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, schemaQueryTimeout)
+	defer cancel()
+
 	rows, err := conn.Query(ctx, sequenceColumnQuery, schemaName, tableName)
 	if err != nil {
 		return nil, fmt.Errorf("getting sequences for table %s.%s: %w", schemaName, tableName, err)

--- a/pkg/wal/processor/postgres/postgres_schema_observer_test.go
+++ b/pkg/wal/processor/postgres/postgres_schema_observer_test.go
@@ -153,6 +153,303 @@ func TestPGSchemaObserver_getGeneratedColumnNames(t *testing.T) {
 	}
 }
 
+func TestPGSchemaObserver_getEnumColumnNames(t *testing.T) {
+	t.Parallel()
+
+	quotedQualifiedTableName := `"test_schema"."test_table"`
+	moodColumn := `"mood"`
+
+	tests := []struct {
+		name         string
+		tableColumns map[string]map[string]struct{}
+		pgConn       pglib.Querier
+
+		wantColumns      map[string]struct{}
+		wantTableColumns map[string]map[string]struct{}
+		wantErr          error
+	}{
+		{
+			name:         "ok - queries and caches enum column",
+			tableColumns: map[string]map[string]struct{}{},
+			pgConn: &pgmocks.Querier{
+				QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
+					require.Equal(t, enumTableColumnsQuery, query)
+					require.Equal(t, []any{testSchema, testTable}, args)
+					return &pgmocks.Rows{
+						CloseFn: func() {},
+						NextFn:  func(i uint) bool { return i == 1 },
+						ScanFn: func(_ uint, dest ...any) error {
+							require.Len(t, dest, 1)
+							colName, ok := dest[0].(*string)
+							require.True(t, ok, fmt.Sprintf("column name, expected *string, got %T", dest[0]))
+							*colName = "mood"
+							return nil
+						},
+						ErrFn: func() error { return nil },
+					}, nil
+				},
+			},
+
+			wantColumns: map[string]struct{}{moodColumn: {}},
+			wantTableColumns: map[string]map[string]struct{}{
+				quotedQualifiedTableName: {moodColumn: {}},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ok - cache hit, no query",
+			tableColumns: map[string]map[string]struct{}{
+				quotedQualifiedTableName: {moodColumn: {}},
+			},
+			pgConn: &pgmocks.Querier{
+				QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
+					return nil, errors.New("unexpected call to QueryFn")
+				},
+			},
+
+			wantColumns: map[string]struct{}{moodColumn: {}},
+			wantTableColumns: map[string]map[string]struct{}{
+				quotedQualifiedTableName: {moodColumn: {}},
+			},
+			wantErr: nil,
+		},
+		{
+			name:         "error - querying enum columns",
+			tableColumns: map[string]map[string]struct{}{},
+			pgConn: &pgmocks.Querier{
+				QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
+					return nil, errTest
+				},
+			},
+
+			wantColumns:      nil,
+			wantTableColumns: map[string]map[string]struct{}{},
+			wantErr:          errTest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			o := &pgSchemaObserver{
+				pgConn:           tc.pgConn,
+				enumTableColumns: synclib.NewMapFromMap(tc.tableColumns),
+				logger:           loglib.NewNoopLogger(),
+			}
+
+			colNames, err := o.getEnumColumnNames(context.TODO(), "test_schema", "test_table")
+			require.ErrorIs(t, err, tc.wantErr)
+			require.Equal(t, tc.wantColumns, colNames)
+			require.Equal(t, tc.wantTableColumns, o.enumTableColumns.GetMap())
+		})
+	}
+}
+
+func TestPGSchemaObserver_invalidateEnumColumns(t *testing.T) {
+	t.Parallel()
+
+	quotedTable := `"test_schema"."test_table"`
+	quotedOtherTable := `"test_schema"."other_table"`
+
+	tests := []struct {
+		name    string
+		objects []wal.DDLObject
+
+		wantEvicted bool
+	}{
+		{
+			// "schema.table", as produced by GetTableObjects
+			name: "table object",
+			objects: []wal.DDLObject{
+				{Schema: "test_schema", Identity: "test_schema.test_table"},
+			},
+
+			wantEvicted: true,
+		},
+		{
+			// "schema.table.column", as produced by GetTableColumnObjects.
+			// GetName() would return "mood" here and evict a key that never
+			// existed, leaving the stale entry behind.
+			name: "table column object",
+			objects: []wal.DDLObject{
+				{Schema: "test_schema", Identity: "test_schema.test_table.mood"},
+			},
+
+			wantEvicted: true,
+		},
+		{
+			name: "unrelated table",
+			objects: []wal.DDLObject{
+				{Schema: "test_schema", Identity: "test_schema.unrelated_table"},
+			},
+
+			wantEvicted: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			o := &pgSchemaObserver{
+				enumTableColumns: synclib.NewMapFromMap(map[string]map[string]struct{}{
+					quotedTable:      {`"mood"`: {}},
+					quotedOtherTable: {`"status"`: {}},
+				}),
+				logger: loglib.NewNoopLogger(),
+			}
+
+			o.invalidateEnumColumns(tc.objects)
+
+			_, found := o.enumTableColumns.Get(quotedTable)
+			require.Equal(t, !tc.wantEvicted, found, "unexpected eviction state for the altered table")
+
+			_, found = o.enumTableColumns.Get(quotedOtherTable)
+			require.True(t, found, "expected the untouched table's entry to survive")
+		})
+	}
+}
+
+// TestPGSchemaObserver_getEnumColumnNames_invalidatedWhileQuerying pins the
+// epoch guard: a lookup whose query overlaps an invalidation must not write its
+// (possibly pre-DDL) answer back into the cache.
+func TestPGSchemaObserver_getEnumColumnNames_invalidatedWhileQuerying(t *testing.T) {
+	t.Parallel()
+
+	quotedTable := `"test_schema"."test_table"`
+
+	o := &pgSchemaObserver{
+		enumTableColumns: synclib.NewMap[string, map[string]struct{}](),
+		logger:           loglib.NewNoopLogger(),
+	}
+
+	o.pgConn = &pgmocks.Querier{
+		QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
+			// a DDL lands while this query is in flight
+			o.invalidateEnumColumns([]wal.DDLObject{
+				{Schema: testSchema, Identity: "test_schema.test_table"},
+			})
+			return &pgmocks.Rows{
+				CloseFn: func() {},
+				NextFn:  func(i uint) bool { return i == 1 },
+				ScanFn: func(_ uint, dest ...any) error {
+					colName, ok := dest[0].(*string)
+					require.True(t, ok)
+					*colName = "mood"
+					return nil
+				},
+				ErrFn: func() error { return nil },
+			}, nil
+		},
+	}
+
+	colNames, err := o.getEnumColumnNames(context.TODO(), testSchema, testTable)
+	require.NoError(t, err)
+	require.Equal(t, map[string]struct{}{`"mood"`: {}}, colNames, "the caller still gets the queried result")
+
+	_, found := o.enumTableColumns.Get(quotedTable)
+	require.False(t, found, "result raced by an invalidation must not be cached")
+}
+
+func TestPGSchemaObserver_getSchemaInfo(t *testing.T) {
+	t.Parallel()
+
+	// each lookup is served from a pre-populated cache, so the only query that
+	// runs is the one the test case makes fail.
+	newObserver := func(failing string) *pgSchemaObserver {
+		return &pgSchemaObserver{
+			logger: loglib.NewNoopLogger(),
+			pgConn: &pgmocks.Querier{
+				QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
+					return nil, errTest
+				},
+			},
+			generatedTableColumns: newSeededMap(failing != "generated", map[string]struct{}{`"gen"`: {}}),
+			alwaysIdentityTableColumns: newSeededMap(failing != "alwaysIdentity",
+				map[string]struct{}{`"id"`: {}}),
+			columnTableSequences: newSeededSequenceMap(failing != "sequences"),
+			enumTableColumns:     newSeededMap(failing != "enum", map[string]struct{}{`"mood"`: {}}),
+		}
+	}
+
+	tests := []struct {
+		name    string
+		failing string
+
+		wantInfo schemaInfo
+		wantErr  error
+	}{
+		{
+			name:    "ok",
+			failing: "",
+
+			wantInfo: schemaInfo{
+				generatedColumns:      map[string]struct{}{`"gen"`: {}},
+				alwaysIdentityColumns: map[string]struct{}{`"id"`: {}},
+				sequenceColumns:       map[string]string{`"id"`: `"test_schema"."seq"`},
+				enumColumns:           map[string]struct{}{`"mood"`: {}},
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "error - generated columns",
+			failing: "generated",
+
+			wantInfo: schemaInfo{},
+			wantErr:  errTest,
+		},
+		{
+			name:    "error - always identity columns",
+			failing: "alwaysIdentity",
+
+			wantInfo: schemaInfo{},
+			wantErr:  errTest,
+		},
+		{
+			name:    "error - sequence columns",
+			failing: "sequences",
+
+			wantInfo: schemaInfo{},
+			wantErr:  errTest,
+		},
+		{
+			name:    "error - enum columns",
+			failing: "enum",
+
+			wantInfo: schemaInfo{},
+			wantErr:  errTest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			info, err := newObserver(tc.failing).getSchemaInfo(context.TODO(), testSchema, testTable)
+			require.ErrorIs(t, err, tc.wantErr)
+			require.Equal(t, tc.wantInfo, info)
+		})
+	}
+}
+
+func newSeededMap(seed bool, value map[string]struct{}) *synclib.Map[string, map[string]struct{}] {
+	m := synclib.NewMap[string, map[string]struct{}]()
+	if seed {
+		m.Set(pglib.QuoteQualifiedIdentifier(testSchema, testTable), value)
+	}
+	return m
+}
+
+func newSeededSequenceMap(seed bool) *synclib.Map[string, map[string]string] {
+	m := synclib.NewMap[string, map[string]string]()
+	if seed {
+		m.Set(pglib.QuoteQualifiedIdentifier(testSchema, testTable),
+			map[string]string{`"id"`: `"test_schema"."seq"`})
+	}
+	return m
+}
+
 func TestPGSchemaObserver_updateGeneratedColumnNames(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/wal/processor/postgres/postgres_wal_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_adapter.go
@@ -16,9 +16,7 @@ type walAdapter interface {
 }
 
 type schemaObserver interface {
-	getGeneratedColumnNames(ctx context.Context, schema, table string) (map[string]struct{}, error)
-	getAlwaysIdentityColumnNames(ctx context.Context, schema, table string) (map[string]struct{}, error)
-	getSequenceColumns(ctx context.Context, schema, table string) (map[string]string, error)
+	getSchemaInfo(ctx context.Context, schema, table string) (schemaInfo, error)
 	isMaterializedView(ctx context.Context, schema, table string) bool
 	update(ddlEvent *wal.DDLEvent)
 	close() error
@@ -36,6 +34,11 @@ type schemaInfo struct {
 	generatedColumns      map[string]struct{}
 	alwaysIdentityColumns map[string]struct{}
 	sequenceColumns       map[string]string
+	// enumColumns is the set of quoted column names whose type is a
+	// user-defined enum. pgx has no binary codec registered for such
+	// database-specific OIDs, so batches touching these columns must use
+	// text-format COPY instead of binary COPY (see needsTextCopyForColumns).
+	enumColumns map[string]struct{}
 }
 
 type adapter struct {
@@ -50,19 +53,19 @@ type (
 	ddlEventAdapter func(*wal.Data) (*wal.DDLEvent, error)
 )
 
-func newAdapter(ctx context.Context, logger loglib.Logger, ignoreDDL bool, pgURL string, onConflictAction string, forCopy bool) (*adapter, error) {
-	schemaObserver, err := newPGSchemaObserver(ctx, pgURL, logger)
+func newAdapter(ctx context.Context, logger loglib.Logger, cfg *Config, forCopy bool) (*adapter, error) {
+	schemaObserver, err := newPGSchemaObserver(ctx, cfg, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	dmlAdapter, err := newDMLAdapter(onConflictAction, forCopy, logger)
+	dmlAdapter, err := newDMLAdapter(cfg.OnConflictAction, forCopy, logger)
 	if err != nil {
 		return nil, err
 	}
 
 	var ddl ddlQueryAdapter
-	if !ignoreDDL {
+	if !cfg.IgnoreDDL {
 		ddl = newDDLAdapter()
 	}
 
@@ -96,26 +99,12 @@ func (a *adapter) walEventToQueries(ctx context.Context, e *wal.Event) ([]*query
 		return a.ddlAdapter.walDataToQueries(ctx, e.Data)
 
 	default:
-		generatedColumns, err := a.schemaObserver.getGeneratedColumnNames(ctx, e.Data.Schema, e.Data.Table)
+		info, err := a.schemaObserver.getSchemaInfo(ctx, e.Data.Schema, e.Data.Table)
 		if err != nil {
 			return nil, err
 		}
 
-		alwaysIdentityColumns, err := a.schemaObserver.getAlwaysIdentityColumnNames(ctx, e.Data.Schema, e.Data.Table)
-		if err != nil {
-			return nil, err
-		}
-
-		columnSequences, err := a.schemaObserver.getSequenceColumns(ctx, e.Data.Schema, e.Data.Table)
-		if err != nil {
-			return nil, err
-		}
-
-		qs, err := a.dmlAdapter.walDataToQueries(e.Data, schemaInfo{
-			generatedColumns:      generatedColumns,
-			alwaysIdentityColumns: alwaysIdentityColumns,
-			sequenceColumns:       columnSequences,
-		})
+		qs, err := a.dmlAdapter.walDataToQueries(e.Data, info)
 		if err != nil {
 			return nil, err
 		}
@@ -144,28 +133,14 @@ func (a *adapter) walEventToMessage(ctx context.Context, e *wal.Event) (*walMess
 		return &walMessage{data: e.Data, isDDL: true}, nil
 
 	default:
-		generatedColumns, err := a.schemaObserver.getGeneratedColumnNames(ctx, e.Data.Schema, e.Data.Table)
-		if err != nil {
-			return nil, err
-		}
-
-		alwaysIdentityColumns, err := a.schemaObserver.getAlwaysIdentityColumnNames(ctx, e.Data.Schema, e.Data.Table)
-		if err != nil {
-			return nil, err
-		}
-
-		columnSequences, err := a.schemaObserver.getSequenceColumns(ctx, e.Data.Schema, e.Data.Table)
+		info, err := a.schemaObserver.getSchemaInfo(ctx, e.Data.Schema, e.Data.Table)
 		if err != nil {
 			return nil, err
 		}
 
 		return &walMessage{
-			data: e.Data,
-			schemaInfo: schemaInfo{
-				generatedColumns:      generatedColumns,
-				alwaysIdentityColumns: alwaysIdentityColumns,
-				sequenceColumns:       columnSequences,
-			},
+			data:       e.Data,
+			schemaInfo: info,
 		}, nil
 	}
 }

--- a/pkg/wal/processor/postgres/postgres_wal_adapter_test.go
+++ b/pkg/wal/processor/postgres/postgres_wal_adapter_test.go
@@ -42,6 +42,7 @@ func TestAdapter_walEventToMessage(t *testing.T) {
 
 	testGeneratedCols := map[string]struct{}{"gen": {}}
 	testSeqCols := map[string]string{"id": "users_id_seq"}
+	testEnumCols := map[string]struct{}{`"mood"`: {}}
 
 	tests := []struct {
 		name            string
@@ -121,11 +122,12 @@ func TestAdapter_walEventToMessage(t *testing.T) {
 			},
 			schemaObserver: &mockSchemaObserver{
 				isMaterializedViewFn: func(schema, table string) bool { return false },
-				getGeneratedColumnNamesFn: func(ctx context.Context, schema, table string) (map[string]struct{}, error) {
-					return testGeneratedCols, nil
-				},
-				getSequenceColumnsFn: func(ctx context.Context, schema, table string) (map[string]string, error) {
-					return testSeqCols, nil
+				getSchemaInfoFn: func(ctx context.Context, schema, table string) (schemaInfo, error) {
+					return schemaInfo{
+						generatedColumns: testGeneratedCols,
+						sequenceColumns:  testSeqCols,
+						enumColumns:      testEnumCols,
+					}, nil
 				},
 			},
 
@@ -134,6 +136,7 @@ func TestAdapter_walEventToMessage(t *testing.T) {
 				schemaInfo: schemaInfo{
 					generatedColumns: testGeneratedCols,
 					sequenceColumns:  testSeqCols,
+					enumColumns:      testEnumCols,
 				},
 			},
 			wantErr: nil,
@@ -152,7 +155,7 @@ func TestAdapter_walEventToMessage(t *testing.T) {
 			wantErr: errTest,
 		},
 		{
-			name: "error getting generated columns",
+			name: "error getting schema info",
 			event: &wal.Event{
 				Data: &wal.Data{
 					Schema: "public",
@@ -161,29 +164,8 @@ func TestAdapter_walEventToMessage(t *testing.T) {
 			},
 			schemaObserver: &mockSchemaObserver{
 				isMaterializedViewFn: func(schema, table string) bool { return false },
-				getGeneratedColumnNamesFn: func(ctx context.Context, schema, table string) (map[string]struct{}, error) {
-					return nil, errTest
-				},
-			},
-
-			wantMsg: nil,
-			wantErr: errTest,
-		},
-		{
-			name: "error getting sequence columns",
-			event: &wal.Event{
-				Data: &wal.Data{
-					Schema: "public",
-					Table:  "users",
-				},
-			},
-			schemaObserver: &mockSchemaObserver{
-				isMaterializedViewFn: func(schema, table string) bool { return false },
-				getGeneratedColumnNamesFn: func(ctx context.Context, schema, table string) (map[string]struct{}, error) {
-					return map[string]struct{}{}, nil
-				},
-				getSequenceColumnsFn: func(ctx context.Context, schema, table string) (map[string]string, error) {
-					return nil, errTest
+				getSchemaInfoFn: func(ctx context.Context, schema, table string) (schemaInfo, error) {
+					return schemaInfo{}, errTest
 				},
 			},
 
@@ -343,12 +325,6 @@ func TestAdapter_walEventToQueries(t *testing.T) {
 			},
 			schemaObserver: &mockSchemaObserver{
 				isMaterializedViewFn: func(schema, table string) bool { return false },
-				getGeneratedColumnNamesFn: func(ctx context.Context, schema, table string) (map[string]struct{}, error) {
-					return map[string]struct{}{}, nil
-				},
-				getSequenceColumnsFn: func(ctx context.Context, schema, table string) (map[string]string, error) {
-					return map[string]string{}, nil
-				},
 			},
 			dmlAdapter: testDMLAdapter,
 			ddlAdapter: testDDLAdapter,
@@ -373,7 +349,7 @@ func TestAdapter_walEventToQueries(t *testing.T) {
 			wantErr:     errTest,
 		},
 		{
-			name: "error getting generated columns",
+			name: "error getting schema info",
 			event: &wal.Event{
 				Data: &wal.Data{
 					Schema: "public",
@@ -382,37 +358,15 @@ func TestAdapter_walEventToQueries(t *testing.T) {
 			},
 			schemaObserver: &mockSchemaObserver{
 				isMaterializedViewFn: func(schema, table string) bool { return false },
-				getGeneratedColumnNamesFn: func(ctx context.Context, schema, table string) (map[string]struct{}, error) {
-					return nil, errTest
-				},
-				getSequenceColumnsFn: func(ctx context.Context, schema, table string) (map[string]string, error) {
-					return nil, errors.New("getSequenceColumns should not be called in this test")
+				getSchemaInfoFn: func(ctx context.Context, schema, table string) (schemaInfo, error) {
+					return schemaInfo{}, errTest
 				},
 			},
-			dmlAdapter: testDMLAdapter,
-			ddlAdapter: testDDLAdapter,
-
-			wantQueries: nil,
-			wantErr:     errTest,
-		},
-		{
-			name: "error getting sequence columns",
-			event: &wal.Event{
-				Data: &wal.Data{
-					Schema: "public",
-					Table:  "users",
+			dmlAdapter: &mockDMLAdapter{
+				walDataToQueriesFn: func(d *wal.Data, si schemaInfo) ([]*query, error) {
+					return nil, errors.New("dml adapter should not be called when schema info fails")
 				},
 			},
-			schemaObserver: &mockSchemaObserver{
-				isMaterializedViewFn: func(schema, table string) bool { return false },
-				getGeneratedColumnNamesFn: func(ctx context.Context, schema, table string) (map[string]struct{}, error) {
-					return map[string]struct{}{}, nil
-				},
-				getSequenceColumnsFn: func(ctx context.Context, schema, table string) (map[string]string, error) {
-					return nil, errTest
-				},
-			},
-			dmlAdapter: testDMLAdapter,
 			ddlAdapter: testDDLAdapter,
 
 			wantQueries: nil,
@@ -428,12 +382,6 @@ func TestAdapter_walEventToQueries(t *testing.T) {
 			},
 			schemaObserver: &mockSchemaObserver{
 				isMaterializedViewFn: func(schema, table string) bool { return false },
-				getGeneratedColumnNamesFn: func(ctx context.Context, schema, table string) (map[string]struct{}, error) {
-					return map[string]struct{}{}, nil
-				},
-				getSequenceColumnsFn: func(ctx context.Context, schema, table string) (map[string]string, error) {
-					return map[string]string{}, nil
-				},
 			},
 			dmlAdapter: &mockDMLAdapter{
 				walDataToQueriesFn: func(d *wal.Data, schemaInfo schemaInfo) ([]*query, error) {
@@ -463,4 +411,45 @@ func TestAdapter_walEventToQueries(t *testing.T) {
 			require.ElementsMatch(t, tc.wantQueries, queries)
 		})
 	}
+}
+
+// TestAdapter_threadsSchemaInfo pins that whatever the observer reports reaches
+// the dml adapter (and the wal message) unaltered. Without it the enum columns
+// could be dropped from the wiring and no test would fail.
+func TestAdapter_threadsSchemaInfo(t *testing.T) {
+	t.Parallel()
+
+	wantInfo := schemaInfo{
+		generatedColumns:      map[string]struct{}{`"gen"`: {}},
+		alwaysIdentityColumns: map[string]struct{}{`"id"`: {}},
+		sequenceColumns:       map[string]string{`"id"`: `"public"."users_id_seq"`},
+		enumColumns:           map[string]struct{}{`"mood"`: {}},
+	}
+
+	event := &wal.Event{Data: &wal.Data{Schema: "public", Table: "users", Action: "I"}}
+	observer := &mockSchemaObserver{
+		isMaterializedViewFn: func(schema, table string) bool { return false },
+		getSchemaInfoFn: func(ctx context.Context, schema, table string) (schemaInfo, error) {
+			return wantInfo, nil
+		},
+	}
+
+	var gotInfo schemaInfo
+	a := adapter{
+		schemaObserver: observer,
+		dmlAdapter: &mockDMLAdapter{
+			walDataToQueriesFn: func(d *wal.Data, si schemaInfo) ([]*query, error) {
+				gotInfo = si
+				return []*query{{sql: "INSERT"}}, nil
+			},
+		},
+	}
+
+	_, err := a.walEventToQueries(context.Background(), event)
+	require.NoError(t, err)
+	require.Equal(t, wantInfo, gotInfo)
+
+	msg, err := a.walEventToMessage(context.Background(), event)
+	require.NoError(t, err)
+	require.Equal(t, wantInfo, msg.schemaInfo)
 }

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
@@ -111,7 +111,7 @@ func (a *dmlAdapter) buildInsertQueries(d *wal.Data, schemaInfo schemaInfo) []*q
 			table:         d.Table,
 			schema:        d.Schema,
 			columnNames:   names,
-			needsTextCopy: needsTextCopy(types),
+			needsTextCopy: needsTextCopyForColumns(names, types, schemaInfo.enumColumns),
 			sql: fmt.Sprintf("INSERT INTO %s(%s) OVERRIDING SYSTEM VALUE VALUES(%s)%s",
 				quotedTableName(d.Schema, d.Table), strings.Join(names, ", "),
 				strings.Join(placeholders, ", "),
@@ -307,14 +307,15 @@ func (a *dmlAdapter) filterRowColumnsForAction(cols []wal.Column, schemaInfo sch
 		val = getTypedRangeValue(c.Type, val)
 
 		if a.forCopy {
-			val = a.updateValueForCopy(val, c.Type)
+			_, isEnum := schemaInfo.enumColumns[quoted]
+			val = a.updateValueForCopy(val, c.Type, isEnum)
 		}
 		rowValues = append(rowValues, val)
 	}
 	return rowColumns, rowTypes, rowValues
 }
 
-func (a *dmlAdapter) updateValueForCopy(value any, colType string) any {
+func (a *dmlAdapter) updateValueForCopy(value any, colType string, isEnum bool) any {
 	// For COPY, we might need to update the value for some data types,
 	// so that it will be able to be encoded into binary format correctly.
 	switch colType {
@@ -334,6 +335,13 @@ func (a *dmlAdapter) updateValueForCopy(value any, colType string) any {
 	// need to be converted to Go slices. The pgx COPY encoder expects proper Go types,
 	// not text representations.
 	if isArray(colType) {
+		// An array of a user-defined enum never reaches binary COPY: pgx has no
+		// codec for the element OID, so the batch is routed to text-format COPY,
+		// which writes the postgres array literal verbatim. Parsing it into a Go
+		// slice here would hand the text encoder a type it cannot render back.
+		if isEnum {
+			return value
+		}
 		// If the value is a string (PostgreSQL array literal like "{val1,val2}"),
 		// we need to parse it into a Go slice for binary COPY format
 		if strVal, ok := value.(string); ok {
@@ -485,6 +493,23 @@ var textOnlyCopyTypes = map[string]struct{}{
 func needsTextCopy(columnTypes []string) bool {
 	for _, t := range columnTypes {
 		if _, ok := textOnlyCopyTypes[t]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// needsTextCopyForColumns reports whether a batch covering the given columns
+// must fall back to text-format COPY instead of pgx's binary COPY. This is the
+// case when a column has a static text-only type (see textOnlyCopyTypes) or a
+// user-defined enum type, whose database-specific OID pgx has no binary codec
+// registered for. columnNames must be quoted to match the enumColumns set.
+func needsTextCopyForColumns(columnNames, columnTypes []string, enumColumns map[string]struct{}) bool {
+	if needsTextCopy(columnTypes) {
+		return true
+	}
+	for _, name := range columnNames {
+		if _, ok := enumColumns[name]; ok {
 			return true
 		}
 	}

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter_bulk.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter_bulk.go
@@ -273,7 +273,7 @@ func (a *dmlAdapter) buildBulkInsertQueries(events []*wal.Data, si schemaInfo) [
 			schema:        events[0].Schema,
 			table:         events[0].Table,
 			columnNames:   names,
-			needsTextCopy: needsTextCopy(types),
+			needsTextCopy: needsTextCopyForColumns(names, types, si.enumColumns),
 			sql:           sql,
 			args:          args,
 		})

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter_bulk_test.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter_bulk_test.go
@@ -295,6 +295,74 @@ func TestBuildBulkInsertQueries(t *testing.T) {
 	require.Equal(t, 2, strings.Count(q.sql, "($"))
 }
 
+// TestBuildBulkInsertQueries_NeedsTextCopy pins the COPY-format decision on the
+// bulk path: a batch touching a user-defined enum column must be routed to
+// text-format COPY, since pgx has no binary codec for the enum's OID.
+func TestBuildBulkInsertQueries_NeedsTextCopy(t *testing.T) {
+	t.Parallel()
+
+	newEvents := func(moodType string) []*wal.Data {
+		return []*wal.Data{
+			{
+				Action: "I",
+				Schema: "public",
+				Table:  "users",
+				Columns: []wal.Column{
+					{Name: "id", Type: "bigint", Value: float64(1)},
+					{Name: "mood", Type: moodType, Value: "happy"},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		events      []*wal.Data
+		enumColumns map[string]struct{}
+
+		wantNeedsTextCopy bool
+	}{
+		{
+			name:              "no enum columns",
+			events:            newEvents("text"),
+			enumColumns:       nil,
+			wantNeedsTextCopy: false,
+		},
+		{
+			name:              "enum column in the batch",
+			events:            newEvents("mood"),
+			enumColumns:       map[string]struct{}{`"mood"`: {}},
+			wantNeedsTextCopy: true,
+		},
+		{
+			name:              "enum column of another table only",
+			events:            newEvents("text"),
+			enumColumns:       map[string]struct{}{`"status"`: {}},
+			wantNeedsTextCopy: false,
+		},
+		{
+			name:              "static text-only type",
+			events:            newEvents("ltree"),
+			enumColumns:       nil,
+			wantNeedsTextCopy: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			queries := newTestDMLAdapter(t).buildBulkInsertQueries(tc.events, schemaInfo{
+				generatedColumns: map[string]struct{}{},
+				sequenceColumns:  map[string]string{},
+				enumColumns:      tc.enumColumns,
+			})
+			require.Len(t, queries, 1)
+			require.Equal(t, tc.wantNeedsTextCopy, queries[0].needsTextCopy)
+		})
+	}
+}
+
 func TestBuildBulkInsertQueries_WithSequence(t *testing.T) {
 	t.Parallel()
 
@@ -515,6 +583,15 @@ func deleteEvent(schema, table, colName, colType string, colValue any) *wal.Data
 func newTestDMLAdapter(t *testing.T) *dmlAdapter {
 	t.Helper()
 	a, err := newDMLAdapter("", false, loglib.NewNoopLogger())
+	require.NoError(t, err)
+	return a
+}
+
+// newTestDMLAdapterForCopy returns an adapter in bulk-COPY mode, where values
+// are rewritten for the COPY encoder.
+func newTestDMLAdapterForCopy(t *testing.T) *dmlAdapter {
+	t.Helper()
+	a, err := newDMLAdapter("", true, loglib.NewNoopLogger())
 	require.NoError(t, err)
 	return a
 }

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter_test.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter_test.go
@@ -914,6 +914,70 @@ func TestDMLAdapter_walDataToQueries(t *testing.T) {
 	}
 }
 
+func Test_needsTextCopyForColumns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		columnNames []string
+		columnTypes []string
+		enumColumns map[string]struct{}
+
+		want bool
+	}{
+		{
+			name:        "no text-only columns",
+			columnNames: []string{`"id"`, `"name"`},
+			columnTypes: []string{"integer", "text"},
+			enumColumns: nil,
+			want:        false,
+		},
+		{
+			name:        "static text-only type",
+			columnNames: []string{`"id"`, `"location"`},
+			columnTypes: []string{"integer", "ltree"},
+			enumColumns: nil,
+			want:        true,
+		},
+		{
+			name:        "enum column",
+			columnNames: []string{`"id"`, `"mood"`},
+			columnTypes: []string{"integer", "mood"},
+			enumColumns: map[string]struct{}{`"mood"`: {}},
+			want:        true,
+		},
+		{
+			name:        "enum type present but column filtered out",
+			columnNames: []string{`"id"`},
+			columnTypes: []string{"integer"},
+			enumColumns: map[string]struct{}{`"mood"`: {}},
+			want:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, needsTextCopyForColumns(tc.columnNames, tc.columnTypes, tc.enumColumns))
+		})
+	}
+}
+
+func Test_updateValueForCopy_enumArray(t *testing.T) {
+	t.Parallel()
+
+	a := newTestDMLAdapterForCopy(t)
+
+	// A non-enum array is parsed into a Go slice so pgx's binary COPY encoder
+	// can handle it.
+	require.Equal(t, []string{"a", "b"}, a.updateValueForCopy("{a,b}", "text[]", false))
+
+	// An array of a user-defined enum goes out through text-format COPY, which
+	// writes the postgres array literal verbatim — parsing it into a slice here
+	// would leave the text encoder with a value it cannot render.
+	require.Equal(t, "{happy,sad}", a.updateValueForCopy("{happy,sad}", "mood[]", true))
+}
+
 func Test_newDMLAdapter(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/wal/processor/postgres/postgres_writer.go
+++ b/pkg/wal/processor/postgres/postgres_writer.go
@@ -72,7 +72,7 @@ func newWriter(ctx context.Context, config *Config, writerType string, opts ...W
 
 	forCopy := writerType == bulkIngestWriter
 
-	w.adapter, err = newAdapter(ctx, w.logger, config.IgnoreDDL, config.URL, config.OnConflictAction, forCopy)
+	w.adapter, err = newAdapter(ctx, w.logger, config, forCopy)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Description

This PR adds support for using bulk_ingest_writer of PostgreSQL when the tables contain user defined enums, array of user defined enums. These enums are passed as text.

The PR also comes with a few small improvements:
* retries for schema queries
* smaller interface for getting schema info from PostgreSQL

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup


#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary

