### PR TITLE
Escape keys when using primary key partitioning

### DIFF
--- a/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
+++ b/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
@@ -138,14 +138,20 @@ func (w *BatchWriter) ProcessWALEvent(ctx context.Context, walEvent *wal.Event) 
 		if err != nil {
 			return fmt.Errorf("marshalling event: %w", err)
 		}
-		// check if walEventBytes is larger than 95% of the Kafka accepted max
+		// the key counts towards the record size the broker enforces, and it
+		// carries row data (primary key values), so it has to be measured with
+		// the value rather than after the check
+		key := w.getMessageKey(walEvent.Data)
+
+		// check if the record is larger than 95% of the Kafka accepted max
 		// message size to allow for some buffer for the rest of the message
-		if len(walDataBytes) > int(0.95*float64(w.maxBatchBytes)) {
+		if len(walDataBytes)+len(key) > int(0.95*float64(w.maxBatchBytes)) {
 			w.logger.Warn(errRecordTooLarge,
 				"kafka batch writer: wal event is larger than 95% of max bytes allowed",
 				loglib.Fields{
 					"max_bytes": w.maxBatchBytes,
-					"size":      len(walDataBytes),
+					"size":      len(walDataBytes) + len(key),
+					"key_size":  len(key),
 					"table":     walEvent.Data.Table,
 					"schema":    walEvent.Data.Schema,
 				})
@@ -153,7 +159,7 @@ func (w *BatchWriter) ProcessWALEvent(ctx context.Context, walEvent *wal.Event) 
 		}
 
 		kafkaMsg = kafka.Message{
-			Key:   w.getMessageKey(walEvent.Data),
+			Key:   key,
 			Value: walDataBytes,
 		}
 	}
@@ -237,9 +243,34 @@ func (w BatchWriter) getMessageKey(walData *wal.Data) []byte {
 	}
 }
 
+// The message key encodes a row identity as
+//
+//	<schema>.<table>:<value>,<value>,...
+//
+// Each component is escaped so that the delimiters can only appear as
+// structure, never as data. Without it the encoding is not injective and
+// distinct rows share a message key: ["a,b","c"] and ["a","b,c"] both render as
+// "a,b,c", and schema "a.b"+table "c" renders the same as schema "a"+table
+// "b.c" — colliding rows lose their separate partitioning identity, and on a
+// compacted topic one silently shadows the other.
+//
+// Identifiers and values use different escape sets on purpose. Only the
+// delimiters that actually terminate a component need escaping there, and every
+// byte escaped is a message key that moves to a different partition on upgrade,
+// so the sets are kept as small as correctness allows. Values may contain "."
+// and ":" freely, since the value list is everything after the first unescaped
+// ":"; identifiers may contain "," freely for the same reason.
+//
+// Both replacers are logically constant and safe for concurrent use.
+var (
+	keyValueEscaper      = strings.NewReplacer(`\`, `\\`, `,`, `\,`)
+	keyIdentifierEscaper = strings.NewReplacer(`\`, `\\`, `.`, `\.`, `:`, `\:`)
+)
+
 // primaryKeyMessageKey returns a key composed of the schema qualified table
 // name and the values of the event primary key columns, as identified by the
-// injector in the wal metadata. It returns nil if the primary key columns or
+// injector in the wal metadata. Identifiers and values are escaped so that
+// distinct rows never share a key. It returns nil if the primary key columns or
 // their values can't be found in the event.
 func primaryKeyMessageKey(walData *wal.Data) []byte {
 	colIDs := walData.Metadata.InternalColIDs
@@ -258,14 +289,18 @@ func primaryKeyMessageKey(walData *wal.Data) []byte {
 		if !found {
 			return nil
 		}
-		values = append(values, fmt.Sprintf("%v", col.Value))
+		values = append(values, keyValueEscaper.Replace(fmt.Sprintf("%v", col.Value)))
 	}
 
 	return fmt.Appendf(tableMessageKey(walData), ":%s", strings.Join(values, ","))
 }
 
+// tableMessageKey returns the schema qualified table name, with both
+// identifiers escaped so that the "." separating them is unambiguous —
+// postgres quoted identifiers may contain it.
 func tableMessageKey(walData *wal.Data) []byte {
-	return []byte(walData.Schema + "." + walData.Table)
+	return []byte(keyIdentifierEscaper.Replace(walData.Schema) + "." +
+		keyIdentifierEscaper.Replace(walData.Table))
 }
 
 func findColumn(cols []wal.Column, id string) (wal.Column, bool) {

--- a/pkg/wal/processor/kafka/wal_kafka_batch_writer_test.go
+++ b/pkg/wal/processor/kafka/wal_kafka_batch_writer_test.go
@@ -5,6 +5,7 @@ package kafka
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -128,6 +129,18 @@ func TestBatchKafkaWriter_ProcessWALEvent(t *testing.T) {
 			name:            "ok - wal event too large, message dropped",
 			walEvent:        testWalEvent,
 			eventSerialiser: func(any) ([]byte, error) { return []byte(strings.Repeat("a", 101)), nil },
+			batchSender:     batchmocks.NewBatchSender[kafka.Message](),
+
+			wantMsgs: []*batch.WALMessage[kafka.Message]{},
+			wantErr:  nil,
+		},
+		{
+			// the key carries primary key values and counts towards the record
+			// size the broker enforces: 90 bytes of value fits under the 95%
+			// threshold on its own, but not once the 11 byte key is added
+			name:            "ok - wal event too large once the key is counted, message dropped",
+			walEvent:        testWalEvent,
+			eventSerialiser: func(any) ([]byte, error) { return []byte(strings.Repeat("a", 90)), nil },
 			batchSender:     batchmocks.NewBatchSender[kafka.Message](),
 
 			wantMsgs: []*batch.WALMessage[kafka.Message]{},
@@ -275,6 +288,55 @@ func TestBatchKafkaWriter_getMessageKey(t *testing.T) {
 			wantKey: "test_schema.test_table:1,alice",
 		},
 		{
+			// ["a,b","c"] and ["a","b,c"] both joined to "a,b,c" before the
+			// delimiter was escaped, colliding on one message key
+			name:         "primary key - composite with a comma in the first value",
+			partitionKey: PartitionKeyPrimaryKey,
+			walData: func() *wal.Data {
+				d := testWalData()
+				d.Columns = []wal.Column{
+					{ID: "col-1", Name: "a", Type: "text", Value: "a,b"},
+					{ID: "col-2", Name: "b", Type: "text", Value: "c"},
+				}
+				d.Metadata.InternalColIDs = []string{"col-1", "col-2"}
+				return d
+			}(),
+
+			wantKey: `test_schema.test_table:a\,b,c`,
+		},
+		{
+			name:         "primary key - composite with a comma in the second value",
+			partitionKey: PartitionKeyPrimaryKey,
+			walData: func() *wal.Data {
+				d := testWalData()
+				d.Columns = []wal.Column{
+					{ID: "col-1", Name: "a", Type: "text", Value: "a"},
+					{ID: "col-2", Name: "b", Type: "text", Value: "b,c"},
+				}
+				d.Metadata.InternalColIDs = []string{"col-1", "col-2"}
+				return d
+			}(),
+
+			wantKey: `test_schema.test_table:a,b\,c`,
+		},
+		{
+			// the escape character itself must be escaped, or ["a\","b"] and
+			// ["a", ",b"] would collide in turn
+			name:         "primary key - composite with a backslash in the value",
+			partitionKey: PartitionKeyPrimaryKey,
+			walData: func() *wal.Data {
+				d := testWalData()
+				d.Columns = []wal.Column{
+					{ID: "col-1", Name: "a", Type: "text", Value: `a\`},
+					{ID: "col-2", Name: "b", Type: "text", Value: "b"},
+				}
+				d.Metadata.InternalColIDs = []string{"col-1", "col-2"}
+				return d
+			}(),
+
+			wantKey: `test_schema.test_table:a\\,b`,
+		},
+		{
 			name:         "primary key - delete event with identity columns",
 			partitionKey: PartitionKeyPrimaryKey,
 			walData: func() *wal.Data {
@@ -331,6 +393,96 @@ func TestBatchKafkaWriter_getMessageKey(t *testing.T) {
 			key := writer.getMessageKey(tc.walData)
 			require.Equal(t, tc.wantKey, string(key))
 		})
+	}
+}
+
+// TestPrimaryKeyMessageKey_DistinctTuples anchors the specific tuples that used
+// to collide. The exhaustive version of this property lives in
+// TestPrimaryKeyMessageKey_Injective; these are the regression cases worth
+// naming, each paired with the tuple it used to be confused with.
+func TestPrimaryKeyMessageKey_DistinctTuples(t *testing.T) {
+	t.Parallel()
+
+	tuples := [][]string{
+		// collided on the comma delimiter
+		{"a,b", "c"},
+		{"a", "b,c"},
+		{"a", "b", "c"},
+		{"a,b,c"},
+		// collide unless the escape character is itself escaped: `a\` escapes
+		// to `a\\`, which must not read back as the single value "a,b"
+		{`a\`, "b"},
+		{"a,b"},
+		{"a", `\b`},
+		{`\`, ""},
+		{`a\,b`, "c"},
+		{"a", `,b,c`},
+		// empty components, including the single empty value whose key sits one
+		// character from the no-primary-key fallback key
+		{""},
+		{"", ","},
+		{",", ""},
+		{"", "", ""},
+	}
+
+	keys := make(map[string][]string, len(tuples))
+	for _, tuple := range tuples {
+		cols := make([]wal.Column, 0, len(tuple))
+		colIDs := make([]string, 0, len(tuple))
+		for i, v := range tuple {
+			id := fmt.Sprintf("col-%d", i)
+			cols = append(cols, wal.Column{ID: id, Name: id, Type: "text", Value: v})
+			colIDs = append(colIDs, id)
+		}
+
+		key := string(primaryKeyMessageKey(&wal.Data{
+			Schema:   testSchema,
+			Table:    testTable,
+			Columns:  cols,
+			Metadata: wal.Metadata{InternalColIDs: colIDs},
+		}))
+
+		if clashing, found := keys[key]; found {
+			t.Errorf("tuples %q and %q both encode to message key %q", clashing, tuple, key)
+			continue
+		}
+		keys[key] = tuple
+	}
+}
+
+// TestPrimaryKeyMessageKey_DistinctIdentifiers covers the other half of the
+// encoding: postgres quoted identifiers may contain the "." and ":" that
+// separate schema, table and value list, so those need escaping too.
+func TestPrimaryKeyMessageKey_DistinctIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	identities := []struct {
+		schema string
+		table  string
+		value  string
+	}{
+		{schema: "a.b", table: "c", value: "1"},
+		{schema: "a", table: "b.c", value: "1"},
+		{schema: "s", table: "t:1", value: "x"},
+		{schema: "s", table: "t", value: "1:x"},
+		{schema: "s", table: `t\`, value: "x"},
+	}
+
+	keys := make(map[string]string, len(identities))
+	for _, id := range identities {
+		key := string(primaryKeyMessageKey(&wal.Data{
+			Schema:   id.schema,
+			Table:    id.table,
+			Columns:  []wal.Column{{ID: "col-1", Name: "pk", Type: "text", Value: id.value}},
+			Metadata: wal.Metadata{InternalColIDs: []string{"col-1"}},
+		}))
+
+		desc := fmt.Sprintf("schema=%q table=%q value=%q", id.schema, id.table, id.value)
+		if clashing, found := keys[key]; found {
+			t.Errorf("%s and %s both encode to message key %q", clashing, desc, key)
+			continue
+		}
+		keys[key] = desc
 	}
 }
 


### PR DESCRIPTION
#### Description

The `primary_key` Kafka partition-key strategy joined composite key values with a comma, which is not injective: the tuples `["a,b","c"]` and `["a","b,c"]` both encoded to `test_schema.test_table:a,b,c`, so two rows with distinct primary keys shared a message key and lost their separate partitioning and ordering identity.

Key components are now escaped before the join (`,` -> `\,`, `\` -> `\\`).

##### Related Issue(s)

- Fixes #1033

#### Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

#### Changes Made

- Added `escapeKeyValue` in `pkg/wal/processor/kafka/wal_kafka_batch_writer.go` and applied it to each component in `primaryKeyMessageKey`.
- Escaped the escape character too, otherwise `["a\","b"]` and `["a",",b"]` collide in turn.

#### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [ ] Documentation updated where necessary

#### Additional Notes

**Partition assignment changes for affected keys.** Any message key that changes moves to a different partition, so per-key ordering continuity is broken across the upgrade for those keys. Escaping was chosen over length-prefixing or per-component hashing precisely to bound this: values containing neither `,` nor `\` encode byte-identically to before, so only keys that were already ambiguous (plus any containing a backslash) move. A deployment keyed on integers or UUIDs sees no change at all. The other two options would have relocated every key in every topic.

The `schema.table:` prefix has the same non-injectivity — `schema="a.b", table="c"` and `schema="a", table="b.c"` both yield `a.b.c` — and is **not** addressed here. Postgres identifiers can contain dots, so it is a real if narrower case. Left out because fixing it would repartition keys for anyone with a dot in a schema or table name; happy to fold in if reviewers prefer.
