### PR TITLE
Catch both outcomes of the enum type creation race in integration tests

### DIFF
--- a/pkg/stream/integration/pg_pg_integration_test.go
+++ b/pkg/stream/integration/pg_pg_integration_test.go
@@ -1113,9 +1113,15 @@ func Test_PostgresToPostgres_EnumPrimaryKeyDelete(t *testing.T) {
 	// created. Creating them on the source can race the same DDL arriving on
 	// the target through replication, and neither CREATE TYPE nor CREATE DOMAIN
 	// supports IF NOT EXISTS, so swallow the duplicate.
+	//
+	// Both outcomes of that race have to be caught. A backend that sees the
+	// existing type during its catalog lookup raises duplicate_object, but one
+	// that loses the race to a concurrent insert gets past the lookup and fails
+	// on the pg_type_typname_nsp_index unique constraint instead, which is
+	// unique_violation.
 	ifNotExists := func(stmt string) string {
 		return fmt.Sprintf(
-			`DO $$ BEGIN %s; EXCEPTION WHEN duplicate_object THEN NULL; END $$`, stmt)
+			`DO $$ BEGIN %s; EXCEPTION WHEN duplicate_object OR unique_violation THEN NULL; END $$`, stmt)
 	}
 	for _, url := range []string{pgurl, targetPGURL} {
 		execQueryWithURL(t, ctx, url, ifNotExists(


### PR DESCRIPTION
#### Description

`Test_PostgresToPostgres_EnumPrimaryKeyDelete` creates its enum and domain
on both source and target, and the same DDL arrives on the target through
replication, so two backends can create the type concurrently.

The guard swallowing that duplicate only caught `duplicate_object`, which
is what a backend raises when its catalog lookup sees the existing type.
A backend that loses the race gets past the lookup and fails on the
pg_type_typname_nsp_index unique constraint instead, raising
unique_violation, which escaped the handler and failed the test:

```
constraint violation: duplicate key value violates unique
constraint "pg_type_typname_nsp_index"
```

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
