### PR TITLE
Fix replicated DELETEs on user-defined enum PKs

### DIFF
--- a/internal/postgres/errors.go
+++ b/internal/postgres/errors.go
@@ -112,6 +112,18 @@ func (e *ErrFeatureNotSupported) Error() string {
 	return fmt.Sprintf("feature not supported: %s", e.Details)
 }
 
+type ErrValueEncoding struct {
+	Details string
+}
+
+func (e *ErrValueEncoding) Error() string {
+	return fmt.Sprintf("value encoding: %s", e.Details)
+}
+
+const encodeArgsErrFragment = "failed to encode args["
+
+var encodeArgsErrDetails = regexp.MustCompile(`^(.*?failed to encode args\[\d+\]).*?(for [^:]+)`)
+
 // MapError maps a Postgres error to a more specific error type
 func MapError(err error) error {
 	if pgconn.Timeout(err) {
@@ -206,5 +218,21 @@ func MapError(err error) error {
 		}
 	}
 
+	// A client-side encoding failure is recognized last, and only when nothing
+	// carried a SQLSTATE: it never reaches the server, so it can never be a
+	// PgError. Checking it earlier would let a genuine server error whose
+	// message happens to quote the fragment — postgres embeds row values in
+	// messages, and pgstream is often pointed at tables holding log text — be
+	// misclassified, changing how the writer and the retrier handle it.
+	if err != nil && pgErr == nil && strings.Contains(err.Error(), encodeArgsErrFragment) {
+		return &ErrValueEncoding{Details: encodingErrDetails(err.Error())}
+	}
+
 	return err
+}
+func encodingErrDetails(msg string) string {
+	if m := encodeArgsErrDetails.FindStringSubmatch(msg); m != nil {
+		return m[1] + " " + m[2]
+	}
+	return encodeArgsErrFragment
 }

--- a/internal/postgres/errors.go
+++ b/internal/postgres/errors.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -230,6 +231,7 @@ func MapError(err error) error {
 
 	return err
 }
+
 func encodingErrDetails(msg string) string {
 	if m := encodeArgsErrDetails.FindStringSubmatch(msg); m != nil {
 		return m[1] + " " + m[2]

--- a/internal/postgres/errors_test.go
+++ b/internal/postgres/errors_test.go
@@ -4,11 +4,30 @@ package postgres
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 )
+
+// TestMapError_realPgxEncodeError guards the message matching in MapError
+// against pgx changing its wrapper text: the error here is produced by pgx
+// itself, encoding the same Go value that #1037 reported (a []any bound against
+// a parameter whose OID pgx has no codec for). No server is needed — the
+// failure happens while building the query.
+func TestMapError_realPgxEncodeError(t *testing.T) {
+	t.Parallel()
+
+	err := (&pgx.ExtendedQueryBuilder{}).Build(pgtype.NewMap(), nil, []any{[]any{"BiteScan"}})
+	require.Error(t, err, "pgx no longer fails to encode []any; revisit the encoding error mapping")
+
+	var errValueEncoding *ErrValueEncoding
+	require.ErrorAs(t, MapError(err), &errValueEncoding,
+		"pgx encoding failures must map to ErrValueEncoding so the batch writer drops only the failing query")
+}
 
 func TestMapError(t *testing.T) {
 	tests := []struct {
@@ -145,6 +164,21 @@ func TestMapError(t *testing.T) {
 			wantErr: &ErrRelationAlreadyExists{},
 		},
 		{
+			// verbatim message produced by pgx v5 when binding a Go slice
+			// against a user-defined enum array parameter (#1037). The query
+			// never reaches the server, so there is no SQLSTATE to key off.
+			name: "client-side argument encoding failure",
+			err: errors.New(`failed to encode args[1]: unable to encode []interface {}{"BiteScan"} ` +
+				`into text format for unknown type (OID 16384): cannot find encode plan`),
+			wantErr: &ErrValueEncoding{},
+		},
+		{
+			name: "client-side argument encoding failure, wrapped",
+			err: fmt.Errorf("executing query: %w",
+				errors.New(`failed to encode args[0]: unable to encode []interface {}{"x"} into text format for unknown type (OID 16384)`)),
+			wantErr: &ErrValueEncoding{},
+		},
+		{
 			name: "42701 duplicate_column",
 			err: &pgconn.PgError{
 				Code:    "42701",
@@ -253,7 +287,7 @@ func TestMapError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mappedErr := MapError(tt.err)
-			require.ErrorAs(t, mappedErr, &tt.wantErr)
+			require.IsType(t, tt.wantErr, mappedErr)
 		})
 	}
 }

--- a/internal/postgres/retrier/pg_querier_retrier.go
+++ b/internal/postgres/retrier/pg_querier_retrier.go
@@ -162,6 +162,7 @@ func (q *Querier) isRetriableError(err error) bool {
 	doesNotExist := &postgres.ErrRelationDoesNotExist{}
 	programLimitExceeded := &postgres.ErrProgramLimitExceeded{}
 	featureNotSupported := &postgres.ErrFeatureNotSupported{}
+	valueEncoding := &postgres.ErrValueEncoding{}
 	switch {
 	case errors.As(mappedErr, &permissionDenied),
 		errors.As(mappedErr, &constraintViolation),
@@ -170,7 +171,8 @@ func (q *Querier) isRetriableError(err error) bool {
 		errors.As(mappedErr, &syntaxError),
 		errors.As(mappedErr, &doesNotExist),
 		errors.As(mappedErr, &programLimitExceeded),
-		errors.As(mappedErr, &featureNotSupported):
+		errors.As(mappedErr, &featureNotSupported),
+		errors.As(mappedErr, &valueEncoding):
 		return false
 	}
 

--- a/internal/postgres/retrier/pg_querier_retrier_test.go
+++ b/internal/postgres/retrier/pg_querier_retrier_test.go
@@ -558,6 +558,22 @@ func TestQuerier_isRetriableError(t *testing.T) {
 			err:             fmt.Errorf("operation failed: %w", errors.New("generic error")),
 			wantIsRetriable: true,
 		},
+		{
+			name:            "value encoding error",
+			err:             &postgres.ErrValueEncoding{},
+			wantIsRetriable: false,
+		},
+		{
+			// isRetriableError maps through MapError, so a raw pgx encoding
+			// failure must be recognized even before anything types it. The
+			// default policy has no attempt or elapsed-time bound, so treating
+			// this as retriable wedges replication instead of letting the
+			// writer drop the one failing query.
+			name: "raw pgx encoding failure",
+			err: errors.New(`failed to encode args[1]: unable to encode []interface {}{"BiteScan"} ` +
+				`into text format for unknown type (OID 16384): cannot find encode plan`),
+			wantIsRetriable: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/stream/integration/pg_pg_integration_test.go
+++ b/pkg/stream/integration/pg_pg_integration_test.go
@@ -1073,3 +1073,148 @@ func Test_PostgresToPostgres_LargeIntegerPrecisionWAL(t *testing.T) {
 		})
 	})
 }
+
+// Test_PostgresToPostgres_EnumPrimaryKeyDelete verifies that replicated DELETE
+// events on a table whose replica identity contains a user-defined enum column
+// are applied on the target.
+//
+// The repro from #1037: BatchWriter.buildCoalescedQueries routes every run of
+// consecutive same-table DELETEs — even a run of length 1 — through the bulk
+// delete builders, which bind one Go slice per identity column. pgx registers
+// no codec for the database-specific enum *array* OID, so binding against
+// `$2::asset_kind[]` failed client-side with "unable to encode
+// []interface {}{...} into text format for unknown type". Because that is a
+// client-side error rather than a recognized pglib error type, it was treated
+// as internal and poisoned the whole batch. Identity values for enum columns
+// are now bound as text[] and cast back on the target.
+//
+// The #1035 enum fix covered only the snapshot bulk-ingest COPY path.
+func Test_PostgresToPostgres_EnumPrimaryKeyDelete(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	cfg := &stream.Config{
+		Listener:  testPostgresListenerCfg(t),
+		Processor: testPostgresProcessorCfg(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runStream(t, ctx, cfg)
+
+	enumType := "pg2pg_asset_kind"
+	domainType := "pg2pg_asset_kind_dom"
+	compositeTable := "pg2pg_asset_composite"
+	singleTable := "pg2pg_asset_single"
+	domainTable := "pg2pg_asset_domain"
+
+	// The types must exist on both sides before the tables referencing them are
+	// created. Creating them on the source can race the same DDL arriving on
+	// the target through replication, and neither CREATE TYPE nor CREATE DOMAIN
+	// supports IF NOT EXISTS, so swallow the duplicate.
+	ifNotExists := func(stmt string) string {
+		return fmt.Sprintf(
+			`DO $$ BEGIN %s; EXCEPTION WHEN duplicate_object THEN NULL; END $$`, stmt)
+	}
+	for _, url := range []string{pgurl, targetPGURL} {
+		execQueryWithURL(t, ctx, url, ifNotExists(
+			fmt.Sprintf(`CREATE TYPE %s AS ENUM ('BiteScan','UpperJawScan','LowerJawScan')`, enumType)))
+		execQueryWithURL(t, ctx, url, ifNotExists(fmt.Sprintf(`CREATE DOMAIN %s AS %s`, domainType, enumType)))
+	}
+	t.Cleanup(func() {
+		// cleanup runs after the test's deferred cancel(), so it needs a live
+		// context of its own.
+		cleanupCtx := context.Background()
+		for _, url := range []string{pgurl, targetPGURL} {
+			execQueryWithURL(t, cleanupCtx, url,
+				fmt.Sprintf("DROP TABLE IF EXISTS %s, %s, %s", compositeTable, singleTable, domainTable))
+			execQueryWithURL(t, cleanupCtx, url, fmt.Sprintf("DROP DOMAIN IF EXISTS %s", domainType))
+			execQueryWithURL(t, cleanupCtx, url, fmt.Sprintf("DROP TYPE IF EXISTS %s", enumType))
+		}
+	})
+
+	// composite PK containing an enum column, exactly as reported
+	execQuery(t, ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			export_id uuid NOT NULL,
+			kind %s NOT NULL,
+			number int NOT NULL,
+			PRIMARY KEY (export_id, kind, number)
+		)`, compositeTable, enumType))
+	// single-column enum PK, which takes the ANY($1::text[]::enum[]) branch
+	execQuery(t, ctx, fmt.Sprintf(`CREATE TABLE %s (kind %s PRIMARY KEY)`, singleTable, enumType))
+	// a domain over the enum needs the column side cast too: the enum
+	// comparison operators are polymorphic over anyenum, which does not accept
+	// a domain. Deletes on this shape failed on every path before, including
+	// the per-row form, with "operator does not exist: dom = dom".
+	execQuery(t, ctx, fmt.Sprintf(`CREATE TABLE %s (kind %s PRIMARY KEY)`, domainTable, domainType))
+
+	targetConn, err := pglib.NewConn(ctx, targetPGURL)
+	require.NoError(t, err)
+	defer targetConn.Close(ctx)
+
+	waitForCount := func(t *testing.T, table string, want int) {
+		t.Helper()
+		require.Eventually(t, func() bool {
+			var count int
+			if err := targetConn.QueryRow(ctx, []any{&count}, fmt.Sprintf("SELECT count(*) FROM %s", table)); err != nil {
+				// the table may not have been replicated yet
+				return false
+			}
+			return count == want
+		}, 20*time.Second, 200*time.Millisecond,
+			"table %s: want %d rows on target", table, want)
+	}
+
+	execQuery(t, ctx, fmt.Sprintf(
+		`INSERT INTO %s VALUES ('550e8400-e29b-41d4-a716-446655440000','BiteScan',1),
+		                       ('550e8400-e29b-41d4-a716-446655440001','UpperJawScan',2)`, compositeTable))
+	execQuery(t, ctx, fmt.Sprintf(`INSERT INTO %s VALUES ('BiteScan'),('UpperJawScan')`, singleTable))
+	execQuery(t, ctx, fmt.Sprintf(`INSERT INTO %s VALUES ('BiteScan'),('UpperJawScan')`, domainTable))
+
+	waitForCount(t, compositeTable, 2)
+	waitForCount(t, singleTable, 2)
+	waitForCount(t, domainTable, 2)
+
+	t.Run("delete on composite enum PK", func(t *testing.T) {
+		execQuery(t, ctx, fmt.Sprintf("DELETE FROM %s WHERE kind = 'BiteScan'", compositeTable))
+		waitForCount(t, compositeTable, 1)
+
+		var kind string
+		err := targetConn.QueryRow(ctx, []any{&kind}, fmt.Sprintf("SELECT kind::text FROM %s", compositeTable))
+		require.NoError(t, err)
+		require.Equal(t, "UpperJawScan", kind, "the wrong row was deleted")
+	})
+
+	t.Run("delete on single-column enum PK", func(t *testing.T) {
+		execQuery(t, ctx, fmt.Sprintf("DELETE FROM %s WHERE kind = 'BiteScan'", singleTable))
+		waitForCount(t, singleTable, 1)
+
+		var kind string
+		err := targetConn.QueryRow(ctx, []any{&kind}, fmt.Sprintf("SELECT kind::text FROM %s", singleTable))
+		require.NoError(t, err)
+		require.Equal(t, "UpperJawScan", kind, "the wrong row was deleted")
+	})
+
+	t.Run("delete on domain-over-enum PK", func(t *testing.T) {
+		// the source statement needs ::text too — postgres has no
+		// `domain = unknown` operator either, which is how exotic this shape is
+		execQuery(t, ctx, fmt.Sprintf("DELETE FROM %s WHERE kind::text = 'BiteScan'", domainTable))
+		waitForCount(t, domainTable, 1)
+
+		var kind string
+		err := targetConn.QueryRow(ctx, []any{&kind}, fmt.Sprintf("SELECT kind::text FROM %s", domainTable))
+		require.NoError(t, err)
+		require.Equal(t, "UpperJawScan", kind, "the wrong row was deleted")
+	})
+
+	t.Run("delete remaining rows", func(t *testing.T) {
+		execQuery(t, ctx, fmt.Sprintf("DELETE FROM %s", compositeTable))
+		execQuery(t, ctx, fmt.Sprintf("DELETE FROM %s", singleTable))
+		execQuery(t, ctx, fmt.Sprintf("DELETE FROM %s", domainTable))
+		waitForCount(t, compositeTable, 0)
+		waitForCount(t, singleTable, 0)
+		waitForCount(t, domainTable, 0)
+	})
+}

--- a/pkg/wal/processor/postgres/postgres_batch_writer.go
+++ b/pkg/wal/processor/postgres/postgres_batch_writer.go
@@ -152,7 +152,7 @@ func (w *BatchWriter) sendBatch(ctx context.Context, b *batch.Batch[*walMessage]
 							if w.strictMode {
 								return fmt.Errorf("strict mode: stopping on non-internal DDL failure: %w", err)
 							}
-							w.recordDroppedQuery(q)
+							w.recordDroppedQuery(q, err)
 							continue
 						}
 						return err
@@ -201,7 +201,7 @@ func (w *BatchWriter) buildCoalescedQueries(run []*walMessage) ([]*query, error)
 		for i, m := range run {
 			events[i] = m.data
 		}
-		return w.dmlAdapter.buildBulkDeleteQuery(events)
+		return w.dmlAdapter.buildBulkDeleteQuery(events, run[0].schemaInfo)
 	case "I":
 		events := make([]*wal.Data, len(run))
 		for i, m := range run {
@@ -244,6 +244,9 @@ func (w *BatchWriter) execQueries(ctx context.Context, queries []*query) ([]*que
 	retryQueries := []*query{}
 	var droppedQuery *query
 	err := w.pgConn.ExecInTx(ctx, func(tx pglib.Tx) error {
+		retryQueries = []*query{}
+		droppedQuery = nil
+
 		if err := w.setReplicationRoleToReplica(ctx, tx); err != nil {
 			return err
 		}
@@ -274,7 +277,7 @@ func (w *BatchWriter) execQueries(ctx context.Context, queries []*query) ([]*que
 		if w.strictMode {
 			return nil, fmt.Errorf("strict mode: stopping on non-internal query failure: %w", err)
 		}
-		w.recordDroppedQuery(droppedQuery)
+		w.recordDroppedQuery(droppedQuery, err)
 	}
 
 	// if there were no errors or no internal errors in the tx, return the
@@ -290,6 +293,7 @@ func (w *BatchWriter) isInternalError(err error) bool {
 	var errRelationAlreadyExists *pglib.ErrRelationAlreadyExists
 	var errPreconditionFailed *pglib.ErrPreconditionFailed
 	var errFeatureNotSupported *pglib.ErrFeatureNotSupported
+	var errValueEncoding *pglib.ErrValueEncoding
 	switch {
 	case errors.As(err, &errRelationDoesNotExist),
 		errors.As(err, &errConstraintViolation),
@@ -297,7 +301,8 @@ func (w *BatchWriter) isInternalError(err error) bool {
 		errors.As(err, &errDataException),
 		errors.As(err, &errRelationAlreadyExists),
 		errors.As(err, &errPreconditionFailed),
-		errors.As(err, &errFeatureNotSupported):
+		errors.As(err, &errFeatureNotSupported),
+		errors.As(err, &errValueEncoding):
 		return false
 	default:
 		return true

--- a/pkg/wal/processor/postgres/postgres_batch_writer_test.go
+++ b/pkg/wal/processor/postgres/postgres_batch_writer_test.go
@@ -449,6 +449,78 @@ func TestBatchWriter_flushQueries(t *testing.T) {
 			wantErr:       nil,
 		},
 		{
+			// #1037: a client-side encoding failure is deterministic and
+			// attributable to one query, so it must drop that query and retry
+			// the rest rather than failing the whole send — which, with
+			// ignore_send_errors, dropped co-batched writes to other tables.
+			name: "ok - value encoding error drops only the failing query",
+			pgconn: &pgmocks.Querier{
+				ExecInTxFn: func(ctx context.Context, f func(tx pglib.Tx) error) error {
+					mockTx := pgmocks.Tx{
+						ExecFn: func(ctx context.Context, i uint, query string, args ...any) (pglib.CommandTag, error) {
+							execCalls++
+							switch i {
+							case 1:
+								require.Equal(t, testQuerySQL, query)
+								require.Equal(t, args1, args)
+								return pglib.CommandTag{}, nil
+							case 2:
+								require.Equal(t, testQuerySQL, query)
+								require.Equal(t, args2, args)
+								return pglib.CommandTag{}, fmt.Errorf("executing query: %w",
+									&pglib.ErrValueEncoding{Details: `failed to encode args[1]: unable to encode []interface {}{"BiteScan"}`})
+							default:
+								return pglib.CommandTag{}, fmt.Errorf("unexpected call to tx ExecFn: %v", args[1])
+							}
+						},
+					}
+					return f(&mockTx)
+				},
+			},
+			queries: []*query{testQuery(args1), testQuery(args2)},
+
+			// query1, failing query2, then query1 again on the retry
+			wantExecCalls: 3,
+			wantErr:       nil,
+		},
+		{
+			// the retrier re-invokes the tx closure, so state recorded by a
+			// failed attempt must not leak into a later successful one:
+			// attempt 1 fails on query 2, attempt 2 commits both, and nothing
+			// may be reported as needing a retry or as dropped.
+			name: "ok - retried tx that succeeds reports nothing to retry",
+			pgconn: &pgmocks.Querier{
+				ExecInTxFn: func(ctx context.Context, f func(tx pglib.Tx) error) error {
+					attempt := 0
+					var runAttempt func() error
+					runAttempt = func() error {
+						attempt++
+						failing := attempt == 1
+						mockTx := pgmocks.Tx{
+							ExecFn: func(ctx context.Context, i uint, query string, args ...any) (pglib.CommandTag, error) {
+								execCalls++
+								if failing && i == 2 {
+									// transient failure, not attributable to the query
+									return pglib.CommandTag{}, errTest
+								}
+								return pglib.CommandTag{}, nil
+							},
+						}
+						if err := f(&mockTx); err != nil && attempt == 1 {
+							return runAttempt()
+						}
+						return nil
+					}
+					return runAttempt()
+				},
+			},
+			queries: []*query{testQuery(args1), testQuery(args2)},
+
+			// attempt 1: query1, query2 (fails); attempt 2: query1, query2
+			wantExecCalls: 4,
+			wantErr:       nil,
+		},
+		{
 			name: "error - internal error in tx exec",
 			pgconn: &pgmocks.Querier{
 				ExecInTxFn: func(ctx context.Context, f func(tx pglib.Tx) error) error {

--- a/pkg/wal/processor/postgres/postgres_schema_observer.go
+++ b/pkg/wal/processor/postgres/postgres_schema_observer.go
@@ -37,9 +37,10 @@ type pgSchemaObserver struct {
 	materializedViews *synclib.Map[string, map[string]struct{}]
 	// columnTableSequences is a map of schema.table to a map of sequence column names.
 	columnTableSequences *synclib.Map[string, map[string]string]
-	// enumTableColumns is a map of schema.table to a set of quoted column names
-	// whose type is a user-defined enum.
-	enumTableColumns *synclib.Map[string, map[string]struct{}]
+	// enumTableColumns is a map of schema.table to the quoted column names whose
+	// type resolves to a user-defined enum, each with the catalog-resolved
+	// information needed to cast it (see enumColumn).
+	enumTableColumns *synclib.Map[string, map[string]enumColumn]
 	// enumCacheEpoch is bumped by every enum invalidation. Unlike its sibling
 	// caches, enumTableColumns is repopulated by a live query rather than from
 	// the DDL event payload, so a lookup that started before an invalidation
@@ -78,7 +79,7 @@ func newPGSchemaObserver(ctx context.Context, cfg *Config, logger loglib.Logger)
 		alwaysIdentityTableColumns: synclib.NewMap[string, map[string]struct{}](),
 		materializedViews:          synclib.NewMap[string, map[string]struct{}](),
 		columnTableSequences:       synclib.NewMap[string, map[string]string](),
-		enumTableColumns:           synclib.NewMap[string, map[string]struct{}](),
+		enumTableColumns:           synclib.NewMap[string, map[string]enumColumn](),
 		logger:                     logger,
 	}, nil
 }
@@ -167,7 +168,7 @@ func (o *pgSchemaObserver) getSequenceColumns(ctx context.Context, schema, table
 // getEnumColumnNames returns the set of quoted column names for the given
 // schema.table whose type is a user-defined enum. If not cached, it queries
 // postgres.
-func (o *pgSchemaObserver) getEnumColumnNames(ctx context.Context, schema, table string) (map[string]struct{}, error) {
+func (o *pgSchemaObserver) getEnumColumnNames(ctx context.Context, schema, table string) (map[string]enumColumn, error) {
 	key := pglib.QuoteQualifiedIdentifier(schema, table)
 
 	columns, found := o.enumTableColumns.Get(key)
@@ -391,16 +392,34 @@ func (o *pgSchemaObserver) queryAlwaysIdentityColumnNames(ctx context.Context, s
 }
 
 // enumTableColumnsQuery returns the columns of a table whose type resolves to a
-// user-defined enum. pgx registers no binary codec for such database-specific
-// OIDs, so these columns force text-format COPY, where the value is written as
-// the literal postgres text representation and parsed by the target's type
-// input function.
+// user-defined enum, together with what a query must cast to in order to talk
+// about them. pgx registers no binary codec for such database-specific OIDs, so
+// these columns force text-format COPY, where the value is written as the
+// literal postgres text representation and parsed by the target's type input
+// function, and they force text[] parameter binding on the bulk delete path
+// (see bindAsText).
 //
 // Four shapes are covered: a scalar enum, an array of enums, a domain over an
 // enum, and a domain over an array of enums. A domain over a domain is not
 // resolved (it would need a recursive walk of typbasetype) and still takes the
 // binary path.
-const enumTableColumnsQuery = `SELECT a.attname
+//
+// enumType is the enum itself — resolved through the array element type and the
+// domain base type — schema-qualified and quoted by postgres. Casting to the
+// *column's declared* type is not equivalent: the enum comparison operators are
+// polymorphic over anyenum, which does not accept a domain, so `dom = dom` has
+// no operator while `dom::the_enum = the_enum` does. It is also read from the
+// target catalog rather than from the replication stream, so it is safe to
+// interpolate into a statement.
+//
+// isArray reports whether the column resolves to an *array* of the enum (either
+// directly or through a domain), which needs a different comparison shape, and
+// isDomain whether the column is a domain, which additionally needs the column
+// side cast to the base enum.
+const enumTableColumnsQuery = `SELECT a.attname,
+	quote_ident(enumns.nspname) || '.' || quote_ident(enumt.typname) AS enum_type,
+	(COALESCE(elem.typtype, '') = 'e' OR COALESCE(baseelem.typtype, '') = 'e') AS is_array,
+	t.typtype = 'd' AS is_domain
 	FROM pg_attribute a
 	JOIN pg_class c ON c.oid = a.attrelid
 	JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -408,6 +427,13 @@ const enumTableColumnsQuery = `SELECT a.attname
 	LEFT JOIN pg_type elem ON elem.oid = t.typelem
 	LEFT JOIN pg_type base ON base.oid = t.typbasetype
 	LEFT JOIN pg_type baseelem ON baseelem.oid = base.typelem
+	JOIN pg_type enumt ON enumt.oid = CASE
+		WHEN t.typtype = 'e' THEN t.oid
+		WHEN t.typtype = 'b' AND elem.typtype = 'e' THEN elem.oid
+		WHEN t.typtype = 'd' AND base.typtype = 'e' THEN base.oid
+		WHEN t.typtype = 'd' AND baseelem.typtype = 'e' THEN baseelem.oid
+	END
+	JOIN pg_namespace enumns ON enumns.oid = enumt.typnamespace
 	WHERE n.nspname = $1 AND c.relname = $2
 	AND a.attnum > 0 AND NOT a.attisdropped
 	AND (
@@ -416,11 +442,11 @@ const enumTableColumnsQuery = `SELECT a.attname
 		OR (t.typtype = 'd' AND (base.typtype = 'e' OR baseelem.typtype = 'e'))
 	)`
 
-func (o *pgSchemaObserver) queryEnumColumnNames(ctx context.Context, schemaName, tableName string) (map[string]struct{}, error) {
+func (o *pgSchemaObserver) queryEnumColumnNames(ctx context.Context, schemaName, tableName string) (map[string]enumColumn, error) {
 	ctx, cancel := context.WithTimeout(ctx, schemaQueryTimeout)
 	defer cancel()
 
-	columnNames := map[string]struct{}{}
+	columns := map[string]enumColumn{}
 	rows, err := o.pgConn.Query(ctx, enumTableColumnsQuery, schemaName, tableName)
 	if err != nil {
 		return nil, fmt.Errorf("getting table enum column names for table %s.%s: %w", schemaName, tableName, err)
@@ -429,17 +455,18 @@ func (o *pgSchemaObserver) queryEnumColumnNames(ctx context.Context, schemaName,
 
 	for rows.Next() {
 		var columnName string
-		if err := rows.Scan(&columnName); err != nil {
+		var col enumColumn
+		if err := rows.Scan(&columnName, &col.enumType, &col.isArray, &col.isDomain); err != nil {
 			return nil, fmt.Errorf("scanning table enum column name: %w", err)
 		}
-		columnNames[pglib.QuoteIdentifier(columnName)] = struct{}{}
+		columns[pglib.QuoteIdentifier(columnName)] = col
 	}
 
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
-	return columnNames, nil
+	return columns, nil
 }
 
 const materializedViewsQuery = `SELECT matviewname FROM pg_matviews WHERE schemaname = $1`

--- a/pkg/wal/processor/postgres/postgres_schema_observer_test.go
+++ b/pkg/wal/processor/postgres/postgres_schema_observer_test.go
@@ -161,16 +161,16 @@ func TestPGSchemaObserver_getEnumColumnNames(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		tableColumns map[string]map[string]struct{}
+		tableColumns map[string]map[string]enumColumn
 		pgConn       pglib.Querier
 
-		wantColumns      map[string]struct{}
-		wantTableColumns map[string]map[string]struct{}
+		wantColumns      map[string]enumColumn
+		wantTableColumns map[string]map[string]enumColumn
 		wantErr          error
 	}{
 		{
 			name:         "ok - queries and caches enum column",
-			tableColumns: map[string]map[string]struct{}{},
+			tableColumns: map[string]map[string]enumColumn{},
 			pgConn: &pgmocks.Querier{
 				QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
 					require.Equal(t, enumTableColumnsQuery, query)
@@ -179,10 +179,17 @@ func TestPGSchemaObserver_getEnumColumnNames(t *testing.T) {
 						CloseFn: func() {},
 						NextFn:  func(i uint) bool { return i == 1 },
 						ScanFn: func(_ uint, dest ...any) error {
-							require.Len(t, dest, 1)
+							require.Len(t, dest, 4)
 							colName, ok := dest[0].(*string)
 							require.True(t, ok, fmt.Sprintf("column name, expected *string, got %T", dest[0]))
 							*colName = "mood"
+							enumType, ok := dest[1].(*string)
+							require.True(t, ok, fmt.Sprintf("enum type, expected *string, got %T", dest[1]))
+							*enumType = "public.mood"
+							_, ok = dest[2].(*bool)
+							require.True(t, ok, fmt.Sprintf("is_array, expected *bool, got %T", dest[2]))
+							_, ok = dest[3].(*bool)
+							require.True(t, ok, fmt.Sprintf("is_domain, expected *bool, got %T", dest[3]))
 							return nil
 						},
 						ErrFn: func() error { return nil },
@@ -190,16 +197,16 @@ func TestPGSchemaObserver_getEnumColumnNames(t *testing.T) {
 				},
 			},
 
-			wantColumns: map[string]struct{}{moodColumn: {}},
-			wantTableColumns: map[string]map[string]struct{}{
-				quotedQualifiedTableName: {moodColumn: {}},
+			wantColumns: map[string]enumColumn{moodColumn: {enumType: "public.mood"}},
+			wantTableColumns: map[string]map[string]enumColumn{
+				quotedQualifiedTableName: {moodColumn: {enumType: "public.mood"}},
 			},
 			wantErr: nil,
 		},
 		{
 			name: "ok - cache hit, no query",
-			tableColumns: map[string]map[string]struct{}{
-				quotedQualifiedTableName: {moodColumn: {}},
+			tableColumns: map[string]map[string]enumColumn{
+				quotedQualifiedTableName: {moodColumn: {enumType: "public.mood"}},
 			},
 			pgConn: &pgmocks.Querier{
 				QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
@@ -207,15 +214,15 @@ func TestPGSchemaObserver_getEnumColumnNames(t *testing.T) {
 				},
 			},
 
-			wantColumns: map[string]struct{}{moodColumn: {}},
-			wantTableColumns: map[string]map[string]struct{}{
-				quotedQualifiedTableName: {moodColumn: {}},
+			wantColumns: map[string]enumColumn{moodColumn: {enumType: "public.mood"}},
+			wantTableColumns: map[string]map[string]enumColumn{
+				quotedQualifiedTableName: {moodColumn: {enumType: "public.mood"}},
 			},
 			wantErr: nil,
 		},
 		{
 			name:         "error - querying enum columns",
-			tableColumns: map[string]map[string]struct{}{},
+			tableColumns: map[string]map[string]enumColumn{},
 			pgConn: &pgmocks.Querier{
 				QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
 					return nil, errTest
@@ -223,7 +230,7 @@ func TestPGSchemaObserver_getEnumColumnNames(t *testing.T) {
 			},
 
 			wantColumns:      nil,
-			wantTableColumns: map[string]map[string]struct{}{},
+			wantTableColumns: map[string]map[string]enumColumn{},
 			wantErr:          errTest,
 		},
 	}
@@ -293,9 +300,9 @@ func TestPGSchemaObserver_invalidateEnumColumns(t *testing.T) {
 			t.Parallel()
 
 			o := &pgSchemaObserver{
-				enumTableColumns: synclib.NewMapFromMap(map[string]map[string]struct{}{
-					quotedTable:      {`"mood"`: {}},
-					quotedOtherTable: {`"status"`: {}},
+				enumTableColumns: synclib.NewMapFromMap(map[string]map[string]enumColumn{
+					quotedTable:      {`"mood"`: {enumType: "public.mood"}},
+					quotedOtherTable: {`"status"`: {enumType: "public.status"}},
 				}),
 				logger: loglib.NewNoopLogger(),
 			}
@@ -320,7 +327,7 @@ func TestPGSchemaObserver_getEnumColumnNames_invalidatedWhileQuerying(t *testing
 	quotedTable := `"test_schema"."test_table"`
 
 	o := &pgSchemaObserver{
-		enumTableColumns: synclib.NewMap[string, map[string]struct{}](),
+		enumTableColumns: synclib.NewMap[string, map[string]enumColumn](),
 		logger:           loglib.NewNoopLogger(),
 	}
 
@@ -334,9 +341,13 @@ func TestPGSchemaObserver_getEnumColumnNames_invalidatedWhileQuerying(t *testing
 				CloseFn: func() {},
 				NextFn:  func(i uint) bool { return i == 1 },
 				ScanFn: func(_ uint, dest ...any) error {
+					require.Len(t, dest, 4)
 					colName, ok := dest[0].(*string)
 					require.True(t, ok)
 					*colName = "mood"
+					enumType, ok := dest[1].(*string)
+					require.True(t, ok)
+					*enumType = "public.mood"
 					return nil
 				},
 				ErrFn: func() error { return nil },
@@ -346,7 +357,7 @@ func TestPGSchemaObserver_getEnumColumnNames_invalidatedWhileQuerying(t *testing
 
 	colNames, err := o.getEnumColumnNames(context.TODO(), testSchema, testTable)
 	require.NoError(t, err)
-	require.Equal(t, map[string]struct{}{`"mood"`: {}}, colNames, "the caller still gets the queried result")
+	require.Equal(t, map[string]enumColumn{`"mood"`: {enumType: "public.mood"}}, colNames, "the caller still gets the queried result")
 
 	_, found := o.enumTableColumns.Get(quotedTable)
 	require.False(t, found, "result raced by an invalidation must not be cached")
@@ -369,7 +380,7 @@ func TestPGSchemaObserver_getSchemaInfo(t *testing.T) {
 			alwaysIdentityTableColumns: newSeededMap(failing != "alwaysIdentity",
 				map[string]struct{}{`"id"`: {}}),
 			columnTableSequences: newSeededSequenceMap(failing != "sequences"),
-			enumTableColumns:     newSeededMap(failing != "enum", map[string]struct{}{`"mood"`: {}}),
+			enumTableColumns:     newSeededMap(failing != "enum", map[string]enumColumn{`"mood"`: {enumType: "public.mood"}}),
 		}
 	}
 
@@ -388,7 +399,7 @@ func TestPGSchemaObserver_getSchemaInfo(t *testing.T) {
 				generatedColumns:      map[string]struct{}{`"gen"`: {}},
 				alwaysIdentityColumns: map[string]struct{}{`"id"`: {}},
 				sequenceColumns:       map[string]string{`"id"`: `"test_schema"."seq"`},
-				enumColumns:           map[string]struct{}{`"mood"`: {}},
+				enumColumns:           map[string]enumColumn{`"mood"`: {enumType: "public.mood"}},
 			},
 			wantErr: nil,
 		},
@@ -433,8 +444,8 @@ func TestPGSchemaObserver_getSchemaInfo(t *testing.T) {
 	}
 }
 
-func newSeededMap(seed bool, value map[string]struct{}) *synclib.Map[string, map[string]struct{}] {
-	m := synclib.NewMap[string, map[string]struct{}]()
+func newSeededMap[T any](seed bool, value map[string]T) *synclib.Map[string, map[string]T] {
+	m := synclib.NewMap[string, map[string]T]()
 	if seed {
 		m.Set(pglib.QuoteQualifiedIdentifier(testSchema, testTable), value)
 	}

--- a/pkg/wal/processor/postgres/postgres_wal_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_adapter.go
@@ -34,11 +34,32 @@ type schemaInfo struct {
 	generatedColumns      map[string]struct{}
 	alwaysIdentityColumns map[string]struct{}
 	sequenceColumns       map[string]string
-	// enumColumns is the set of quoted column names whose type is a
-	// user-defined enum. pgx has no binary codec registered for such
-	// database-specific OIDs, so batches touching these columns must use
-	// text-format COPY instead of binary COPY (see needsTextCopyForColumns).
-	enumColumns map[string]struct{}
+	// enumColumns maps quoted column names whose type resolves to a
+	// user-defined enum to what a query needs in order to cast them. pgx has no
+	// binary codec registered for such database-specific OIDs, so batches
+	// touching these columns must use text-format COPY instead of binary COPY
+	// (see needsTextCopyForColumns), and the bulk delete path must bind their
+	// values as text[] and cast them back on the target (see bindAsText).
+	enumColumns map[string]enumColumn
+}
+
+// enumColumn describes how to cast a column whose type resolves to a
+// user-defined enum. Every field is resolved from the target catalog by
+// enumTableColumnsQuery, never from the replication stream, so enumType is safe
+// to interpolate into a statement.
+type enumColumn struct {
+	// enumType is the enum itself, schema-qualified and quoted — resolved
+	// through the array element type and the domain base type, since the
+	// column's own type name is not always usable in a comparison.
+	enumType string
+	// isArray reports whether the column resolves to an array of the enum,
+	// which compares as a whole array rather than element-wise.
+	isArray bool
+	// isDomain reports whether the column is a domain over the enum. The enum
+	// comparison operators are polymorphic over anyenum, which does not accept
+	// a domain, so the column side needs an explicit cast to the base enum —
+	// which forfeits use of any plain index on that column.
+	isDomain bool
 }
 
 type adapter struct {

--- a/pkg/wal/processor/postgres/postgres_wal_adapter_test.go
+++ b/pkg/wal/processor/postgres/postgres_wal_adapter_test.go
@@ -42,7 +42,7 @@ func TestAdapter_walEventToMessage(t *testing.T) {
 
 	testGeneratedCols := map[string]struct{}{"gen": {}}
 	testSeqCols := map[string]string{"id": "users_id_seq"}
-	testEnumCols := map[string]struct{}{`"mood"`: {}}
+	testEnumCols := map[string]enumColumn{`"mood"`: {enumType: "public.mood"}}
 
 	tests := []struct {
 		name            string
@@ -423,7 +423,7 @@ func TestAdapter_threadsSchemaInfo(t *testing.T) {
 		generatedColumns:      map[string]struct{}{`"gen"`: {}},
 		alwaysIdentityColumns: map[string]struct{}{`"id"`: {}},
 		sequenceColumns:       map[string]string{`"id"`: `"public"."users_id_seq"`},
-		enumColumns:           map[string]struct{}{`"mood"`: {}},
+		enumColumns:           map[string]enumColumn{`"mood"`: {enumType: "public.mood"}},
 	}
 
 	event := &wal.Event{Data: &wal.Data{Schema: "public", Table: "users", Action: "I"}}

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
@@ -504,7 +504,7 @@ func needsTextCopy(columnTypes []string) bool {
 // case when a column has a static text-only type (see textOnlyCopyTypes) or a
 // user-defined enum type, whose database-specific OID pgx has no binary codec
 // registered for. columnNames must be quoted to match the enumColumns set.
-func needsTextCopyForColumns(columnNames, columnTypes []string, enumColumns map[string]struct{}) bool {
+func needsTextCopyForColumns(columnNames, columnTypes []string, enumColumns map[string]enumColumn) bool {
 	if needsTextCopy(columnTypes) {
 		return true
 	}

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter_bulk.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter_bulk.go
@@ -57,7 +57,10 @@ func (a *dmlAdapter) getIdentityColumns(d *wal.Data) ([]wal.Column, error) {
 // Single PK: DELETE FROM t WHERE col = ANY($1::type[])
 // Composite PK: DELETE FROM t WHERE (a,b) IN (SELECT * FROM unnest($1::a[], $2::b[]))
 // NULL identity values are handled as individual queries.
-func (a *dmlAdapter) buildBulkDeleteQuery(events []*wal.Data) ([]*query, error) {
+//
+// Identity columns whose type is a user-defined enum are bound as text[] and
+// cast back on the target instead, see bindAsText.
+func (a *dmlAdapter) buildBulkDeleteQuery(events []*wal.Data, si schemaInfo) ([]*query, error) {
 	if len(events) == 0 {
 		return nil, nil
 	}
@@ -111,14 +114,14 @@ func (a *dmlAdapter) buildBulkDeleteQuery(events []*wal.Data) ([]*query, error) 
 
 	if numPKCols == 1 {
 		// single PK: use ANY($1::type[])
-		q, err := a.buildBulkDeleteSinglePK(normalEvents, firstCols[0], tableName)
+		q, err := a.buildBulkDeleteSinglePK(normalEvents, firstCols[0], tableName, si)
 		if err != nil {
 			return nil, err
 		}
 		queries = append(queries, q)
 	} else {
 		// composite PK: use unnest of one array per PK column
-		q, err := a.buildBulkDeleteCompositePK(normalEvents, numPKCols, tableName)
+		q, err := a.buildBulkDeleteCompositePK(normalEvents, numPKCols, tableName, si)
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +131,45 @@ func (a *dmlAdapter) buildBulkDeleteQuery(events []*wal.Data) ([]*query, error) 
 	return queries, nil
 }
 
-func (a *dmlAdapter) buildBulkDeleteSinglePK(events []*wal.Data, refCol wal.Column, tableName string) (*query, error) {
+// bindAsText reports whether the identity values for the given column must be
+// bound as a text[] parameter and cast back on the target, rather than bound
+// directly as an array of the column's own type. The returned enumColumn
+// carries the catalog-resolved cast information and is only meaningful when the
+// second return value is true.
+//
+// columnName must be quoted to match the enumColumns set.
+func bindAsText(columnName string, si schemaInfo) (enumColumn, bool) {
+	col, isEnum := si.enumColumns[columnName]
+	return col, isEnum
+}
+
+// enumComparison renders the comparison between an enum-resolving identity
+// column and a text[] parameter, casting whichever sides the column's shape
+// requires. Cast targets come from the target catalog (see enumColumn), never
+// from the replication stream, so they are safe to interpolate.
+func enumComparison(colName string, col enumColumn, param string) string {
+	switch {
+	case col.isArray:
+		// ANY unwraps one array level, which would compare the element type
+		// against an array-typed column ("operator does not exist:
+		// my_enum[] = my_enum"), so compare whole arrays with IN (SELECT ...).
+		return fmt.Sprintf("%s IN (SELECT unnest(%s::text[])::%s[])", colName, param, col.enumType)
+	case col.isDomain:
+		// the enum comparison operators are polymorphic over anyenum, which
+		// does not accept a domain, so the column side must be cast too. That
+		// forfeits a plain index on the column, but no index-friendly form
+		// exists: uncast, postgres reports "operator does not exist:
+		// my_domain = my_enum".
+		return fmt.Sprintf("%s::%s = ANY(%s::text[]::%s[])", colName, col.enumType, param, col.enumType)
+	default:
+		// the cast stays entirely on the parameter side, leaving the column
+		// side untouched so an index on it remains usable (verified: Index
+		// Cond: (col = ANY (('{...}'::text[])::my_enum[]))).
+		return fmt.Sprintf("%s = ANY(%s::text[]::%s[])", colName, param, col.enumType)
+	}
+}
+
+func (a *dmlAdapter) buildBulkDeleteSinglePK(events []*wal.Data, refCol wal.Column, tableName string, si schemaInfo) (*query, error) {
 	values := make([]any, 0, len(events))
 	for _, e := range events {
 		cols, err := a.getIdentityColumns(e)
@@ -139,8 +180,12 @@ func (a *dmlAdapter) buildBulkDeleteSinglePK(events []*wal.Data, refCol wal.Colu
 	}
 
 	colName := pglib.QuoteIdentifier(refCol.Name)
-	arrayType := pgArrayType(refCol.Type)
-	sql := fmt.Sprintf("DELETE FROM %s WHERE %s = ANY($1::%s)", tableName, colName, arrayType)
+	var sql string
+	if enumCol, isEnum := bindAsText(colName, si); isEnum {
+		sql = fmt.Sprintf("DELETE FROM %s WHERE %s", tableName, enumComparison(colName, enumCol, "$1"))
+	} else {
+		sql = fmt.Sprintf("DELETE FROM %s WHERE %s = ANY($1::%s)", tableName, colName, pgArrayType(refCol.Type))
+	}
 
 	return &query{
 		schema: events[0].Schema,
@@ -157,7 +202,15 @@ func (a *dmlAdapter) buildBulkDeleteSinglePK(events []*wal.Data, refCol wal.Colu
 //
 // One array parameter is bound per PK column, so the parameter count is
 // constant (numPKCols) regardless of how many rows are deleted.
-func (a *dmlAdapter) buildBulkDeleteCompositePK(events []*wal.Data, numPKCols int, tableName string) (*query, error) {
+//
+// Columns that must be bound as text[] (see bindAsText) are cast back inside
+// the unnest projection, which requires naming the unnest output columns:
+//
+//	DELETE FROM t WHERE (a,b) IN (SELECT c1,c2::my_enum FROM unnest($1::a[],$2::text[]) AS u(c1,c2))
+//
+// A domain over an enum additionally needs the column side cast, for the
+// anyenum reason described on enumComparison.
+func (a *dmlAdapter) buildBulkDeleteCompositePK(events []*wal.Data, numPKCols int, tableName string, si schemaInfo) (*query, error) {
 	// determine column names + types from the first event
 	firstCols, err := a.getIdentityColumns(events[0])
 	if err != nil {
@@ -166,11 +219,31 @@ func (a *dmlAdapter) buildBulkDeleteCompositePK(events []*wal.Data, numPKCols in
 
 	colNames := make([]string, numPKCols)
 	unnestArgs := make([]string, numPKCols)
+	unnestAliases := make([]string, numPKCols)
+	selectItems := make([]string, numPKCols)
+	needsCast := false
 	// one array per PK column, gathered across all events
 	colValues := make([][]any, numPKCols)
 	for i, c := range firstCols {
 		colNames[i] = pglib.QuoteIdentifier(c.Name)
-		unnestArgs[i] = fmt.Sprintf("$%d::%s", i+1, pgArrayType(c.Type))
+		unnestAliases[i] = fmt.Sprintf("c%d", i+1)
+		enumCol, isEnum := bindAsText(colNames[i], si)
+		switch {
+		case !isEnum:
+			unnestArgs[i] = fmt.Sprintf("$%d::%s", i+1, pgArrayType(c.Type))
+			selectItems[i] = unnestAliases[i]
+		default:
+			needsCast = true
+			unnestArgs[i] = fmt.Sprintf("$%d::text[]", i+1)
+			castType := enumCol.enumType
+			if enumCol.isArray {
+				castType += "[]"
+			}
+			selectItems[i] = fmt.Sprintf("%s::%s", unnestAliases[i], castType)
+			if enumCol.isDomain && !enumCol.isArray {
+				colNames[i] = fmt.Sprintf("%s::%s", colNames[i], enumCol.enumType)
+			}
+		}
 		colValues[i] = make([]any, 0, len(events))
 	}
 
@@ -189,10 +262,20 @@ func (a *dmlAdapter) buildBulkDeleteCompositePK(events []*wal.Data, numPKCols in
 		args[i] = colValues[i]
 	}
 
-	sql := fmt.Sprintf("DELETE FROM %s WHERE (%s) IN (SELECT * FROM unnest(%s))",
+	// only name the unnest output columns when a cast needs to reference them,
+	// so the emitted SQL is unchanged for tables without such columns.
+	unnestSelect := fmt.Sprintf("SELECT * FROM unnest(%s)", strings.Join(unnestArgs, ","))
+	if needsCast {
+		unnestSelect = fmt.Sprintf("SELECT %s FROM unnest(%s) AS u(%s)",
+			strings.Join(selectItems, ","),
+			strings.Join(unnestArgs, ","),
+			strings.Join(unnestAliases, ","))
+	}
+
+	sql := fmt.Sprintf("DELETE FROM %s WHERE (%s) IN (%s)",
 		tableName,
 		strings.Join(colNames, ","),
-		strings.Join(unnestArgs, ","))
+		unnestSelect)
 
 	return &query{
 		schema: events[0].Schema,

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter_bulk_test.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter_bulk_test.go
@@ -52,7 +52,7 @@ func TestBuildBulkDeleteQuery_SinglePK(t *testing.T) {
 		deleteEvent("public", "users", "id", "bigint", float64(3)),
 	}
 
-	queries, err := adapter.buildBulkDeleteQuery(events)
+	queries, err := adapter.buildBulkDeleteQuery(events, schemaInfo{})
 	require.NoError(t, err)
 	require.Len(t, queries, 1)
 
@@ -76,7 +76,7 @@ func TestBuildBulkDeleteQuery_SinglePK_UUID(t *testing.T) {
 		deleteEvent("public", "items", "id", "uuid", "550e8400-e29b-41d4-a716-446655440001"),
 	}
 
-	queries, err := adapter.buildBulkDeleteQuery(events)
+	queries, err := adapter.buildBulkDeleteQuery(events, schemaInfo{})
 	require.NoError(t, err)
 	require.Len(t, queries, 1)
 	require.Contains(t, queries[0].sql, "ANY($1::uuid[])")
@@ -100,7 +100,7 @@ func TestBuildBulkDeleteQuery_CompositePK(t *testing.T) {
 		}
 	}
 
-	queries, err := adapter.buildBulkDeleteQuery(events)
+	queries, err := adapter.buildBulkDeleteQuery(events, schemaInfo{})
 	require.NoError(t, err)
 	require.Len(t, queries, 1)
 
@@ -113,6 +113,221 @@ func TestBuildBulkDeleteQuery_CompositePK(t *testing.T) {
 		require.True(t, ok)
 		require.Len(t, values, 3) // one value per event
 	}
+}
+
+// Identity columns typed as a user-defined enum must be bound as text[] and
+// cast back on the target. pgx registers no codec for the database-specific
+// enum array OID, so binding the values against $1::asset_kind[] fails to
+// encode client-side with "unable to encode []interface {}{...} into text
+// format for unknown type", poisoning the whole batch.
+func TestBuildBulkDeleteQuery_SinglePK_Enum(t *testing.T) {
+	t.Parallel()
+
+	adapter := newTestDMLAdapter(t)
+
+	events := []*wal.Data{
+		deleteEvent("public", "asset", "kind", "asset_kind", "BiteScan"),
+		deleteEvent("public", "asset", "kind", "asset_kind", "UpperJawScan"),
+	}
+	si := schemaInfo{enumColumns: map[string]enumColumn{`"kind"`: {enumType: "public.asset_kind"}}}
+
+	queries, err := adapter.buildBulkDeleteQuery(events, si)
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+
+	q := queries[0]
+	require.Equal(t,
+		`DELETE FROM "public"."asset" WHERE "kind" = ANY($1::text[]::public.asset_kind[])`,
+		q.sql)
+	// the column side stays uncast so an index on it remains usable
+	require.NotContains(t, q.sql, `"kind"::`)
+	require.Equal(t, []any{[]any{"BiteScan", "UpperJawScan"}}, q.args)
+}
+
+// A composite PK mixing an enum column with regular ones: only the enum column
+// is bound as text[], and the cast is applied inside the unnest projection.
+func TestBuildBulkDeleteQuery_CompositePK_Enum(t *testing.T) {
+	t.Parallel()
+
+	adapter := newTestDMLAdapter(t)
+
+	events := []*wal.Data{
+		{
+			Action: "D", Schema: "public", Table: "asset",
+			Identity: []wal.Column{
+				{Name: "export_id", Type: "uuid", Value: "550e8400-e29b-41d4-a716-446655440000"},
+				{Name: "kind", Type: "asset_kind", Value: "BiteScan"},
+				{Name: "number", Type: "integer", Value: float64(1)},
+			},
+		},
+	}
+	si := schemaInfo{enumColumns: map[string]enumColumn{`"kind"`: {enumType: "public.asset_kind"}}}
+
+	queries, err := adapter.buildBulkDeleteQuery(events, si)
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+
+	q := queries[0]
+	require.Equal(t,
+		`DELETE FROM "public"."asset" WHERE ("export_id","kind","number") IN `+
+			`(SELECT c1,c2::public.asset_kind,c3 FROM unnest($1::uuid[],$2::text[],$3::int4[]) AS u(c1,c2,c3))`,
+		q.sql)
+	require.Equal(t, []any{
+		[]any{"550e8400-e29b-41d4-a716-446655440000"},
+		[]any{"BiteScan"},
+		[]any{float64(1)},
+	}, q.args)
+}
+
+// An array-of-enum identity column is reported in enumColumns too, and wal2json
+// delivers its value as a postgres array literal, so the same text[] binding
+// works with the array type as the cast target. It needs IN (SELECT ...) rather
+// than = ANY(ARRAY(...)), which unwraps an array level and leaves postgres
+// comparing asset_kind[] against asset_kind.
+func TestBuildBulkDeleteQuery_SinglePK_EnumArray(t *testing.T) {
+	t.Parallel()
+
+	adapter := newTestDMLAdapter(t)
+
+	events := []*wal.Data{
+		deleteEvent("public", "asset", "kinds", "asset_kind[]", "{BiteScan}"),
+	}
+	si := schemaInfo{enumColumns: map[string]enumColumn{`"kinds"`: {enumType: "public.asset_kind", isArray: true}}}
+
+	queries, err := adapter.buildBulkDeleteQuery(events, si)
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+	require.Equal(t,
+		`DELETE FROM "public"."asset" WHERE "kinds" IN (SELECT unnest($1::text[])::public.asset_kind[])`,
+		queries[0].sql)
+	require.Equal(t, []any{[]any{"{BiteScan}"}}, queries[0].args)
+}
+
+// A domain over an enum needs the *column* side cast as well: the enum
+// comparison operators are polymorphic over anyenum, which does not accept a
+// domain, so postgres rejects `my_domain = my_enum` with "operator does not
+// exist". Casting the column forfeits an index on it, but no index-friendly
+// form exists — and without this, every shape of delete on such a column fails,
+// including the per-row form that predates bulk coalescing.
+func TestBuildBulkDeleteQuery_SinglePK_DomainOverEnum(t *testing.T) {
+	t.Parallel()
+
+	adapter := newTestDMLAdapter(t)
+
+	events := []*wal.Data{
+		deleteEvent("public", "asset", "kind", "kind_dom", "BiteScan"),
+	}
+	si := schemaInfo{enumColumns: map[string]enumColumn{
+		`"kind"`: {enumType: "public.asset_kind", isDomain: true},
+	}}
+
+	queries, err := adapter.buildBulkDeleteQuery(events, si)
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+	require.Equal(t,
+		`DELETE FROM "public"."asset" WHERE "kind"::public.asset_kind = ANY($1::text[]::public.asset_kind[])`,
+		queries[0].sql)
+}
+
+// A domain over an array of enums compares as a whole array, like a plain enum
+// array — the column side needs no cast because the comparison is against
+// my_enum[] rather than the polymorphic anyenum.
+func TestBuildBulkDeleteQuery_SinglePK_DomainOverEnumArray(t *testing.T) {
+	t.Parallel()
+
+	adapter := newTestDMLAdapter(t)
+
+	events := []*wal.Data{
+		deleteEvent("public", "asset", "kinds", "kind_arr_dom", "{BiteScan}"),
+	}
+	si := schemaInfo{enumColumns: map[string]enumColumn{
+		`"kinds"`: {enumType: "public.asset_kind", isArray: true, isDomain: true},
+	}}
+
+	queries, err := adapter.buildBulkDeleteQuery(events, si)
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+	require.Equal(t,
+		`DELETE FROM "public"."asset" WHERE "kinds" IN (SELECT unnest($1::text[])::public.asset_kind[])`,
+		queries[0].sql)
+}
+
+// The composite path casts the column side for a domain too, inside the row
+// constructor.
+func TestBuildBulkDeleteQuery_CompositePK_DomainOverEnum(t *testing.T) {
+	t.Parallel()
+
+	adapter := newTestDMLAdapter(t)
+
+	events := []*wal.Data{
+		{
+			Action: "D", Schema: "public", Table: "asset",
+			Identity: []wal.Column{
+				{Name: "id", Type: "integer", Value: float64(1)},
+				{Name: "kind", Type: "kind_dom", Value: "BiteScan"},
+			},
+		},
+	}
+	si := schemaInfo{enumColumns: map[string]enumColumn{
+		`"kind"`: {enumType: "public.asset_kind", isDomain: true},
+	}}
+
+	queries, err := adapter.buildBulkDeleteQuery(events, si)
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+	require.Equal(t,
+		`DELETE FROM "public"."asset" WHERE ("id","kind"::public.asset_kind) IN `+
+			`(SELECT c1,c2::public.asset_kind FROM unnest($1::int4[],$2::text[]) AS u(c1,c2))`,
+		queries[0].sql)
+}
+
+// The cast target comes from the target catalog, never from the column type
+// carried by the replication stream — which for a kafka source is unvalidated
+// input. A hostile type string must not reach the generated SQL.
+func TestBuildBulkDeleteQuery_CastTargetIgnoresStreamType(t *testing.T) {
+	t.Parallel()
+
+	adapter := newTestDMLAdapter(t)
+
+	events := []*wal.Data{
+		deleteEvent("public", "asset", "kind", `asset_kind)) OR true --`, "BiteScan"),
+	}
+	si := schemaInfo{enumColumns: map[string]enumColumn{
+		`"kind"`: {enumType: "public.asset_kind"},
+	}}
+
+	queries, err := adapter.buildBulkDeleteQuery(events, si)
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+	require.Equal(t,
+		`DELETE FROM "public"."asset" WHERE "kind" = ANY($1::text[]::public.asset_kind[])`,
+		queries[0].sql)
+	require.NotContains(t, queries[0].sql, "OR true")
+}
+
+// Tables with no enum identity columns must emit exactly the SQL they did
+// before: no unnest aliases, no casts.
+func TestBuildBulkDeleteQuery_CompositePK_NoEnumUnchanged(t *testing.T) {
+	t.Parallel()
+
+	adapter := newTestDMLAdapter(t)
+
+	events := []*wal.Data{
+		{
+			Action: "D", Schema: "public", Table: "orders",
+			Identity: []wal.Column{
+				{Name: "user_id", Type: "bigint", Value: float64(1)},
+				{Name: "order_id", Type: "bigint", Value: float64(10)},
+			},
+		},
+	}
+
+	queries, err := adapter.buildBulkDeleteQuery(events, schemaInfo{enumColumns: map[string]enumColumn{`"other"`: {enumType: "public.asset_kind"}}})
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+	require.Equal(t,
+		`DELETE FROM "public"."orders" WHERE ("user_id","order_id") IN (SELECT * FROM unnest($1::int8[],$2::int8[]))`,
+		queries[0].sql)
 }
 
 // A large composite-PK delete must stay a single query with a constant
@@ -142,7 +357,7 @@ func TestBuildBulkDeleteQuery_CompositePK_LargeBatch(t *testing.T) {
 		}
 	}
 
-	queries, err := adapter.buildBulkDeleteQuery(events)
+	queries, err := adapter.buildBulkDeleteQuery(events, schemaInfo{})
 	require.NoError(t, err)
 	require.Len(t, queries, 1, "unnest form needs no splitting")
 
@@ -168,7 +383,7 @@ func TestBuildBulkDeleteQuery_NullIdentity(t *testing.T) {
 		deleteEvent("public", "t", "id", "bigint", float64(3)),
 	}
 
-	queries, err := adapter.buildBulkDeleteQuery(events)
+	queries, err := adapter.buildBulkDeleteQuery(events, schemaInfo{})
 	require.NoError(t, err)
 
 	// should have 2 queries: 1 bulk for non-null, 1 individual for null
@@ -204,7 +419,7 @@ func TestBuildBulkDeleteQuery_NoIdentity(t *testing.T) {
 		},
 	}
 
-	_, err := adapter.buildBulkDeleteQuery(events)
+	_, err := adapter.buildBulkDeleteQuery(events, schemaInfo{})
 	require.Error(t, err)
 }
 
@@ -213,7 +428,7 @@ func TestBuildBulkDeleteQuery_Empty(t *testing.T) {
 
 	adapter := newTestDMLAdapter(t)
 
-	queries, err := adapter.buildBulkDeleteQuery(nil)
+	queries, err := adapter.buildBulkDeleteQuery(nil, schemaInfo{})
 	require.NoError(t, err)
 	require.Nil(t, queries)
 }
@@ -246,7 +461,7 @@ func TestBuildBulkDeleteQuery_InternalColIDs(t *testing.T) {
 		},
 	}
 
-	queries, err := adapter.buildBulkDeleteQuery(events)
+	queries, err := adapter.buildBulkDeleteQuery(events, schemaInfo{})
 	require.NoError(t, err)
 	require.Len(t, queries, 1)
 	require.Contains(t, queries[0].sql, "ANY")
@@ -318,7 +533,7 @@ func TestBuildBulkInsertQueries_NeedsTextCopy(t *testing.T) {
 	tests := []struct {
 		name        string
 		events      []*wal.Data
-		enumColumns map[string]struct{}
+		enumColumns map[string]enumColumn
 
 		wantNeedsTextCopy bool
 	}{
@@ -331,13 +546,13 @@ func TestBuildBulkInsertQueries_NeedsTextCopy(t *testing.T) {
 		{
 			name:              "enum column in the batch",
 			events:            newEvents("mood"),
-			enumColumns:       map[string]struct{}{`"mood"`: {}},
+			enumColumns:       map[string]enumColumn{`"mood"`: {enumType: "public.mood"}},
 			wantNeedsTextCopy: true,
 		},
 		{
 			name:              "enum column of another table only",
 			events:            newEvents("text"),
-			enumColumns:       map[string]struct{}{`"status"`: {}},
+			enumColumns:       map[string]enumColumn{`"status"`: {enumType: "public.status"}},
 			wantNeedsTextCopy: false,
 		},
 		{

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter_test.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter_test.go
@@ -921,7 +921,7 @@ func Test_needsTextCopyForColumns(t *testing.T) {
 		name        string
 		columnNames []string
 		columnTypes []string
-		enumColumns map[string]struct{}
+		enumColumns map[string]enumColumn
 
 		want bool
 	}{
@@ -943,14 +943,14 @@ func Test_needsTextCopyForColumns(t *testing.T) {
 			name:        "enum column",
 			columnNames: []string{`"id"`, `"mood"`},
 			columnTypes: []string{"integer", "mood"},
-			enumColumns: map[string]struct{}{`"mood"`: {}},
+			enumColumns: map[string]enumColumn{`"mood"`: {enumType: "public.mood"}},
 			want:        true,
 		},
 		{
 			name:        "enum type present but column filtered out",
 			columnNames: []string{`"id"`},
 			columnTypes: []string{"integer"},
-			enumColumns: map[string]struct{}{`"mood"`: {}},
+			enumColumns: map[string]enumColumn{`"mood"`: {enumType: "public.mood"}},
 			want:        false,
 		},
 	}

--- a/pkg/wal/processor/postgres/postgres_writer.go
+++ b/pkg/wal/processor/postgres/postgres_writer.go
@@ -127,11 +127,18 @@ func (w *Writer) initMetrics() error {
 
 // recordDroppedQuery accounts for a single query dropped due to a non-internal
 // (DATALOSS) failure and logs the divergence prominently.
-func (w *Writer) recordDroppedQuery(q *query) {
+// recordDroppedQuery reports a query the writer gave up on. cause is what made
+// it undeliverable: without it the DATALOSS warning says what diverged but not
+// why, leaving an operator to correlate by timestamp against the error logged
+// where the query failed. schema and table are surfaced as their own fields so
+// the diverging table can be alerted on without parsing the SQL.
+func (w *Writer) recordDroppedQuery(q *query, cause error) {
 	dropped := w.droppedQueries.Add(1)
-	w.logger.Warn(nil, "dropping failed query and advancing checkpoint, replica may diverge", loglib.Fields{
+	w.logger.Warn(cause, "dropping failed query and advancing checkpoint, replica may diverge", loglib.Fields{
 		"sql":             q.sql,
 		"args":            q.args,
+		"schema":          q.schema,
+		"table":           q.table,
 		"severity":        "DATALOSS",
 		"dropped_queries": dropped,
 	})


### PR DESCRIPTION
#### Description

Replicated `DELETE`s on tables whose replica identity contains a user-defined enum column always failed to encode, and the failure took down the whole batch. The enum fix (#1035) covered the snapshot bulk-ingest COPY path only.

Identity values for enum columns are now bound as `text[]` and cast back on the target. Cast targets are resolved from the **target catalog** (the enum itself, through the array element type and the domain base type), not from the column type carried by the replication stream. Casting to the column's declared type is not equivalent: the enum comparison operators are polymorphic over `anyenum`, which does not accept a domain, so `dom = dom` has no operator while `dom::the_enum = the_enum` does.

The error was also misclassified. Being client-side it carries no SQLSTATE, so `isInternalError` treated it as internal, skipping the drop-one-query-and-retry path — with `ignore_send_errors: true` the entire batch was dropped, including co-batched writes to unrelated tables. It is now a typed `ErrValueEncoding`, non-internal in the writer and non-retriable in the retrier.

##### Related Issue(s)

  - Fixes #1037

  #### Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] 📚 Documentation update
  - [ ] 🔧 Refactoring (no functional changes)
  - [ ] ⚡ Performance improvement
  - [ ] 🧪 Test coverage improvement
  - [ ] 🔨 Build/CI changes
  - [ ] 🧹 Code cleanup

  #### Changes Made

  - `enumTableColumnsQuery` now returns, per enum-resolving column, the quoted schema-qualified enum type plus `isArray`/`isDomain`; `schemaInfo.enumColumns` carries that instead of a bare name set.
  - Bulk DELETE emits the shape each column needs, all verified against a live PostgreSQL: `= ANY($1::text[]::enum[])` for a scalar enum (keeps the index — `Index Cond: (col = ANY (...))`), `IN (SELECT unnest($1::text[])::enum[])` for an enum array, and an additional
  column-side cast for a domain over an enum. Tables with no enum identity column emit byte-identical SQL to before.
  - Fixes a pre-existing gap: deletes on a domain-over-enum column failed on **every** path, including the per-row form, with `operator does not exist: dom = dom`.
  - New `pglib.ErrValueEncoding`, recognised in `MapError` after the `PgError` switch (a client-side failure can never carry a SQLSTATE, and checking first could shadow a real one, since postgres embeds row values in messages). `Details` keeps only pgx's prefix — pgx
  formats the offending argument with `%#v`, which for a bulk delete is every identity value in the batch, and that string reaches logs and OTel spans.
  - Added to `isRetriableError`. The default policy sets neither `MaxRetries` nor `MaxElapsedTime`, so a deterministic encode failure would otherwise retry forever with a connection-pool reset per attempt, and the drop-one-query recovery would never be reached.

  #### Testing

  - [x] Unit tests added/updated
  - [x] Integration tests added/updated
  - [x] Manual testing performed
  - [x] All existing tests pass

  #### Checklist

  - [x] Code follows project style guidelines
  - [x] Self-review completed
  - [x] Code is well-commented
  - [x] Documentation updated where necessary