### PR TITLE
Pool the templates that share greenmask's funcmap state

### DIFF
--- a/pkg/stream/integration/pg_search_integration_test.go
+++ b/pkg/stream/integration/pg_search_integration_test.go
@@ -60,25 +60,39 @@ func Test_PostgresToSearch(t *testing.T) {
 						return false
 					}
 
+					idField := fmt.Sprintf("%s-1", testTablePgstreamID)
+					nameField := fmt.Sprintf("%s-2", testTablePgstreamID)
+
+					// the index exists before the indexer has finished applying
+					// the schema event's field mappings, so keep waiting until
+					// every field is there. Asserting on a mapping that is
+					// still being built fails the test outright, because these
+					// requires run inside the retry loop.
 					mapping := getIndexMapping(t, ctx, client, testIndex)
+					for _, field := range []string{"_table", idField, nameField, testTable} {
+						if _, found := mapping[field]; !found {
+							return false
+						}
+					}
+
 					require.Equal(t, map[string]any{"type": "keyword"}, mapping["_table"])
-					require.Equal(t, map[string]any{"type": "long"}, mapping[fmt.Sprintf("%s-1", testTablePgstreamID)])
+					require.Equal(t, map[string]any{"type": "long"}, mapping[idField])
 					require.Equal(t, map[string]any{
 						"fields": map[string]any{
 							"text": map[string]any{"type": "text"},
 						},
 						"ignore_above": float64(32766),
 						"type":         "keyword",
-					}, mapping[fmt.Sprintf("%s-2", testTablePgstreamID)])
+					}, mapping[nameField])
 					require.Equal(t, map[string]any{
 						"properties": map[string]any{
 							"id": map[string]any{
 								"type": "alias",
-								"path": fmt.Sprintf("%s-1", testTablePgstreamID),
+								"path": idField,
 							},
 							"name": map[string]any{
 								"type": "alias",
-								"path": fmt.Sprintf("%s-2", testTablePgstreamID),
+								"path": nameField,
 							},
 						},
 					}, mapping[testTable])

--- a/pkg/transformers/builder/transformer_concurrency_test.go
+++ b/pkg/transformers/builder/transformer_concurrency_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/xataio/pgstream/pkg/transformers"
 )
 
+// randomTemplateFuncs calls the greenmask toolkit template functions that are
+// backed by state shared across the function map: the rng behind the random
+// and noise functions, and the pgtype.Map behind the interval ones (issue
+// #1043).
+const randomTemplateFuncs = `{{ randomInt 1 1000 }} {{ randomFloat 0 1 2 }} {{ randomString 4 8 }} ` +
+	`{{ randomBool }} {{ noiseInt 0.5 100 }} {{ noiseFloat 0.5 2 100.0 }} ` +
+	`{{ randomDate (dateModify "-24h" now) now }} {{ noiseDatePgInterval "1 day" now }} ` +
+	`{{ tsModify "1 day" now }}`
+
 // concurrencyTestCase exercises a transformer from multiple goroutines, the
 // way pgstream snapshot workers share a single transformer per column. Run
 // with the race detector enabled, it catches transformers that share rng or
@@ -38,7 +47,10 @@ func TestTransformers_ConcurrentTransform(t *testing.T) {
 			input: "user@example.com",
 		},
 		transformers.Template: {
-			params: transformers.ParameterValues{"template": "{{ .GetValue }} - transformed"},
+			// the greenmask toolkit template functions draw from state shared
+			// by the whole function map, so the template must exercise them to
+			// catch issue #1043
+			params: transformers.ParameterValues{"template": "{{ .GetValue }} - " + randomTemplateFuncs},
 			input:  "hello",
 		},
 		transformers.JSON: {
@@ -47,7 +59,7 @@ func TestTransformers_ConcurrentTransform(t *testing.T) {
 					map[string]any{
 						"operation":       "set",
 						"path":            "/greeting",
-						"value":           "hello world",
+						"value_template":  randomTemplateFuncs,
 						"error_not_exist": false,
 					},
 				},
@@ -58,9 +70,9 @@ func TestTransformers_ConcurrentTransform(t *testing.T) {
 			params: transformers.ParameterValues{
 				"operations": []any{
 					map[string]any{
-						"operation": "set",
-						"key":       "test",
-						"value":     "value",
+						"operation":      "set",
+						"key":            "test",
+						"value_template": randomTemplateFuncs,
 					},
 				},
 			},

--- a/pkg/transformers/hstore_transformer.go
+++ b/pkg/transformers/hstore_transformer.go
@@ -7,11 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"text/template"
 
-	"github.com/Masterminds/sprig/v3"
-	greenmasktoolkit "github.com/eminano/greenmask/pkg/toolkit"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/xataio/pgstream/pkg/transformers/internal/template"
 )
 
 const (
@@ -50,10 +48,7 @@ func NewHstoreTransformer(params ParameterValues) (*HstoreTransformer, error) {
 	// prepare the template objects for operations that has template values
 	for idx, o := range operations {
 		if o.valueTemplate != "" {
-			tmpl, err := template.New(fmt.Sprintf("op[%d] %s %s", idx, o.operation, o.key)).
-				Funcs(greenmasktoolkit.FuncMap()).
-				Funcs(sprig.FuncMap()).
-				Parse(o.valueTemplate)
+			tmpl, err := template.New(fmt.Sprintf("op[%d] %s %s", idx, o.operation, o.key), o.valueTemplate)
 			if err != nil {
 				return nil, fmt.Errorf("hstore_transformer: error parsing template op[%d] with key \"%s\": %w", idx, o.key, err)
 			}

--- a/pkg/transformers/hstore_transformer_operation.go
+++ b/pkg/transformers/hstore_transformer_operation.go
@@ -5,9 +5,9 @@ package transformers
 import (
 	"bytes"
 	"fmt"
-	"text/template"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/xataio/pgstream/pkg/transformers/internal/template"
 )
 
 type hstoreOperation struct {

--- a/pkg/transformers/internal/template/template.go
+++ b/pkg/transformers/internal/template/template.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package template builds the text/template instances used by the
+// transformers that accept user provided templates. The greenmask toolkit
+// function map they rely on closes over state that is not safe for concurrent
+// use (a shared *rand.Rand behind randomInt/randomString/noiseInt/..., and a
+// pgtype.Map behind tsModify/noiseDatePgInterval), so a single template cannot
+// be executed by several snapshot workers at once. Templates are pooled
+// instead: each execution gets an instance with function map state of its own.
+package template
+
+import (
+	"io"
+	"maps"
+	texttemplate "text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	greenmasktoolkit "github.com/eminano/greenmask/pkg/toolkit"
+	"github.com/xataio/pgstream/pkg/transformers/internal/pool"
+)
+
+// Template is a text/template with the greenmask toolkit and sprig function
+// maps available to it, safe for concurrent execution.
+type Template struct {
+	pool *pool.Pool[*texttemplate.Template]
+}
+
+// New parses text into a template named name. Parse errors are reported here
+// rather than on first execution.
+func New(name, text string) (*Template, error) {
+	p, err := pool.New(func() (*texttemplate.Template, error) {
+		return texttemplate.New(name).Funcs(funcMap()).Parse(text)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Template{pool: p}, nil
+}
+
+// Execute applies the template to data, writing the output to w. It can be
+// called concurrently.
+func (t *Template) Execute(w io.Writer, data any) error {
+	tmpl, err := t.pool.Acquire()
+	if err != nil {
+		return err
+	}
+	defer t.pool.Release(tmpl)
+	return tmpl.Execute(w, data)
+}
+
+// funcMap returns a function map for exclusive use by a single template
+// instance. Sprig is applied last, so its functions win over the greenmask
+// ones with the same name.
+func funcMap() texttemplate.FuncMap {
+	fm := greenmasktoolkit.FuncMap()
+	maps.Copy(fm, sprig.FuncMap())
+	return fm
+}

--- a/pkg/transformers/internal/template/template_test.go
+++ b/pkg/transformers/internal/template/template_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		template string
+		data     any
+		wantErr  bool
+		wantOut  string
+	}{
+		{
+			name:     "static template",
+			template: "hello world",
+			wantOut:  "hello world",
+		},
+		{
+			name:     "template with data",
+			template: "hello {{ . }}",
+			data:     "world",
+			wantOut:  "hello world",
+		},
+		{
+			name:     "template with sprig function",
+			template: "{{ upper . }}",
+			data:     "world",
+			wantOut:  "WORLD",
+		},
+		{
+			name:     "template with greenmask function",
+			template: `{{ masking "default" . }}`,
+			data:     "secret",
+			wantOut:  "******",
+		},
+		{
+			name:     "invalid template",
+			template: "{{ unknownFunction }}",
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpl, err := New("test", tc.template)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			buf := &strings.Builder{}
+			require.NoError(t, tmpl.Execute(buf, tc.data))
+			require.Equal(t, tc.wantOut, buf.String())
+		})
+	}
+}
+
+// TestTemplate_ConcurrentExecute exercises issue #1043: the greenmask toolkit
+// function map closes over a shared rng, so executing one template from
+// several goroutines corrupted the generator and failed with "index out of
+// range [-1]". Run with the race detector, it also covers the pgtype.Map
+// behind the interval functions.
+func TestTemplate_ConcurrentExecute(t *testing.T) {
+	t.Parallel()
+
+	const (
+		numGoroutines = 16
+		numIterations = 100
+		minValue      = 1
+		maxValue      = 1000
+	)
+
+	tmpl, err := New("test", `{{ randomInt 1 1000 }} {{ randomFloat 0 1 2 }} {{ randomString 4 8 }} `+
+		`{{ randomBool }} {{ noiseInt 0.5 100 }} {{ noiseFloat 0.5 2 100.0 }} `+
+		`{{ randomDate (dateModify "-24h" now) now }} {{ noiseDatePgInterval "1 day" now }} `+
+		`{{ tsModify "1 day" now }}`)
+	require.NoError(t, err)
+
+	results := make([][]string, numGoroutines)
+	errs := make([]error, numGoroutines)
+
+	var wg sync.WaitGroup
+	for g := range numGoroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range numIterations {
+				buf := &strings.Builder{}
+				if err := tmpl.Execute(buf, nil); err != nil {
+					errs[g] = err
+					return
+				}
+				results[g] = append(results[g], buf.String())
+			}
+		}()
+	}
+	wg.Wait()
+
+	for g := range numGoroutines {
+		require.NoError(t, errs[g])
+		require.Len(t, results[g], numIterations)
+		for _, res := range results[g] {
+			// a corrupted rng can also return values outside the requested
+			// bounds instead of panicking, so check the first field
+			randomInt, err := strconv.Atoi(strings.Fields(res)[0])
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, randomInt, minValue)
+			require.LessOrEqual(t, randomInt, maxValue)
+		}
+	}
+}

--- a/pkg/transformers/json_transformer.go
+++ b/pkg/transformers/json_transformer.go
@@ -8,11 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"text/template"
 
-	"github.com/Masterminds/sprig/v3"
-	greenmasktoolkit "github.com/eminano/greenmask/pkg/toolkit"
 	"github.com/xataio/pgstream/internal/json"
+	"github.com/xataio/pgstream/pkg/transformers/internal/template"
 )
 
 const (
@@ -54,10 +52,7 @@ func NewJSONTransformer(params ParameterValues) (*JSONTransformer, error) {
 	// prepare the template objects for operations that has template values
 	for idx, o := range operations {
 		if o.valueTemplate != "" {
-			tmpl, err := template.New(fmt.Sprintf("op[%d] %s %s", idx, o.operation, o.path)).
-				Funcs(greenmasktoolkit.FuncMap()).
-				Funcs(sprig.FuncMap()).
-				Parse(o.valueTemplate)
+			tmpl, err := template.New(fmt.Sprintf("op[%d] %s %s", idx, o.operation, o.path), o.valueTemplate)
 			if err != nil {
 				return nil, fmt.Errorf("json_transformer: error parsing template op[%d] with path \"%s\": %w", idx, o.path, err)
 			}

--- a/pkg/transformers/json_transformer_operation.go
+++ b/pkg/transformers/json_transformer_operation.go
@@ -5,10 +5,10 @@ package transformers
 import (
 	"bytes"
 	"fmt"
-	"text/template"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"github.com/xataio/pgstream/pkg/transformers/internal/template"
 )
 
 var (

--- a/pkg/transformers/template_transformer.go
+++ b/pkg/transformers/template_transformer.go
@@ -7,10 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"text/template"
 
-	"github.com/Masterminds/sprig/v3"
-	greenmasktoolkit "github.com/eminano/greenmask/pkg/toolkit"
+	"github.com/xataio/pgstream/pkg/transformers/internal/template"
 )
 
 type TemplateTransformer struct {
@@ -43,7 +41,7 @@ func NewTemplateTransformer(params ParameterValues) (*TemplateTransformer, error
 		return nil, errTemplateMustBeProvided
 	}
 
-	tmpl, err := template.New("").Funcs(greenmasktoolkit.FuncMap()).Funcs(sprig.FuncMap()).Parse(templateStr)
+	tmpl, err := template.New("", templateStr)
 	if err != nil {
 		return nil, fmt.Errorf("template_transformer: error parsing template: %w", err)
 	}


### PR DESCRIPTION
#### Description

This PR fixes the concurrency issues in transformers.

Similar to #789

##### Related Issue(s)

- Fixes #1043

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Use the same pooling pattern as in other transformer fixes
- Extract template functions into a common package
-

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

#### Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Code is well-commented
- [ ] Documentation updated where necessary
