### PR TITLE
Add a counter for batches dropped by ignore_send_errors

### DIFF
--- a/pkg/stream/integration/helper_test.go
+++ b/pkg/stream/integration/helper_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/xataio/pgstream/pkg/backoff"
 	kafkalib "github.com/xataio/pgstream/pkg/kafka"
 	loglib "github.com/xataio/pgstream/pkg/log"
+	"github.com/xataio/pgstream/pkg/otel"
 	pgsnapshotgenerator "github.com/xataio/pgstream/pkg/snapshot/generator/postgres/data"
 	"github.com/xataio/pgstream/pkg/snapshot/generator/postgres/schema/pgdumprestore"
 	"github.com/xataio/pgstream/pkg/stream"
@@ -101,10 +102,17 @@ func (m *mockWebhookServer) close() {
 
 func runStream(t *testing.T, ctx context.Context, cfg *stream.Config) {
 	t.Helper()
+	runStreamWithInstrumentation(t, ctx, cfg, nil)
+}
+
+// runStreamWithInstrumentation runs the stream with metrics wired up, so that
+// tests can observe what the pipeline exports while it is running.
+func runStreamWithInstrumentation(t *testing.T, ctx context.Context, cfg *stream.Config, instrumentation *otel.Instrumentation) {
+	t.Helper()
 
 	done := make(chan error, 1)
 	go func() {
-		done <- stream.Run(ctx, testLogger(), cfg, false, nil)
+		done <- stream.Run(ctx, testLogger(), cfg, false, instrumentation)
 	}()
 
 	t.Cleanup(func() {
@@ -354,6 +362,14 @@ func withStrictMode() option {
 	return func(cfg *stream.ProcessorConfig) {
 		if cfg.Postgres != nil {
 			cfg.Postgres.BatchWriter.StrictMode = true
+		}
+	}
+}
+
+func withIgnoreSendErrors() option {
+	return func(cfg *stream.ProcessorConfig) {
+		if cfg.Postgres != nil {
+			cfg.Postgres.BatchWriter.BatchConfig.IgnoreSendErrors = true
 		}
 	}
 }

--- a/pkg/stream/integration/pg_pg_dropped_batch_metrics_integration_test.go
+++ b/pkg/stream/integration/pg_pg_dropped_batch_metrics_integration_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/pkg/otel"
+	"github.com/xataio/pgstream/pkg/stream"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// the exported names are a contract with whatever scrapes them, so the test
+// spells them out rather than reaching for the constants in the batch package
+const (
+	droppedBatchesMetric  = "pgstream.batch.sender.dropped_batches"
+	droppedMessagesMetric = "pgstream.batch.sender.dropped_messages"
+)
+
+// Test_PostgresToPostgres_DroppedBatchMetrics observes what a running pipeline
+// exports when ignore_send_errors discards a batch. The target is seeded with a
+// row the replicated insert collides with: strict mode turns the duplicate key
+// into a batch send failure, and ignore_send_errors drops the batch rather than
+// stopping the pipeline. That silent loss is only visible through these
+// counters, so the test asserts on them while the stream is still running.
+func Test_PostgresToPostgres_DroppedBatchMetrics(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	reader, instrumentation := testMetricsInstrumentation()
+
+	cfg := &stream.Config{
+		Listener:  testPostgresListenerCfg(t),
+		Processor: testPostgresProcessorCfg(withStrictMode(), withIgnoreSendErrors()),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runStreamWithInstrumentation(t, ctx, cfg, instrumentation)
+
+	testTable := "pg2pg_dropped_batch_metrics_test"
+
+	targetConn, err := pglib.NewConn(ctx, targetPGURL)
+	require.NoError(t, err)
+	defer targetConn.Close(ctx)
+
+	execQuery(t, ctx, fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, name text)", testTable))
+	defer execQuery(t, ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", testTable))
+
+	require.Eventually(t, func() bool {
+		return len(getInformationSchemaColumns(t, ctx, targetConn, testTable)) == 2
+	}, 20*time.Second, 200*time.Millisecond, "table schema not replicated")
+
+	// nothing has failed to send yet, so the counters are exported at zero
+	// rather than being absent
+	dropped := collectDroppedBatchMetrics(t, ctx, reader)
+	require.Equal(t, int64(0), dropped[droppedBatchesMetric].value)
+	require.Equal(t, int64(0), dropped[droppedMessagesMetric].value)
+
+	// seed the row the replicated insert cannot be written over
+	execQueryWithURL(t, ctx, targetPGURL, fmt.Sprintf(
+		"INSERT INTO %s(id, name) VALUES (1, 'stale-target-row')", testTable))
+
+	execQuery(t, ctx, fmt.Sprintf("INSERT INTO %s(id, name) VALUES (1, 'source-row')", testTable))
+
+	require.Eventually(t, func() bool {
+		dropped = collectDroppedBatchMetrics(t, ctx, reader)
+		return dropped[droppedBatchesMetric].value > 0
+	}, 30*time.Second, 200*time.Millisecond, "dropped batch counters were never incremented")
+
+	// the batch size is 1, so the failed insert is a batch of exactly one
+	// message, and both counters have to agree on that
+	require.Equal(t, int64(1), dropped[droppedBatchesMetric].value)
+	require.Equal(t, int64(1), dropped[droppedMessagesMetric].value)
+
+	// the label has to name the writer that dropped, so a run with several
+	// writers can be told apart
+	require.Equal(t, batchWriterType, dropped[droppedBatchesMetric].writerType)
+	require.Equal(t, batchWriterType, dropped[droppedMessagesMetric].writerType)
+
+	// the source row is gone: it was never written, which is the loss the
+	// counters are reporting
+	var count int
+	require.NoError(t, targetConn.QueryRow(ctx, []any{&count},
+		fmt.Sprintf("SELECT count(*) FROM %s WHERE name = 'source-row'", testTable)))
+	require.Zero(t, count, "the dropped row must not have reached the target")
+
+	// dropping the batch left the pipeline running: the next insert replicates
+	execQuery(t, ctx, fmt.Sprintf("INSERT INTO %s(id, name) VALUES (2, 'after-drop')", testTable))
+	require.Eventually(t, func() bool {
+		var name string
+		if err := targetConn.QueryRow(ctx, []any{&name},
+			fmt.Sprintf("SELECT name FROM %s WHERE id = 2", testTable)); err != nil {
+			return false
+		}
+		return name == "after-drop"
+	}, 30*time.Second, 200*time.Millisecond, "pipeline stopped replicating after the dropped batch")
+
+	// and a successful send does not move the counters
+	dropped = collectDroppedBatchMetrics(t, ctx, reader)
+	require.Equal(t, int64(1), dropped[droppedBatchesMetric].value)
+	require.Equal(t, int64(1), dropped[droppedMessagesMetric].value)
+}
+
+const batchWriterType = "postgres_batch_writer"
+
+// testMetricsInstrumentation returns instrumentation backed by a manual reader,
+// so a test can collect the exported metrics on demand.
+func testMetricsInstrumentation() (*sdkmetric.ManualReader, *otel.Instrumentation) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	return reader, &otel.Instrumentation{Meter: provider.Meter("integration_test")}
+}
+
+type droppedMetric struct {
+	value      int64
+	writerType string
+}
+
+// collectDroppedBatchMetrics reads the drop counters exported by the batch
+// senders. Collect runs their observable callbacks, so the values are the ones
+// the pipeline holds at this instant.
+func collectDroppedBatchMetrics(t *testing.T, ctx context.Context, reader *sdkmetric.ManualReader) map[string]droppedMetric {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	metrics := map[string]droppedMetric{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != droppedBatchesMetric && m.Name != droppedMessagesMetric {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "metric %s is not an int64 sum", m.Name)
+			require.Len(t, sum.DataPoints, 1, "metric %s has more than one writer reporting", m.Name)
+
+			writerType, found := sum.DataPoints[0].Attributes.Value("writer_type")
+			require.True(t, found, "metric %s is missing the writer_type attribute", m.Name)
+			metrics[m.Name] = droppedMetric{
+				value:      sum.DataPoints[0].Value,
+				writerType: writerType.AsString(),
+			}
+		}
+	}
+
+	require.Contains(t, metrics, droppedBatchesMetric, "%s was not exported", droppedBatchesMetric)
+	require.Contains(t, metrics, droppedMessagesMetric, "%s was not exported", droppedMessagesMetric)
+	return metrics
+}

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -80,6 +80,7 @@ func buildProcessor(ctx context.Context, logger loglib.Logger, config *Processor
 			pgreplication.NewLSNParser(),
 			search.WithCheckpoint(checkpoint),
 			search.WithLogger(logger),
+			search.WithInstrumentation(instrumentation),
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/wal/processor/batch/wal_batch_dropped_counter.go
+++ b/pkg/wal/processor/batch/wal_batch_dropped_counter.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package batch
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	loglib "github.com/xataio/pgstream/pkg/log"
+	"github.com/xataio/pgstream/pkg/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// DroppedCounter accumulates what ignore_send_errors has silently discarded.
+type DroppedCounter struct {
+	batches  atomic.Uint64
+	messages atomic.Uint64
+}
+
+func NewDroppedCounter() *DroppedCounter {
+	return &DroppedCounter{}
+}
+
+func (c *DroppedCounter) record(messages uint64) (uint64, uint64) {
+	if c == nil {
+		return 0, 0
+	}
+	return c.batches.Add(1), c.messages.Add(messages)
+}
+
+// Batches returns the number of batches silently discarded because
+// ignore_send_errors is enabled. It stays at zero otherwise.
+func (c *DroppedCounter) Batches() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.batches.Load()
+}
+
+// Messages returns the number of messages lost with the batches counted by
+// Batches.
+func (c *DroppedCounter) Messages() uint64 {
+	if c == nil {
+		return 0
+	}
+	return c.messages.Load()
+}
+
+// LogTotals reports what was dropped, once, at shutdown.
+func (c *DroppedCounter) LogTotals(logger loglib.Logger) {
+	batches := c.Batches()
+	if batches == 0 {
+		return
+	}
+	logger.Error(nil, "closed with dropped batches", loglib.Fields{
+		"severity":         "DATALOSS",
+		"dropped_batches":  batches,
+		"dropped_messages": c.Messages(),
+	})
+}
+
+const (
+	droppedBatchesMetricName  = "pgstream.batch.sender.dropped_batches"
+	droppedMessagesMetricName = "pgstream.batch.sender.dropped_messages"
+)
+
+// RegisterMetrics exports the counter as two observable counters, labelled with
+// the writer that owns it.
+func (c *DroppedCounter) RegisterMetrics(i *otel.Instrumentation, writerType string) error {
+	if i == nil || i.Meter == nil {
+		return nil
+	}
+	meter := i.Meter
+
+	droppedBatches, err := meter.Int64ObservableCounter(droppedBatchesMetricName,
+		metric.WithUnit("{batch}"),
+		metric.WithDescription("Number of batches silently dropped by the batch sender because ignore_send_errors is enabled"))
+	if err != nil {
+		return fmt.Errorf("creating %s counter: %w", droppedBatchesMetricName, err)
+	}
+
+	droppedMessages, err := meter.Int64ObservableCounter(droppedMessagesMetricName,
+		metric.WithUnit("{message}"),
+		metric.WithDescription("Number of messages lost with the batches counted by "+droppedBatchesMetricName))
+	if err != nil {
+		return fmt.Errorf("creating %s counter: %w", droppedMessagesMetricName, err)
+	}
+
+	_, err = meter.RegisterCallback(
+		func(_ context.Context, o metric.Observer) error {
+			attrs := metric.WithAttributes(attribute.String("writer_type", writerType))
+			o.ObserveInt64(droppedBatches, int64(c.Batches()), attrs)
+			o.ObserveInt64(droppedMessages, int64(c.Messages()), attrs)
+			return nil
+		},
+		droppedBatches, droppedMessages,
+	)
+	if err != nil {
+		return fmt.Errorf("registering batch sender dropped counters: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/wal/processor/batch/wal_batch_dropped_counter_test.go
+++ b/pkg/wal/processor/batch/wal_batch_dropped_counter_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package batch
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/pkg/log"
+	"github.com/xataio/pgstream/pkg/otel"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestDroppedCounter_record(t *testing.T) {
+	t.Parallel()
+
+	c := NewDroppedCounter()
+	require.Equal(t, uint64(0), c.Batches())
+	require.Equal(t, uint64(0), c.Messages())
+
+	batches, messages := c.record(10)
+	require.Equal(t, uint64(1), batches)
+	require.Equal(t, uint64(10), messages)
+
+	batches, messages = c.record(5)
+	require.Equal(t, uint64(2), batches)
+	require.Equal(t, uint64(15), messages)
+
+	require.Equal(t, uint64(2), c.Batches())
+	require.Equal(t, uint64(15), c.Messages())
+}
+
+func TestDroppedCounter_record_concurrent(t *testing.T) {
+	t.Parallel()
+
+	// the drainer pool records concurrently, and the totals returned by record
+	// are what the per-drop log line reports: every caller must see a distinct
+	// batch total, or two log lines claim the same drop
+	const senders, drops = 8, 50
+
+	c := NewDroppedCounter()
+	seen := make(chan uint64, senders*drops)
+
+	wg := sync.WaitGroup{}
+	for range senders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range drops {
+				batches, _ := c.record(2)
+				seen <- batches
+			}
+		}()
+	}
+	wg.Wait()
+	close(seen)
+
+	require.Equal(t, uint64(senders*drops), c.Batches())
+	require.Equal(t, uint64(senders*drops*2), c.Messages())
+
+	totals := map[uint64]struct{}{}
+	for total := range seen {
+		require.NotContains(t, totals, total, "two callers reported the same running total")
+		totals[total] = struct{}{}
+	}
+	require.Len(t, totals, senders*drops)
+}
+
+func TestDroppedCounter_LogTotals(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nothing dropped stays silent", func(t *testing.T) {
+		t.Parallel()
+		NewDroppedCounter().LogTotals(log.NewNoopLogger())
+	})
+
+	t.Run("drops are reported", func(t *testing.T) {
+		t.Parallel()
+		c := NewDroppedCounter()
+		c.record(3)
+		c.LogTotals(log.NewNoopLogger())
+		require.Equal(t, uint64(1), c.Batches())
+	})
+}
+
+func TestDroppedCounter_RegisterMetrics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no instrumentation is a no-op", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, NewDroppedCounter().RegisterMetrics(nil, "test_writer"))
+		require.NoError(t, NewDroppedCounter().RegisterMetrics(&otel.Instrumentation{}, "test_writer"))
+	})
+
+	t.Run("counters are exported with the writer type", func(t *testing.T) {
+		t.Parallel()
+
+		reader := metric.NewManualReader()
+		provider := metric.NewMeterProvider(metric.WithReader(reader))
+		instrumentation := &otel.Instrumentation{Meter: provider.Meter("test")}
+
+		c := NewDroppedCounter()
+		require.NoError(t, c.RegisterMetrics(instrumentation, "postgres_bulk_ingest_writer"))
+
+		c.record(25000)
+		c.record(25000)
+
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(context.Background(), &rm))
+
+		got := map[string]int64{}
+		attrs := map[string]string{}
+		for _, sm := range rm.ScopeMetrics {
+			for _, m := range sm.Metrics {
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				require.True(t, ok, "metric %s is not an int64 sum", m.Name)
+				require.Len(t, sum.DataPoints, 1)
+				got[m.Name] = sum.DataPoints[0].Value
+				writerType, found := sum.DataPoints[0].Attributes.Value("writer_type")
+				require.True(t, found, "metric %s is missing the writer_type attribute", m.Name)
+				attrs[m.Name] = writerType.AsString()
+			}
+		}
+
+		require.Equal(t, int64(2), got[droppedBatchesMetricName])
+		require.Equal(t, int64(50000), got[droppedMessagesMetricName])
+		require.Equal(t, "postgres_bulk_ingest_writer", attrs[droppedBatchesMetricName])
+		require.Equal(t, "postgres_bulk_ingest_writer", attrs[droppedMessagesMetricName])
+	})
+}

--- a/pkg/wal/processor/batch/wal_batch_sender.go
+++ b/pkg/wal/processor/batch/wal_batch_sender.go
@@ -27,6 +27,12 @@ type Sender[T Message] struct {
 	sendErr          error
 	ignoreSendErrors bool
 
+	// dropped accumulates what ignoreSendErrors has silently discarded. It is
+	// usually supplied by the owning writer and shared with its other senders,
+	// so the totals and the exported metrics cover the writer rather than one
+	// table. A sender built without one keeps its own.
+	dropped *DroppedCounter
+
 	maxBatchBytes     int64
 	maxBatchSize      int64
 	batchSendInterval time.Duration
@@ -43,8 +49,22 @@ type sendBatchFn[T Message] func(context.Context, *Batch[T]) error
 
 var errSendStopped = errors.New("stop processing, sending has stopped")
 
-func NewSender[T Message](ctx context.Context, config *Config, sendfn sendBatchFn[T], logger loglib.Logger) (*Sender[T], error) {
+type Option[T Message] func(*Sender[T])
+
+// WithDroppedCounter shares the owning writer's counter with this sender, so
+// the drop totals and the metrics derived from them span every sender the
+// writer builds rather than a single table's.
+func WithDroppedCounter[T Message](c *DroppedCounter) Option[T] {
+	return func(s *Sender[T]) {
+		if c != nil {
+			s.dropped = c
+		}
+	}
+}
+
+func NewSender[T Message](ctx context.Context, config *Config, sendfn sendBatchFn[T], logger loglib.Logger, opts ...Option[T]) (*Sender[T], error) {
 	s := &Sender[T]{
+		dropped:           NewDroppedCounter(),
 		batchSendInterval: config.GetBatchTimeout(),
 		maxBatchBytes:     config.GetMaxBatchBytes(),
 		maxBatchSize:      config.GetMaxBatchSize(),
@@ -254,10 +274,11 @@ func (s *Sender[T]) startSendDrainers(batchChan chan *Batch[T]) (*sync.WaitGroup
 				err := s.sendBatch(context.Background(), batch)
 				s.queueBytesSema.Release(int64(batch.totalBytes))
 				if err != nil {
-					s.logger.Error(err, "failed to send batch")
 					if s.ignoreSendErrors {
+						s.recordDroppedBatch(err, batch)
 						continue
 					}
+					s.logger.Error(err, "failed to send batch")
 					s.recordSendErr(err)
 					sendErrChan <- err
 					return
@@ -283,10 +304,11 @@ func (s *Sender[T]) startSendDrainers(batchChan chan *Batch[T]) (*sync.WaitGroup
 				err := s.sendBatch(sendCtx, batch)
 				s.queueBytesSema.Release(int64(batch.totalBytes))
 				if err != nil {
-					s.logger.Error(err, "failed to send batch")
 					if s.ignoreSendErrors {
+						s.recordDroppedBatch(err, batch)
 						continue
 					}
+					s.logger.Error(err, "failed to send batch")
 					firstErr.Do(func() {
 						s.recordSendErr(err)
 						// abort in-flight COPYs in the other drainers
@@ -322,6 +344,22 @@ func (s *Sender[T]) Close() error {
 		return nil
 	}
 	return sendErr
+}
+
+// recordDroppedBatch accounts for a batch discarded by ignoreSendErrors and
+// logs it as data loss. The DATALOSS severity matches the convention used at
+// every other silent-loss site in the codebase, so a single alert rule keyed on
+// it covers them all.
+func (s *Sender[T]) recordDroppedBatch(err error, batch *Batch[T]) {
+	msgCount := len(batch.GetMessages())
+	batches, messages := s.dropped.record(uint64(msgCount))
+	s.logger.Error(err, "failed to send batch: dropping it and continuing", loglib.Fields{
+		"severity":         "DATALOSS",
+		"batch_messages":   msgCount,
+		"batch_bytes":      batch.totalBytes,
+		"dropped_batches":  batches,
+		"dropped_messages": messages,
+	})
 }
 
 func (s *Sender[T]) recordSendErr(err error) {

--- a/pkg/wal/processor/batch/wal_batch_sender.go
+++ b/pkg/wal/processor/batch/wal_batch_sender.go
@@ -79,6 +79,10 @@ func NewSender[T Message](ctx context.Context, config *Config, sendfn sendBatchF
 		sendConcurrency:   config.GetSendConcurrency(),
 	}
 
+	for _, opt := range opts {
+		opt(s)
+	}
+
 	if config.AutoTune.Enabled {
 		// The batch bytes auto-tuner relies on a per-batch serial-timing model
 		// that is corrupted by concurrent sends, so it is incompatible with a

--- a/pkg/wal/processor/batch/wal_batch_sender_test.go
+++ b/pkg/wal/processor/batch/wal_batch_sender_test.go
@@ -740,6 +740,35 @@ func TestNewSender_autoTuneDisabledWithConcurrency(t *testing.T) {
 	})
 }
 
+// TestNewSender_WithDroppedCounter covers the wiring rather than the counting:
+// a sender that records into a counter of its own still logs every drop, so
+// only the writer's totals and the metrics derived from them go missing, and
+// they are permanently zero rather than absent.
+func TestNewSender_WithDroppedCounter(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	noopSendFn := func(context.Context, *Batch[*mockMessage]) error { return nil }
+
+	t.Run("the owning writer's counter is used", func(t *testing.T) {
+		t.Parallel()
+		counter := NewDroppedCounter()
+		sender, err := NewSender(ctx, &Config{}, noopSendFn, log.NewNoopLogger(),
+			WithDroppedCounter[*mockMessage](counter))
+		require.NoError(t, err)
+		defer sender.Close()
+		require.Same(t, counter, sender.dropped)
+	})
+
+	t.Run("a sender built without one keeps its own", func(t *testing.T) {
+		t.Parallel()
+		sender, err := NewSender(ctx, &Config{}, noopSendFn, log.NewNoopLogger())
+		require.NoError(t, err)
+		defer sender.Close()
+		require.NotNil(t, sender.dropped)
+	})
+}
+
 func TestConfig_GetSendConcurrency(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/wal/processor/batch/wal_batch_sender_test.go
+++ b/pkg/wal/processor/batch/wal_batch_sender_test.go
@@ -319,6 +319,7 @@ func TestSender_send(t *testing.T) {
 				wg:                &sync.WaitGroup{},
 				cancelFn:          func() {},
 				ignoreSendErrors:  tc.ignoreErrors,
+				dropped:           NewDroppedCounter(),
 			}
 			defer sender.Close()
 
@@ -353,6 +354,60 @@ func TestSender_send(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("send errors ignored, dropped batches counted", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+
+		doneChan := make(chan struct{}, 1)
+		defer close(doneChan)
+
+		once := sync.Once{}
+		sender := &Sender[*mockMessage]{
+			batchSendInterval: 100 * time.Millisecond,
+			maxBatchSize:      10,
+			msgChan:           make(chan *WALMessage[*mockMessage]),
+			queueBytesSema:    &syncmocks.WeightedSemaphore{ReleaseFn: func(uint64, int64) {}},
+			sendDone:          make(chan struct{}),
+			once:              &sync.Once{},
+			logger:            log.NewNoopLogger(),
+			sendBatchFn: func(ctx context.Context, b *Batch[*mockMessage]) error {
+				defer once.Do(func() { doneChan <- struct{}{} })
+				return errTest
+			},
+			wg:               &sync.WaitGroup{},
+			cancelFn:         func() {},
+			ignoreSendErrors: true,
+			dropped:          NewDroppedCounter(),
+		}
+		defer sender.Close()
+
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := sender.send(ctx)
+			require.ErrorIs(t, err, context.Canceled)
+		}()
+
+		sender.msgChan <- testWALMsg(1)
+
+		select {
+		case <-doneChan:
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for the batch to be sent")
+		}
+		// cancel and wait for send to return: it closes the batch channel and
+		// waits on the drainers, so the drop has been accounted for by then.
+		cancel()
+		wg.Wait()
+
+		require.Equal(t, uint64(1), sender.dropped.Batches())
+		require.Equal(t, uint64(1), sender.dropped.Messages())
+	})
 
 	t.Run("graceful shutdown, drain in-flight batch", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
+++ b/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
@@ -193,8 +193,9 @@ func (w *BatchWriter) Name() string {
 }
 
 func (w *BatchWriter) Close() error {
+	err := errors.Join(w.batchSender.Close(), w.writer.Close())
 	w.dropped.LogTotals(w.logger)
-	return errors.Join(w.batchSender.Close(), w.writer.Close())
+	return err
 }
 
 func (w *BatchWriter) sendBatch(ctx context.Context, batch *batch.Batch[kafka.Message]) error {

--- a/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
+++ b/pkg/wal/processor/kafka/wal_kafka_batch_writer.go
@@ -29,6 +29,11 @@ type BatchWriter struct {
 	maxBatchBytes int64
 	partitionKey  PartitionKey
 
+	// dropped accumulates what ignore_send_errors has discarded, and is shared
+	// with the sender so the totals and metrics cover this writer.
+	dropped         *batch.DroppedCounter
+	instrumentation *otel.Instrumentation
+
 	// optional checkpointer callback to mark what was safely processed
 	checkpointer checkpointer.Checkpoint
 
@@ -84,13 +89,27 @@ func NewBatchWriter(ctx context.Context, config *Config, opts ...Option) (*Batch
 		opt(w)
 	}
 
-	w.batchSender, err = batch.NewSender(ctx, &config.Batch, w.sendBatch, w.logger)
+	w.dropped = batch.NewDroppedCounter()
+	if config.Batch.IgnoreSendErrors {
+		w.logger.Warn(nil, "ignore_send_errors is enabled: batches that fail to send will be dropped and the run will continue", loglib.Fields{
+			"posture":     "at_risk",
+			"writer_type": kafkaWriterType,
+		})
+	}
+	if err := w.dropped.RegisterMetrics(w.instrumentation, kafkaWriterType); err != nil {
+		return nil, fmt.Errorf("initialising kafka batch writer metrics: %w", err)
+	}
+
+	w.batchSender, err = batch.NewSender(ctx, &config.Batch, w.sendBatch, w.logger,
+		batch.WithDroppedCounter[kafka.Message](w.dropped))
 	if err != nil {
 		return nil, err
 	}
 
 	return w, nil
 }
+
+const kafkaWriterType = "kafka_batch_writer"
 
 func WithLogger(l loglib.Logger) Option {
 	return func(w *BatchWriter) {
@@ -108,6 +127,7 @@ func WithCheckpoint(c checkpointer.Checkpoint) Option {
 
 func WithInstrumentation(i *otel.Instrumentation) Option {
 	return func(w *BatchWriter) {
+		w.instrumentation = i
 		instrumentedWriter, err := kafkainstrumentation.NewWriter(w.writer, i)
 		if err != nil {
 			w.logger.Error(err, "initialising kafka writer instrumentation")
@@ -173,6 +193,7 @@ func (w *BatchWriter) Name() string {
 }
 
 func (w *BatchWriter) Close() error {
+	w.dropped.LogTotals(w.logger)
 	return errors.Join(w.batchSender.Close(), w.writer.Close())
 }
 

--- a/pkg/wal/processor/kafka/wal_kafka_batch_writer_close_test.go
+++ b/pkg/wal/processor/kafka/wal_kafka_batch_writer_close_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/pkg/kafka"
+	kafkamocks "github.com/xataio/pgstream/pkg/kafka/mocks"
+	loglib "github.com/xataio/pgstream/pkg/log"
+	"github.com/xataio/pgstream/pkg/wal"
+	"github.com/xataio/pgstream/pkg/wal/processor/batch"
+)
+
+// TestBatchWriter_Close_reportsDropsFromTheFinalDrain pins the ordering inside
+// Close. The sender drains its in-flight batch as it closes, so a batch dropped
+// there is only counted once the sender has returned: logging the totals first
+// reports a stale number, and for a writer that only ever dropped on shutdown
+// it reports nothing at all.
+func TestBatchWriter_Close_reportsDropsFromTheFinalDrain(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dropped := batch.NewDroppedCounter()
+	logger := newRecordingLogger()
+
+	// the send always fails and errors are ignored, so the batch the drain
+	// picks up is dropped rather than sent
+	sender, err := batch.NewSender(ctx, &batch.Config{
+		IgnoreSendErrors: true,
+		MaxBatchSize:     100,
+		// only the drain on close sends this batch, never the ticker
+		BatchTimeout: time.Hour,
+	}, func(context.Context, *batch.Batch[kafka.Message]) error {
+		return errTest
+	}, loglib.NewNoopLogger(), batch.WithDroppedCounter[kafka.Message](dropped))
+	require.NoError(t, err)
+
+	writer := &BatchWriter{
+		logger:      logger,
+		batchSender: sender,
+		dropped:     dropped,
+		writer:      &kafkamocks.Writer{CloseFn: func() error { return nil }},
+	}
+
+	require.NoError(t, sender.SendMessage(ctx, batch.NewWALMessage(
+		kafka.Message{Value: []byte("test")}, wal.CommitPosition(testLSNStr))))
+
+	require.NoError(t, writer.Close())
+
+	require.Equal(t, uint64(1), dropped.Batches(), "the drain on close should have dropped the batch")
+
+	fields := logger.find(droppedTotalsLogMsg)
+	require.NotNil(t, fields, "the shutdown summary was not logged")
+	require.Equal(t, uint64(1), fields["dropped_batches"])
+	require.Equal(t, uint64(1), fields["dropped_messages"])
+}
+
+const droppedTotalsLogMsg = "closed with dropped batches"
+
+// recordingLogger keeps the fields of the messages logged at error level, so a
+// test can assert on what a shutdown summary reported.
+type recordingLogger struct {
+	*loglib.NoopLogger
+
+	mutex   sync.Mutex
+	entries map[string]loglib.Fields
+}
+
+func newRecordingLogger() *recordingLogger {
+	return &recordingLogger{
+		NoopLogger: loglib.NewNoopLogger(),
+		entries:    map[string]loglib.Fields{},
+	}
+}
+
+func (l *recordingLogger) Error(_ error, msg string, fields ...loglib.Fields) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	merged := loglib.Fields{}
+	for _, f := range fields {
+		merged = loglib.MergeFields(merged, f)
+	}
+	l.entries[msg] = merged
+}
+
+func (l *recordingLogger) find(msg string) loglib.Fields {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	return l.entries[msg]
+}

--- a/pkg/wal/processor/kafka/wal_kafka_message_key_property_test.go
+++ b/pkg/wal/processor/kafka/wal_kafka_message_key_property_test.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"github.com/xataio/pgstream/pkg/wal"
+)
+
+// Property-based test for the primary key message key encoding.
+//
+// The message key decides partition placement, so the encoding has to be
+// injective: two row identities differing in any component must never produce
+// the same key. When they collide the rows share a partition and lose their
+// separate ordering guarantees, and on a compacted topic one silently shadows
+// the other.
+//
+// The property checked here is that the encoding round-trips — decoding a key
+// recovers exactly the schema, table and values it was built from. That is
+// strictly stronger than injectivity (a decodable encoding cannot map two
+// inputs to one output) and, unlike comparing two generated identities, it
+// fails on a single input rather than needing the generator to stumble onto a
+// colliding pair. It catches any transformation that loses information, which
+// includes both the delimiter ambiguity and lossy re-encoding of bytes that
+// are not valid UTF-8.
+
+// keyComponent generates strings biased towards the characters that carry
+// structural meaning in the encoding, plus an invalid UTF-8 byte, so that
+// collisions are actually reachable rather than astronomically unlikely.
+func keyComponent(t *rapid.T, label string) string {
+	alphabet := []string{"a", "b", ",", `\`, ".", ":", "\xff", "\xfe", "é", ""}
+	return rapid.Map(
+		rapid.SliceOfN(rapid.SampledFrom(alphabet), 0, 6),
+		func(parts []string) string { return strings.Join(parts, "") },
+	).Draw(t, label)
+}
+
+type rowIdentity struct {
+	schema string
+	table  string
+	values []string
+}
+
+func (r rowIdentity) messageKey() string {
+	cols := make([]wal.Column, 0, len(r.values))
+	colIDs := make([]string, 0, len(r.values))
+	for i, v := range r.values {
+		id := fmt.Sprintf("col-%d", i)
+		cols = append(cols, wal.Column{ID: id, Name: id, Type: "text", Value: v})
+		colIDs = append(colIDs, id)
+	}
+
+	return string(primaryKeyMessageKey(&wal.Data{
+		Schema:   r.schema,
+		Table:    r.table,
+		Columns:  cols,
+		Metadata: wal.Metadata{InternalColIDs: colIDs},
+	}))
+}
+
+// decodeMessageKey is the inverse of the encoding in primaryKeyMessageKey. It
+// exists only in the test: nothing in production decodes a message key, but
+// being able to decode one is what proves the encoding loses no information.
+//
+// It scans byte-wise, treating "\" as escaping whatever follows: the schema
+// ends at the first unescaped ".", the table at the first unescaped ":", and
+// the remaining values are separated by unescaped ",".
+func decodeMessageKey(key string) (rowIdentity, error) {
+	var (
+		id       rowIdentity
+		current  []byte
+		haveSep  bool
+		haveCol  bool
+		decoded  []string
+		escaping bool
+	)
+
+	for i := 0; i < len(key); i++ {
+		c := key[i]
+		switch {
+		case escaping:
+			current = append(current, c)
+			escaping = false
+		case c == '\\':
+			escaping = true
+		case c == '.' && !haveSep:
+			id.schema = string(current)
+			current, haveSep = nil, true
+		case c == ':' && haveSep && !haveCol:
+			id.table = string(current)
+			current, haveCol = nil, true
+		case c == ',' && haveCol:
+			decoded = append(decoded, string(current))
+			current = nil
+		default:
+			current = append(current, c)
+		}
+	}
+
+	if escaping {
+		return id, fmt.Errorf("key ends with a dangling escape character: %q", key)
+	}
+	if !haveSep || !haveCol {
+		return id, fmt.Errorf("key is missing the schema/table/value separators: %q", key)
+	}
+
+	// the trailing component is not followed by a separator, so it is only
+	// flushed here
+	decoded = append(decoded, string(current))
+	id.values = decoded
+	return id, nil
+}
+
+func (r rowIdentity) equal(other rowIdentity) bool {
+	if r.schema != other.schema || r.table != other.table || len(r.values) != len(other.values) {
+		return false
+	}
+	for i, v := range r.values {
+		if v != other.values[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func genRowIdentity(t *rapid.T, label string) rowIdentity {
+	// arity varies so the encoding is also exercised across a primary key
+	// definition changing under DDL, not just within one fixed table
+	arity := rapid.IntRange(1, 3).Draw(t, label+"-arity")
+	values := make([]string, 0, arity)
+	for i := range arity {
+		values = append(values, keyComponent(t, fmt.Sprintf("%s-value-%d", label, i)))
+	}
+
+	return rowIdentity{
+		schema: keyComponent(t, label+"-schema"),
+		table:  keyComponent(t, label+"-table"),
+		values: values,
+	}
+}
+
+func TestPrimaryKeyMessageKey_RoundTrips(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		want := genRowIdentity(t, "row")
+		key := want.messageKey()
+
+		got, err := decodeMessageKey(key)
+		if err != nil {
+			t.Fatalf("decoding key %q built from %#v: %v", key, want, err)
+		}
+
+		if !got.equal(want) {
+			t.Fatalf("key %q does not round-trip:\n  encoded %#v\n  decoded %#v", key, want, got)
+		}
+	})
+}
+
+// TestPrimaryKeyMessageKey_Injective checks injectivity directly on generated
+// pairs. Round-tripping already implies it, so this is a cheap backstop against
+// the decoder and the encoder being wrong in the same direction.
+func TestPrimaryKeyMessageKey_Injective(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		a := genRowIdentity(t, "a")
+		b := genRowIdentity(t, "b")
+
+		sameKey := a.messageKey() == b.messageKey()
+		sameIdentity := a.equal(b)
+
+		if sameKey != sameIdentity {
+			t.Fatalf("injectivity violated:\n  a = %#v -> %q\n  b = %#v -> %q\n  same key = %v, same identity = %v",
+				a, a.messageKey(), b, b.messageKey(), sameKey, sameIdentity)
+		}
+	})
+}

--- a/pkg/wal/processor/kafka/wal_kafka_message_key_property_test.go
+++ b/pkg/wal/processor/kafka/wal_kafka_message_key_property_test.go
@@ -73,12 +73,13 @@ func (r rowIdentity) messageKey() string {
 func decodeMessageKey(key string) (rowIdentity, error) {
 	var (
 		id       rowIdentity
-		current  []byte
 		haveSep  bool
 		haveCol  bool
 		decoded  []string
 		escaping bool
 	)
+
+	current := make([]byte, 0, len(key))
 
 	for i := 0; i < len(key); i++ {
 		c := key[i]
@@ -90,13 +91,13 @@ func decodeMessageKey(key string) (rowIdentity, error) {
 			escaping = true
 		case c == '.' && !haveSep:
 			id.schema = string(current)
-			current, haveSep = nil, true
+			current, haveSep = current[:0], true
 		case c == ':' && haveSep && !haveCol:
 			id.table = string(current)
-			current, haveCol = nil, true
+			current, haveCol = current[:0], true
 		case c == ',' && haveCol:
 			decoded = append(decoded, string(current))
-			current = nil
+			current = current[:0]
 		default:
 			current = append(current, c)
 		}

--- a/pkg/wal/processor/postgres/postgres_batch_writer.go
+++ b/pkg/wal/processor/postgres/postgres_batch_writer.go
@@ -99,7 +99,8 @@ func (w *BatchWriter) Name() string {
 
 func (w *BatchWriter) Close() error {
 	w.logger.Debug("closing batch writer")
-	return errors.Join(w.batchSender.Close(), w.close())
+	senderErr := w.batchSender.Close()
+	return errors.Join(senderErr, w.close())
 }
 
 func (w *BatchWriter) sendBatch(ctx context.Context, b *batch.Batch[*walMessage]) error {

--- a/pkg/wal/processor/postgres/postgres_batch_writer.go
+++ b/pkg/wal/processor/postgres/postgres_batch_writer.go
@@ -52,7 +52,8 @@ func NewBatchWriter(ctx context.Context, config *Config, opts ...WriterOption) (
 	// postgres.Config, and bulk ingest defaults SendConcurrency to >1.
 	batchConfig := config.BatchConfig
 	batchConfig.SendConcurrency = 1
-	bw.batchSender, err = batch.NewSender(ctx, &batchConfig, bw.sendBatch, w.logger)
+	bw.batchSender, err = batch.NewSender(ctx, &batchConfig, bw.sendBatch, w.logger,
+		batch.WithDroppedCounter[*walMessage](w.dropped))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/wal/processor/postgres/postgres_batch_writer.go
+++ b/pkg/wal/processor/postgres/postgres_batch_writer.go
@@ -58,6 +58,10 @@ func NewBatchWriter(ctx context.Context, config *Config, opts ...WriterOption) (
 		return nil, err
 	}
 
+	if err := w.initDroppedQueriesMetric(); err != nil {
+		return nil, fmt.Errorf("initialising postgres batch writer metrics: %w", err)
+	}
+
 	return bw, nil
 }
 

--- a/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
+++ b/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
@@ -61,7 +61,10 @@ func NewBulkIngestWriter(ctx context.Context, config *Config, opts ...WriterOpti
 
 	biw.batchSenderBuilder = func(ctx context.Context, schema, table string) (queryBatchSender, error) {
 		logger := w.logger.WithFields(loglib.Fields{"schema": schema, "table": table})
-		return batch.NewSender(ctx, &config.BatchConfig, biw.sendBatch, logger)
+		// every per-table sender shares the writer's counter, so the drop
+		// totals and metrics cover the run rather than one table
+		return batch.NewSender(ctx, &config.BatchConfig, biw.sendBatch, logger,
+			batch.WithDroppedCounter[*query](w.dropped))
 	}
 
 	return biw, nil

--- a/pkg/wal/processor/postgres/postgres_writer.go
+++ b/pkg/wal/processor/postgres/postgres_writer.go
@@ -101,9 +101,6 @@ func newWriter(ctx context.Context, config *Config, writerType string, opts ...W
 
 	if w.instrumentation.IsEnabled() {
 		w.adapter = newInstrumentedWalAdapter(w.adapter, w.instrumentation)
-		if err := w.initMetrics(); err != nil {
-			return nil, fmt.Errorf("initialising postgres writer metrics: %w", err)
-		}
 		if err := w.dropped.RegisterMetrics(w.instrumentation, writerType); err != nil {
 			return nil, fmt.Errorf("initialising postgres writer metrics: %w", err)
 		}
@@ -121,7 +118,13 @@ func (w *Writer) DroppedQueries() uint64 {
 
 const droppedQueriesMetricName = "pgstream.postgres.writer.dropped_queries"
 
-func (w *Writer) initMetrics() error {
+// initDroppedQueriesMetric registers the per-query drop counter. Only the batch
+// writer reaches recordDroppedQuery, so only the batch writer registers this:
+// exporting it for the bulk ingest writer too would publish a permanent zero
+// under a writer_type label naming a component that does silently drop data, by
+// whole batches. Called by NewBatchWriter rather than by the shared
+// constructor, so the restriction is structural rather than a type check.
+func (w *Writer) initDroppedQueriesMetric() error {
 	if w.instrumentation == nil || w.instrumentation.Meter == nil {
 		return nil
 	}

--- a/pkg/wal/processor/postgres/postgres_writer.go
+++ b/pkg/wal/processor/postgres/postgres_writer.go
@@ -30,6 +30,10 @@ type Writer struct {
 	droppedQueries       atomic.Uint64
 	instrumentation      *otel.Instrumentation
 	droppedQueriesMetric metric.Int64ObservableCounter
+
+	// dropped is shared with every batch sender this writer builds, so the
+	// totals and metrics span the writer rather than a single table.
+	dropped *batch.DroppedCounter
 }
 
 type queryBatchSender interface {
@@ -50,6 +54,7 @@ func newWriter(ctx context.Context, config *Config, writerType string, opts ...W
 		writerType:      writerType,
 		disableTriggers: config.DisableTriggers,
 		strictMode:      config.StrictMode,
+		dropped:         batch.NewDroppedCounter(),
 	}
 
 	for _, opt := range opts {
@@ -80,6 +85,9 @@ func newWriter(ctx context.Context, config *Config, writerType string, opts ...W
 	if w.instrumentation.IsEnabled() {
 		w.adapter = newInstrumentedWalAdapter(w.adapter, w.instrumentation)
 		if err := w.initMetrics(); err != nil {
+			return nil, fmt.Errorf("initialising postgres writer metrics: %w", err)
+		}
+		if err := w.dropped.RegisterMetrics(w.instrumentation, writerType); err != nil {
 			return nil, fmt.Errorf("initialising postgres writer metrics: %w", err)
 		}
 	}
@@ -145,6 +153,7 @@ func (w *Writer) recordDroppedQuery(q *query, cause error) {
 }
 
 func (w *Writer) close() error {
+	w.dropped.LogTotals(w.logger)
 	if err := w.adapter.close(); err != nil {
 		w.logger.Error(err, "closing adapter")
 	}

--- a/pkg/wal/processor/postgres/postgres_writer.go
+++ b/pkg/wal/processor/postgres/postgres_writer.go
@@ -61,6 +61,23 @@ func newWriter(ctx context.Context, config *Config, writerType string, opts ...W
 		opt(w)
 	}
 
+	// State the suppression posture where the flags live, rather than at stream
+	// assembly: both of these turn a write failure into silently missing rows,
+	// are easy to set once and forget, and are otherwise only visible by
+	// counting log lines after the fact.
+	if config.BatchConfig.IgnoreSendErrors {
+		w.logger.Warn(nil, "ignore_send_errors is enabled: batches that fail to send will be dropped and the run will continue", loglib.Fields{
+			"posture":     "at_risk",
+			"writer_type": writerType,
+		})
+	}
+	// strict mode only governs the per-query drop-and-continue path, which the
+	// bulk ingest writer never reaches, so saying so there would describe
+	// behaviour the running writer does not have.
+	if !config.StrictMode && writerType == batchWriter {
+		w.logger.Info("strict_mode is disabled: non-internal query failures will be dropped and counted rather than stopping the pipeline")
+	}
+
 	var err error
 	if config.RetryPolicy.DisableRetries {
 		w.pgConn, err = pglib.NewConnPool(ctx, config.URL)

--- a/pkg/wal/processor/search/search_batch_indexer.go
+++ b/pkg/wal/processor/search/search_batch_indexer.go
@@ -9,6 +9,7 @@ import (
 	"runtime/debug"
 
 	loglib "github.com/xataio/pgstream/pkg/log"
+	"github.com/xataio/pgstream/pkg/otel"
 	"github.com/xataio/pgstream/pkg/wal"
 	"github.com/xataio/pgstream/pkg/wal/checkpointer"
 	"github.com/xataio/pgstream/pkg/wal/processor"
@@ -28,6 +29,11 @@ type BatchIndexer struct {
 
 	// checkpoint callback to mark what was safely stored
 	checkpoint checkpointer.Checkpoint
+
+	// dropped accumulates what ignore_send_errors has discarded, and is shared
+	// with the sender so the totals and metrics cover this indexer.
+	dropped         *batch.DroppedCounter
+	instrumentation *otel.Instrumentation
 }
 
 type Option func(*BatchIndexer)
@@ -58,12 +64,34 @@ func NewBatchIndexer(ctx context.Context, config IndexerConfig, store Store, lsn
 	indexer.adapter = newAdapter(store.GetMapper(), lsnParser, idHasher)
 
 	var err error
-	indexer.batchSender, err = batch.NewSender(ctx, &config.Batch, indexer.sendBatch, indexer.logger)
+	indexer.dropped = batch.NewDroppedCounter()
+	if config.Batch.IgnoreSendErrors {
+		indexer.logger.Warn(nil, "ignore_send_errors is enabled: batches that fail to send will be dropped and the run will continue", loglib.Fields{
+			"posture":     "at_risk",
+			"writer_type": searchIndexerType,
+		})
+	}
+	if err := indexer.dropped.RegisterMetrics(indexer.instrumentation, searchIndexerType); err != nil {
+		return nil, fmt.Errorf("initialising search batch indexer metrics: %w", err)
+	}
+
+	indexer.batchSender, err = batch.NewSender(ctx, &config.Batch, indexer.sendBatch, indexer.logger,
+		batch.WithDroppedCounter[*msg](indexer.dropped))
 	if err != nil {
 		return nil, err
 	}
 
 	return indexer, nil
+}
+
+const searchIndexerType = "search_batch_indexer"
+
+// WithInstrumentation exports the indexer's dropped-batch counters. The store is
+// instrumented separately; this covers what the batch sender discards.
+func WithInstrumentation(i *otel.Instrumentation) Option {
+	return func(indexer *BatchIndexer) {
+		indexer.instrumentation = i
+	}
 }
 
 func WithLogger(l loglib.Logger) Option {
@@ -122,6 +150,7 @@ func (i *BatchIndexer) Name() string {
 }
 
 func (i *BatchIndexer) Close() error {
+	i.dropped.LogTotals(i.logger)
 	return i.batchSender.Close()
 }
 

--- a/pkg/wal/processor/search/search_batch_indexer.go
+++ b/pkg/wal/processor/search/search_batch_indexer.go
@@ -150,8 +150,9 @@ func (i *BatchIndexer) Name() string {
 }
 
 func (i *BatchIndexer) Close() error {
+	err := i.batchSender.Close()
 	i.dropped.LogTotals(i.logger)
-	return i.batchSender.Close()
+	return err
 }
 
 func (i *BatchIndexer) sendBatch(ctx context.Context, batch *batch.Batch[*msg]) error {

--- a/pkg/wal/processor/search/search_batch_indexer_close_test.go
+++ b/pkg/wal/processor/search/search_batch_indexer_close_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package search
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	loglib "github.com/xataio/pgstream/pkg/log"
+	"github.com/xataio/pgstream/pkg/wal/processor/batch"
+)
+
+// TestBatchIndexer_Close_reportsDropsFromTheFinalDrain pins the ordering inside
+// Close. The sender drains its in-flight batch as it closes, so a batch dropped
+// there is only counted once the sender has returned: logging the totals first
+// reports a stale number, and for an indexer that only ever dropped on shutdown
+// it reports nothing at all.
+func TestBatchIndexer_Close_reportsDropsFromTheFinalDrain(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dropped := batch.NewDroppedCounter()
+	logger := newRecordingLogger()
+
+	// the send always fails and errors are ignored, so the batch the drain
+	// picks up is dropped rather than indexed
+	sender, err := batch.NewSender(ctx, &batch.Config{
+		IgnoreSendErrors: true,
+		MaxBatchSize:     100,
+		// only the drain on close sends this batch, never the ticker
+		BatchTimeout: time.Hour,
+	}, func(context.Context, *batch.Batch[*msg]) error {
+		return errTest
+	}, loglib.NewNoopLogger(), batch.WithDroppedCounter[*msg](dropped))
+	require.NoError(t, err)
+
+	indexer := &BatchIndexer{
+		logger:      logger,
+		batchSender: sender,
+		dropped:     dropped,
+	}
+
+	require.NoError(t, sender.SendMessage(ctx, batch.NewWALMessage(
+		&msg{schemaDiff: newTestSchemaDiff(), bytesSize: 1}, newTestCommitPosition())))
+
+	require.NoError(t, indexer.Close())
+
+	require.Equal(t, uint64(1), dropped.Batches(), "the drain on close should have dropped the batch")
+
+	fields := logger.find(droppedTotalsLogMsg)
+	require.NotNil(t, fields, "the shutdown summary was not logged")
+	require.Equal(t, uint64(1), fields["dropped_batches"])
+	require.Equal(t, uint64(1), fields["dropped_messages"])
+}
+
+const droppedTotalsLogMsg = "closed with dropped batches"
+
+// recordingLogger keeps the fields of the messages logged at error level, so a
+// test can assert on what a shutdown summary reported.
+type recordingLogger struct {
+	*loglib.NoopLogger
+
+	mutex   sync.Mutex
+	entries map[string]loglib.Fields
+}
+
+func newRecordingLogger() *recordingLogger {
+	return &recordingLogger{
+		NoopLogger: loglib.NewNoopLogger(),
+		entries:    map[string]loglib.Fields{},
+	}
+}
+
+func (l *recordingLogger) Error(_ error, msg string, fields ...loglib.Fields) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	merged := loglib.Fields{}
+	for _, f := range fields {
+		merged = loglib.MergeFields(merged, f)
+	}
+	l.entries[msg] = merged
+}
+
+func (l *recordingLogger) find(msg string) loglib.Fields {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	return l.entries[msg]
+}


### PR DESCRIPTION
#### Description

Nothing counts what `ignore_send_errors discards`: a failing table shows up
as individual log line with no total anywhere, and no
metric at all.

New metrics:
* `pgstream.batch.sender.dropped_batches`: count
* `pgstream.batch.sender.dropped_messages`: count

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

#### Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Code is well-commented
- [ ] Documentation updated where necessary


#### Additional Notes

<!-- Any context or special instructions for reviewers -->
