### PR TITLE
Added tests and docs for snapshot+stream from a read replica

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,25 @@ jobs:
         with:
           go-version-file: "go.mod"
 
+      # The snapshot shells out to pg_dump, which refuses to dump from a server
+      # newer than itself. Runner images ship a 16 client, so tests using a
+      # newer source server (the read replica tests use 17) fail without this.
+      - name: Install PostgreSQL 17 client
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
+            https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends postgresql-client-17
+          # take precedence over the preinstalled client
+          echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
+
+      - name: Verify pg_dump version
+        run: pg_dump --version
+
       - name: Run integration tests
         run: make integration-test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ make test
 go test -run TestName ./pkg/path/to/package
 
 # Run integration tests (requires Docker for testcontainers)
-PGSTREAM_INTEGRATION_TESTS=true go test -timeout 180s github.com/xataio/pgstream/pkg/stream/integration
+PGSTREAM_INTEGRATION_TESTS=true go test -timeout 600s github.com/xataio/pgstream/pkg/stream/integration
 
 # Lint (golangci-lint v2)
 make lint

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 
 .PHONY: integration-test
 integration-test:
-	@PGSTREAM_INTEGRATION_TESTS=true go test -timeout 180s \
+	@PGSTREAM_INTEGRATION_TESTS=true go test -timeout 600s \
 		github.com/xataio/pgstream/pkg/stream/integration \
 		github.com/xataio/pgstream/pkg/snapshot/store/postgres/integration
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ For more advanced usage, implementation details, and detailed configuration sett
    - [Environment Variables](docs/configuration.md#environment-variables)
    - [Examples](docs/examples/)
 3. [Snapshots](docs/snapshots.md)
+   - [Running from a read replica](docs/replicas.md)
 4. [Transformers](docs/transformers.md)
    - [Supported Transformers](docs/transformers.md#supported-transformers)
    - [Transformation Rules](docs/transformers.md#transformation-rules)

--- a/cli-definition.json
+++ b/cli-definition.json
@@ -81,6 +81,11 @@
           "default": ""
         },
         {
+          "name": "slot-only",
+          "description": "Whether to only drop the replication slot, leaving the pgstream schema and migrations in place",
+          "default": "false"
+        },
+        {
           "name": "with-injector",
           "description": "Whether to also destroy the injector related database objects",
           "default": "false"
@@ -109,6 +114,11 @@
           "name": "replication-slot",
           "description": "Name of the postgres replication slot to be created by pgstream on the source url",
           "default": ""
+        },
+        {
+          "name": "slot-only",
+          "description": "Whether to only create the replication slot, without running the database migrations. Useful when creating the slot on a read replica, where the migrations cannot be applied",
+          "default": "false"
         },
         {
           "name": "upgrade",

--- a/cmd/init_cmd.go
+++ b/cmd/init_cmd.go
@@ -103,6 +103,9 @@ func initDestroyFlagBinding(cmd *cobra.Command, _ []string) {
 	if f := cmd.Flags().Lookup("migrations-only"); f != nil {
 		viper.BindPFlag("migrations-only", f)
 	}
+	if f := cmd.Flags().Lookup("slot-only"); f != nil {
+		viper.BindPFlag("slot-only", f)
+	}
 	if f := cmd.Flags().Lookup("upgrade"); f != nil {
 		viper.BindPFlag("upgrade", f)
 	}
@@ -127,6 +130,9 @@ func getInitOptions() []stream.InitOption {
 	initOpts := []stream.InitOption{}
 	if viper.GetBool("migrations-only") {
 		initOpts = append(initOpts, stream.WithMigrationsOnly())
+	}
+	if viper.GetBool("slot-only") {
+		initOpts = append(initOpts, stream.WithSlotOnly())
 	}
 	if viper.GetBool("upgrade") {
 		initOpts = append(initOpts, stream.WithUpgrade())

--- a/cmd/init_cmd.go
+++ b/cmd/init_cmd.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/xataio/pgstream/cmd/config"
+	"github.com/xataio/pgstream/internal/log/zerolog"
 	"github.com/xataio/pgstream/pkg/stream"
 
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
@@ -127,7 +128,11 @@ func initDestroyFlagBinding(cmd *cobra.Command, _ []string) {
 }
 
 func getInitOptions() []stream.InitOption {
-	initOpts := []stream.InitOption{}
+	initOpts := []stream.InitOption{
+		// so a replication slot creation that is blocked rather than slow
+		// reports why, instead of sitting on a silent spinner
+		stream.WithInitLogger(zerolog.NewStdLogger(zerolog.NewLogger(loggerConfigFromViper()))),
+	}
 	if viper.GetBool("migrations-only") {
 		initOpts = append(initOpts, stream.WithMigrationsOnly())
 	}

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -70,6 +70,12 @@ func Prepare() *cobra.Command {
 	initCmd.Flags().Bool("migrations-only", false, "Whether to only run the initialization database migrations")
 	initCmd.Flags().Bool("slot-only", false, "Whether to only create the replication slot, without running the database migrations. Useful when creating the slot on a read replica, where the migrations cannot be applied")
 	initCmd.Flags().Bool("upgrade", false, "Clean up v0.9.x state before initializing (idempotent, safe for repeated use)")
+	// slot-only selects the half of the work the other two flags act on, so
+	// combining them is always a mistake: --migrations-only asks for the
+	// complementary half, and --upgrade only cleans up schema state that
+	// slot-only never touches, which would otherwise be silently ignored
+	initCmd.MarkFlagsMutuallyExclusive("migrations-only", "slot-only")
+	initCmd.MarkFlagsMutuallyExclusive("upgrade", "slot-only")
 
 	// destroy cmd
 	destroyCmd.Flags().String("postgres-url", "", "Source postgres URL where pgstream destroy will be run")
@@ -77,6 +83,7 @@ func Prepare() *cobra.Command {
 	destroyCmd.Flags().Bool("with-injector", false, "Whether to also destroy the injector related database objects")
 	destroyCmd.Flags().Bool("migrations-only", false, "Whether to only revert the database migrations")
 	destroyCmd.Flags().Bool("slot-only", false, "Whether to only drop the replication slot, leaving the pgstream schema and migrations in place")
+	destroyCmd.MarkFlagsMutuallyExclusive("migrations-only", "slot-only")
 
 	// tear down cmd
 	tearDownCmd.Flags().String("postgres-url", "", "Source postgres URL where pgstream tear down will be run")

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -68,6 +68,7 @@ func Prepare() *cobra.Command {
 	initCmd.Flags().String("replication-slot", "", "Name of the postgres replication slot to be created by pgstream on the source url")
 	initCmd.Flags().Bool("with-injector", false, "Whether to initialise pgstream with the injector database migrations")
 	initCmd.Flags().Bool("migrations-only", false, "Whether to only run the initialization database migrations")
+	initCmd.Flags().Bool("slot-only", false, "Whether to only create the replication slot, without running the database migrations. Useful when creating the slot on a read replica, where the migrations cannot be applied")
 	initCmd.Flags().Bool("upgrade", false, "Clean up v0.9.x state before initializing (idempotent, safe for repeated use)")
 
 	// destroy cmd
@@ -75,6 +76,7 @@ func Prepare() *cobra.Command {
 	destroyCmd.Flags().String("replication-slot", "", "Name of the postgres replication slot to be deleted by pgstream from the source url")
 	destroyCmd.Flags().Bool("with-injector", false, "Whether to also destroy the injector related database objects")
 	destroyCmd.Flags().Bool("migrations-only", false, "Whether to only revert the database migrations")
+	destroyCmd.Flags().Bool("slot-only", false, "Whether to only drop the replication slot, leaving the pgstream schema and migrations in place")
 
 	// tear down cmd
 	tearDownCmd.Flags().String("postgres-url", "", "Source postgres URL where pgstream tear down will be run")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,6 +83,7 @@ The `init` command prepares your PostgreSQL database for streaming by:
 - `--replication-slot` - Name of the postgres replication slot to be created by pgstream on the source url
 - `--with-injector` - Whether to initialize pgstream with the injector database migrations. Required for search targets (OpenSearch/Elasticsearch)
 - `--migrations-only` - Whether to only run the database migrations without creating the replication slot
+- `--slot-only` - Whether to only create the replication slot, without running the database migrations
 
 **Examples:**
 
@@ -91,9 +92,12 @@ pgstream init --postgres-url <source-postgres-url> --replication-slot <replicati
 pgstream init -c config.yaml
 pgstream init -c config.env
 pgstream init -c config.yaml --migrations-only
+pgstream init --postgres-url <replica-postgres-url> --slot-only
 ```
 
 **Note:** The `--migrations-only` flag runs only the database migrations (creating the pgstream schema, tables, functions, and triggers) without creating the replication slot. This is useful when you want to set up the schema separately or when using different database credentials for migrations versus replication.
+
+**Note:** The `--slot-only` flag is the complement: it creates only the replication slot, skipping the schema and migrations entirely. This is what a **read replica** source needs, since a standby is read only and cannot take the migrations, while the schema and event trigger reach it through physical replication from the primary. See [Running pgstream from a read replica](replicas.md). The two flags are mutually exclusive.
 
 ### run
 
@@ -354,6 +358,7 @@ The `destroy` command cleans up all resources created by `pgstream init`:
 - `--replication-slot` - Name of the postgres replication slot to be deleted by pgstream from the source url
 - `--with-injector` - Whether to also destroy the injector related database objects
 - `--migrations-only` - Whether to only revert the database migrations without dropping the replication slot
+- `--slot-only` - Whether to only drop the replication slot, leaving the pgstream schema and migrations in place
 
 **Examples:**
 
@@ -362,9 +367,12 @@ pgstream destroy --postgres-url <source-postgres-url> --replication-slot <replic
 pgstream destroy -c config.yaml
 pgstream destroy -c config.env
 pgstream destroy -c config.yaml --migrations-only
+pgstream destroy --postgres-url <postgres-url> --slot-only
 ```
 
 **Note:** The `--migrations-only` flag reverts only the database migrations (removing the pgstream schema, tables, functions, and triggers) without dropping the pgstream schema (with any tables that it might contain, such as the snapshot recorder), or dropping the replication slot. This is useful for minimal downtime migrations where you want to preserve the replication slot position.
+
+**Note:** The `--slot-only` flag is the complement: it drops only the replication slot and leaves the pgstream schema and the `emit_ddl` event trigger in place. Use it to remove a slot that is no longer consumed — an unused logical slot pins WAL indefinitely — without disturbing DDL replication for anything still streaming. The two flags are mutually exclusive.
 
 **⚠️ Important Notes:**
 

--- a/docs/replicas.md
+++ b/docs/replicas.md
@@ -152,6 +152,36 @@ See [Configuration](configuration.md) for the full set of options.
   FROM pg_replication_slots WHERE slot_name = 'pgstream_<dbname>_slot';
   ```
 
+- **`hot_standby_feedback` holds back vacuum on the primary.** It takes no locks there — it
+  only moves the primary's vacuum horizon — so it cannot cause the DDL lock contention that
+  motivates moving the snapshot off the primary in the first place. What it does cost is bloat,
+  and the cost differs sharply by phase:
+
+  - **Steady-state replication** is cheap. A logical slot needs only `catalog_xmin`, so the
+    retained rows are in the system catalogs rather than user tables.
+  - **The snapshot phase is not.** The parallel data snapshot holds a `REPEATABLE READ`
+    transaction open on the replica for as long as the snapshot runs, and that is a real reader
+    with a data `xmin`. While it is open the primary cannot vacuum the tables being snapshotted.
+
+  Measured on a primary/standby pair with a snapshot-style transaction open on the standby:
+
+  ```
+  VACUUM (VERBOSE) on the primary:
+    tuples: 0 removed, 6000 remain, 5000 are dead but not yet removable
+    removable cutoff: 742    <- pinned at the xmin fed back by the standby
+  ```
+
+  So budget for the primary not vacuuming the snapshotted tables for the duration of the
+  snapshot, and let autovacuum catch up afterwards. Watch `n_dead_tup` on the largest tables.
+  In the extreme — a horizon pinned long enough to trigger anti-wraparound autovacuum — DDL
+  *can* end up blocked, because that flavour of autovacuum holds `SHARE UPDATE EXCLUSIVE` and
+  is not cancelled when a conflicting lock request arrives.
+
+- **`max_standby_streaming_delay` is the complementary lever.** It protects long-running queries
+  on the replica by pausing WAL replay instead of touching the primary's horizon, trading
+  replication lag for query survival. It does **not** replace `hot_standby_feedback` for a
+  long-lived slot: delaying the conflicting WAL only defers the invalidation.
+
 - **Failover.** The slot is local to the replica, so promoting *that* node keeps it. Failing
   over to a different node, or rebuilding the replica, loses the slot and requires a new
   snapshot.

--- a/docs/replicas.md
+++ b/docs/replicas.md
@@ -65,13 +65,12 @@ primary indefinitely — the exact disk pressure you are trying to avoid. See
 
 If you already created one, drop it:
 
-```sql
--- on the primary
-SELECT pg_drop_replication_slot('pgstream_<dbname>_slot');
+```bash
+pgstream destroy --postgres-url <primary-url> --slot-only
 ```
 
-> ⚠️ Use `pg_drop_replication_slot`, **not** `pgstream destroy`. Destroy would also remove the
-> pgstream schema and the `emit_ddl` event trigger, which must stay on the primary.
+> ⚠️ Use `--slot-only`. A plain `pgstream destroy` would also remove the pgstream schema and
+> the `emit_ddl` event trigger, which must stay on the primary.
 
 > ⚠️ Two different slots live on the primary and only the `slot_type` column tells them apart.
 > Drop the unused **logical** slot; **keep** the replica's own **physical** slot, which is what
@@ -88,15 +87,27 @@ hot_standby_feedback = on
 
 ### 3. Create the logical replication slot on the replica
 
-```sql
--- on the replica
-SELECT pg_create_logical_replication_slot('pgstream_<dbname>_slot', 'wal2json');
+```bash
+pgstream init --postgres-url <replica-url> --slot-only
 ```
 
+`--slot-only` creates the replication slot and skips the schema and migrations, which is what
+makes this work against a read only standby. See [CLI: init](cli.md#init).
+
 The slot name only has to match what pgstream looks for on the source URL. If
-`source.postgres.replication.replication_slot` is left empty, pgstream derives
-`pgstream_<dbname>_slot` from the URL's database name; since the replica is a physical copy
-its database name is the same, so the default resolves identically on both hosts.
+`--replication-slot` and `source.postgres.replication.replication_slot` are both left empty,
+pgstream derives `pgstream_<dbname>_slot` from the URL's database name; since the replica is
+a physical copy its database name is the same, so the default resolves identically on both
+hosts.
+
+> ⚠️ **If this command does not return promptly, it is waiting, not failing.** Creating a
+> logical slot on a standby blocks until the primary emits an `xl_running_xacts` record, which
+> is what lets the standby build a consistent catalog snapshot. An idle primary may never emit
+> one. Unblock it by running this on the **primary**:
+>
+> ```sql
+> SELECT pg_log_standby_snapshot();
+> ```
 
 ### 4. Run pgstream against the replica
 

--- a/docs/replicas.md
+++ b/docs/replicas.md
@@ -1,0 +1,151 @@
+# Running pgstream from a read replica
+
+This guide explains how to run pgstream — both the snapshot and the replication phases —
+against a **physical streaming replica** instead of the primary. This reduces load on the primary
+and also avoids locking issues due to the long-running snapshots created by pgstream.
+
+## Table of Contents
+
+1. [Requirements](#requirements)
+2. [Why DDL replication still works](#why-ddl-replication-still-works)
+3. [Setup](#setup)
+4. [Configuration](#configuration)
+5. [Operational considerations](#operational-considerations)
+
+## Requirements
+
+- **PostgreSQL 16 or later.** Logical decoding on a standby does not exist before 16.
+- **`wal_level = logical` on the primary _and_ on the replica.** See the warning below —
+      the replica does not inherit this.
+- **`hot_standby_feedback = on` on the replica.**
+- **The wal2json output plugin installed on the replica's host.** It is a shared library,
+      not a SQL extension, so it does not arrive through replication — it must be present on
+      that machine.
+- **A single-instance endpoint** for the replica, not a load-balanced reader endpoint.
+- Superuser-equivalent access on the primary for the one-time `pgstream init`.
+
+> ⚠️ **`wal_level = logical` is not inherited by the replica.** If the primary sets it with a
+> command line flag, the setting never reaches `postgresql.conf` and so is not copied by
+> `pg_basebackup`. The replica comes up at `wal_level = replica` and slot creation fails with
+> `logical decoding requires "wal_level" >= "logical"`. Set it explicitly on the replica.
+
+> ⚠️ **Point the source URL at a specific replica instance.** The parallel data snapshot
+> exports a transaction snapshot and imports it on sibling connections, and an exported
+> snapshot is instance-local. An Aurora reader (`cluster-ro`) endpoint, an RDS reader
+> endpoint, or a pooler spanning instances will fail nondeterministically. See
+> [Snapshots](snapshots.md#️-the-data-snapshot-source-must-be-a-single-instance);
+> `pgstream check` flags this before a snapshot runs.
+
+## How streaming DDL works
+
+pgstream's DDL replication is **stateless**. `pgstream init` installs an event trigger
+(`pgstream.emit_ddl`) that calls `pg_logical_emit_message()`, so DDL travels inline in the WAL
+stream as a logical message rather than through a table that has to be read back.
+
+You cannot install that event trigger on the replica because a standby is read only. But it's not needed. 
+The event trigger runs on the *primary*, where DDL actually executes, and `pg_logical_emit_message()`
+writes an ordinary WAL record. The replica replays that record like any other, so a logical slot on 
+the replica decodes it for free. No pgstream state of any kind is required on the replica.
+
+## Setup
+
+### 1. Initialise pgstream on the primary — without a replication slot
+
+```bash
+pgstream init --postgres-url <primary-url> --migrations-only
+```
+
+This installs the pgstream schema, functions and the `emit_ddl` event trigger, all of which
+reach the replica through physical replication.
+
+`--migrations-only` is important: without it, `init` also creates a logical replication slot
+on the primary. In this setup nothing ever consumes that slot, so it would pin WAL on the
+primary indefinitely — the exact disk pressure you are trying to avoid. See
+[CLI: init](cli.md#init).
+
+If you already created one, drop it:
+
+```sql
+-- on the primary
+SELECT pg_drop_replication_slot('pgstream_<dbname>_slot');
+```
+
+> ⚠️ Use `pg_drop_replication_slot`, **not** `pgstream destroy`. Destroy would also remove the
+> pgstream schema and the `emit_ddl` event trigger, which must stay on the primary.
+
+> ⚠️ Two different slots live on the primary and only the `slot_type` column tells them apart.
+> Drop the unused **logical** slot; **keep** the replica's own **physical** slot, which is what
+> stops the primary from discarding WAL the replica still needs.
+
+### 2. Configure the replica
+
+Both settings are required, and neither is inherited from the primary:
+
+```
+wal_level = logical
+hot_standby_feedback = on
+```
+
+### 3. Create the logical replication slot on the replica
+
+```sql
+-- on the replica
+SELECT pg_create_logical_replication_slot('pgstream_<dbname>_slot', 'wal2json');
+```
+
+The slot name only has to match what pgstream looks for on the source URL. If
+`source.postgres.replication.replication_slot` is left empty, pgstream derives
+`pgstream_<dbname>_slot` from the URL's database name; since the replica is a physical copy
+its database name is the same, so the default resolves identically on both hosts.
+
+### 4. Run pgstream against the replica
+
+Point `source.postgres.url` at the replica and run as normal. `pgstream run` never creates a
+slot, it only connects to an existing one, so a missing or invalidated slot is a startup
+failure rather than something that silently recreates itself.
+
+## Configuration
+
+Nothing here is replica-specific except the URL: the source simply points at the replica.
+
+```yaml
+source:
+  postgres:
+    url: "postgres://user:pass@replica-host:5432/mydb"
+    mode: snapshot_and_replication
+    replication:
+      replication_slot: "pgstream_mydb_slot" # the slot created on the replica
+    snapshot:
+      mode: full
+      tables:
+        - "*"
+      schema:
+        pgdump_pgrestore:
+          clean_target_db: false
+
+target:
+  postgres:
+    url: "postgres://user:pass@target-host:5432/targetdb"
+```
+
+See [Configuration](configuration.md) for the full set of options.
+
+## Operational considerations
+
+- **Slot invalidation is the main risk.** A logical slot on a standby can be invalidated by
+  recovery conflicts, or by the primary's `max_slot_wal_keep_size`. Invalidation means a full
+  resnapshot, not a resume — a slot on the primary does not have this failure mode. Monitor it:
+
+  ```sql
+  SELECT slot_name, conflicting, invalidation_reason  -- invalidation_reason is PG17+
+  FROM pg_replication_slots WHERE slot_name = 'pgstream_<dbname>_slot';
+  ```
+
+- **Failover.** The slot is local to the replica, so promoting *that* node keeps it. Failing
+  over to a different node, or rebuilding the replica, loses the slot and requires a new
+  snapshot.
+
+- **The primary is still required for DDL.** DDL continues to execute on the primary and the
+  event trigger must remain installed there. Re-run
+  `pgstream init --postgres-url <primary-url> --migrations-only` after any upgrade that adds
+  migrations.

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -42,4 +42,6 @@ fine.
 > `pgstream check` includes a preflight check that probes the source and reports a clear
 > error when it detects a load-balanced source, so you can catch this before a snapshot runs.
 
+To keep snapshot load off a primary that cannot afford it, the snapshot can be taken from a physical read replica instead. See [Running pgstream from a read replica](replicas.md).
+
 For more details into the snapshot implementation and performance benchmarking, check out this [blogpost](https://xata.io/blog/behind-the-scenes-speeding-up-pgstream-snapshots-for-postgresql). For details on how to use and configure the snapshot mode, check the [snapshot tutorial](tutorials/postgres_snapshot.md).

--- a/internal/testcontainers/test_postgres_replica_container.go
+++ b/internal/testcontainers/test_postgres_replica_container.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package testcontainers
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/network"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	replicaSetupUser     = "postgres"
+	replicaSetupPassword = "postgres"
+	replicaSetupDB       = "testdb"
+
+	// primaryNetworkAlias is the hostname the standby uses to reach the
+	// primary over the shared docker network.
+	primaryNetworkAlias = "primary"
+
+	// physicalSlotName is the physical replication slot the standby creates on
+	// the primary, so the primary retains the WAL the standby still needs.
+	physicalSlotName = "pgstream_test_physical_slot"
+)
+
+// standbySetupScript runs as the standby container's entrypoint. It takes a
+// base backup of the primary, turns the result into a standby, and then execs
+// postgres in its place.
+//
+// The two settings appended to postgresql.auto.conf are both load bearing:
+//   - wal_level=logical is NOT inherited from the primary. The primary sets it
+//     via a command line flag, which never reaches postgresql.conf and so is
+//     not copied by the base backup. Without it the standby comes up at
+//     wal_level=replica and logical slot creation fails with
+//     `logical decoding requires "wal_level" >= "logical"`.
+//   - hot_standby_feedback=on stops the primary from vacuuming away catalog
+//     rows the logical decoder on the standby still needs. Without it the
+//     standby's logical slot is invalidated by recovery conflicts.
+//
+// The PG_VERSION guard keeps the script idempotent, so a container restart
+// re-execs postgres against the existing data directory rather than trying to
+// take a second base backup (which would fail on the already-existing slot).
+const standbySetupScript = `
+set -e
+until pg_isready -h ` + primaryNetworkAlias + ` -U ` + replicaSetupUser + ` -q; do sleep 1; done
+if [ ! -s "$PGDATA/PG_VERSION" ]; then
+  rm -rf "$PGDATA"/* || true
+  chown postgres:postgres "$PGDATA"
+  chmod 0700 "$PGDATA"
+  gosu postgres pg_basebackup \
+    -h ` + primaryNetworkAlias + ` -p 5432 -U ` + replicaSetupUser + ` \
+    -D "$PGDATA" -Fp -Xs -R -S ` + physicalSlotName + ` -C
+  {
+    echo "wal_level = logical"
+    echo "hot_standby_feedback = on"
+  } >> "$PGDATA/postgresql.auto.conf"
+fi
+exec gosu postgres postgres
+`
+
+// SetupPostgresPrimaryReplica starts a Postgres primary together with a
+// physical streaming replica of it, on a shared docker network, and writes
+// their connection strings to primaryURL and replicaURL.
+//
+// Both run Postgres 17 with wal2json, built from testdata/pg-wal2json. That
+// combination is required and not otherwise available in this repo: logical
+// decoding on a standby needs Postgres 16+, while the debezium/postgres images
+// used by the rest of the suite only ship wal2json up to their 14 tag.
+//
+// The returned cleanup tears down both containers and the network.
+func SetupPostgresPrimaryReplica(ctx context.Context, primaryURL, replicaURL *string) (cleanup, error) {
+	cleanups := []cleanup{}
+	cleanupAll := func() error {
+		var err error
+		// unwind in reverse order, so the network outlives the containers
+		// attached to it
+		for i := len(cleanups) - 1; i >= 0; i-- {
+			if cerr := cleanups[i](); cerr != nil && err == nil {
+				err = cerr
+			}
+		}
+		return err
+	}
+	// on any failure below, release whatever was already started
+	failed := true
+	defer func() {
+		if failed {
+			cleanupAll() //nolint:errcheck
+		}
+	}()
+
+	nw, err := network.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating docker network: %w", err)
+	}
+	cleanups = append(cleanups, func() error { return nw.Remove(ctx) })
+
+	dockerfileDir, err := walReplicaDockerfileDir()
+	if err != nil {
+		return nil, err
+	}
+
+	primary, err := runPostgresReplicaContainer(ctx, testcontainers.ContainerRequest{
+		FromDockerfile: testcontainers.FromDockerfile{
+			Context:    dockerfileDir,
+			Dockerfile: "Dockerfile",
+			KeepImage:  true,
+		},
+		ExposedPorts:   []string{"5432/tcp"},
+		Networks:       []string{nw.Name},
+		NetworkAliases: map[string][]string{nw.Name: {primaryNetworkAlias}},
+		Env: map[string]string{
+			"POSTGRES_USER":     replicaSetupUser,
+			"POSTGRES_PASSWORD": replicaSetupPassword,
+			"POSTGRES_DB":       replicaSetupDB,
+		},
+		Cmd: []string{
+			"postgres",
+			"-c", "wal_level=logical",
+			"-c", "max_wal_senders=10",
+			"-c", "max_replication_slots=10",
+			"-c", "hot_standby=on",
+		},
+		WaitingFor: wait.
+			ForLog("database system is ready to accept connections").
+			WithOccurrence(2).
+			WithStartupTimeout(2 * time.Minute),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("starting primary postgres container: %w", err)
+	}
+	cleanups = append(cleanups, func() error { return primary.Terminate(ctx) })
+
+	// the stock pg_hba.conf has no entry for replication connections, so
+	// pg_basebackup from the standby would be rejected
+	if err := allowReplicationConnections(ctx, primary); err != nil {
+		return nil, err
+	}
+
+	standby, err := runPostgresReplicaContainer(ctx, testcontainers.ContainerRequest{
+		FromDockerfile: testcontainers.FromDockerfile{
+			Context:    dockerfileDir,
+			Dockerfile: "Dockerfile",
+			KeepImage:  true,
+		},
+		ExposedPorts: []string{"5432/tcp"},
+		Networks:     []string{nw.Name},
+		Env:          map[string]string{"PGPASSWORD": replicaSetupPassword},
+		Entrypoint:   []string{"bash", "-c", standbySetupScript},
+		WaitingFor: wait.
+			ForLog("database system is ready to accept read-only connections").
+			WithStartupTimeout(2 * time.Minute),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("starting standby postgres container: %w", err)
+	}
+	cleanups = append(cleanups, func() error { return standby.Terminate(ctx) })
+
+	if *primaryURL, err = postgresReplicaURL(ctx, primary); err != nil {
+		return nil, fmt.Errorf("retrieving primary connection string: %w", err)
+	}
+	if *replicaURL, err = postgresReplicaURL(ctx, standby); err != nil {
+		return nil, fmt.Errorf("retrieving standby connection string: %w", err)
+	}
+
+	failed = false
+	return cleanupAll, nil
+}
+
+func runPostgresReplicaContainer(ctx context.Context, req testcontainers.ContainerRequest) (testcontainers.Container, error) {
+	return testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+}
+
+func allowReplicationConnections(ctx context.Context, ctr testcontainers.Container) error {
+	appendHBA := []string{
+		"bash", "-c",
+		`echo "host replication all all scram-sha-256" >> "$PGDATA/pg_hba.conf"`,
+	}
+	if code, _, err := ctr.Exec(ctx, appendHBA); err != nil || code != 0 {
+		return fmt.Errorf("appending replication entry to pg_hba.conf (exit %d): %w", code, err)
+	}
+
+	reload := []string{"psql", "-U", replicaSetupUser, "-tAc", "select pg_reload_conf()"}
+	if code, _, err := ctr.Exec(ctx, reload); err != nil || code != 0 {
+		return fmt.Errorf("reloading postgres configuration (exit %d): %w", code, err)
+	}
+	return nil
+}
+
+func postgresReplicaURL(ctx context.Context, ctr testcontainers.Container) (string, error) {
+	host, err := ctr.Host(ctx)
+	if err != nil {
+		return "", err
+	}
+	port, err := ctr.MappedPort(ctx, "5432/tcp")
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
+		replicaSetupUser, replicaSetupPassword, host, port.Port(), replicaSetupDB), nil
+}
+
+// walReplicaDockerfileDir resolves the build context relative to this source
+// file, so the helper works regardless of the test's working directory.
+func walReplicaDockerfileDir() (string, error) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("resolving testcontainers source path")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "testdata", "pg-wal2json"), nil
+}

--- a/internal/testcontainers/testdata/pg-wal2json/Dockerfile
+++ b/internal/testcontainers/testdata/pg-wal2json/Dockerfile
@@ -1,8 +1,4 @@
-# Postgres 17 with the wal2json output plugin.
-#
-# Logical decoding on a standby requires Postgres 16 or later, and the
-# debezium/postgres images used elsewhere in the test suite only ship wal2json
-# up to the 14 tag, so the replica tests build their own image instead.
+# Postgres with the wal2json output plugin, for the read replica tests.
 FROM postgres:17
 
 RUN apt-get update \

--- a/internal/testcontainers/testdata/pg-wal2json/Dockerfile
+++ b/internal/testcontainers/testdata/pg-wal2json/Dockerfile
@@ -1,0 +1,10 @@
+# Postgres 17 with the wal2json output plugin.
+#
+# Logical decoding on a standby requires Postgres 16 or later, and the
+# debezium/postgres images used elsewhere in the test suite only ship wal2json
+# up to the 14 tag, so the replica tests build their own image instead.
+FROM postgres:17
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-17-wal2json \
+    && rm -rf /var/lib/apt/lists/*

--- a/pkg/stream/integration/pg_replica_integration_test.go
+++ b/pkg/stream/integration/pg_replica_integration_test.go
@@ -78,13 +78,14 @@ func Test_ReplicaSourceSnapshotAndReplication(t *testing.T) {
 	// the snapshot reads from the standby, including the parallel path that
 	// exports a transaction snapshot and imports it on sibling connections
 	require.Eventually(t, func() bool {
-		rows := fetchReplicaTestRows(t, ctx, targetConn, testTable, false)
-		return len(rows) == 2
+		rows, err := fetchReplicaTestRows(ctx, targetConn, testTable, false)
+		return err == nil && len(rows) == 2
 	}, 60*time.Second, time.Second, "timeout waiting for snapshot from standby")
 
+	snapshotRows, err := fetchReplicaTestRows(ctx, targetConn, testTable, false)
+	require.NoError(t, err)
 	require.ElementsMatch(t,
-		[]replicaTestRow{{id: 1, name: "a"}, {id: 2, name: "b"}},
-		fetchReplicaTestRows(t, ctx, targetConn, testTable, false))
+		[]replicaTestRow{{id: 1, name: "a"}, {id: 2, name: "b"}}, snapshotRows)
 
 	// DDL runs on the primary, so the event trigger fires there. If the emitted
 	// logical message survives the trip through physical replication and out of
@@ -95,17 +96,21 @@ func Test_ReplicaSourceSnapshotAndReplication(t *testing.T) {
 		`INSERT INTO %s(name, email) VALUES('c','c@test.com')`, testTable))
 
 	require.Eventually(t, func() bool {
-		if !targetHasColumn(t, ctx, targetConn, testTable, "email") {
+		hasColumn, err := targetHasColumn(ctx, targetConn, testTable, "email")
+		if err != nil || !hasColumn {
 			return false
 		}
-		return len(fetchReplicaTestRows(t, ctx, targetConn, testTable, true)) == 3
+		rows, err := fetchReplicaTestRows(ctx, targetConn, testTable, true)
+		return err == nil && len(rows) == 3
 	}, 60*time.Second, time.Second, "timeout waiting for DDL and DML replicated from standby")
 
+	replicatedRows, err := fetchReplicaTestRows(ctx, targetConn, testTable, true)
+	require.NoError(t, err)
 	require.ElementsMatch(t, []replicaTestRow{
 		{id: 1, name: "a"},
 		{id: 2, name: "b"},
 		{id: 3, name: "c", email: "c@test.com"},
-	}, fetchReplicaTestRows(t, ctx, targetConn, testTable, true))
+	}, replicatedRows)
 
 	// A logical slot on a standby is invalidated by recovery conflicts unless
 	// hot_standby_feedback keeps the primary from vacuuming rows the decoder
@@ -249,9 +254,13 @@ type replicaTestRow struct {
 	email string
 }
 
-func fetchReplicaTestRows(t *testing.T, ctx context.Context, conn pglib.Querier, table string, withEmail bool) []replicaTestRow {
-	t.Helper()
-
+// fetchReplicaTestRows returns an error rather than asserting, because it is
+// called from inside require.Eventually closures. Those run on their own
+// goroutine, where a require failure calls runtime.Goexit and the result is
+// never sent back to Eventually: the test would stall for the whole timeout and
+// then report the generic "condition never satisfied" message, hiding the error
+// that actually caused it.
+func fetchReplicaTestRows(ctx context.Context, conn pglib.Querier, table string, withEmail bool) ([]replicaTestRow, error) {
 	query := fmt.Sprintf("SELECT id, name FROM %s ORDER BY id", table)
 	if withEmail {
 		query = fmt.Sprintf("SELECT id, name, COALESCE(email,'') FROM %s ORDER BY id", table)
@@ -260,7 +269,7 @@ func fetchReplicaTestRows(t *testing.T, ctx context.Context, conn pglib.Querier,
 	rows, err := conn.Query(ctx, query)
 	if err != nil {
 		// the table may not exist yet while the snapshot is still running
-		return nil
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -268,23 +277,24 @@ func fetchReplicaTestRows(t *testing.T, ctx context.Context, conn pglib.Querier,
 	for rows.Next() {
 		row := replicaTestRow{}
 		if withEmail {
-			require.NoError(t, rows.Scan(&row.id, &row.name, &row.email))
+			err = rows.Scan(&row.id, &row.name, &row.email)
 		} else {
-			require.NoError(t, rows.Scan(&row.id, &row.name))
+			err = rows.Scan(&row.id, &row.name)
+		}
+		if err != nil {
+			return nil, err
 		}
 		result = append(result, row)
 	}
-	require.NoError(t, rows.Err())
-	return result
+	return result, rows.Err()
 }
 
-func targetHasColumn(t *testing.T, ctx context.Context, conn pglib.Querier, table, column string) bool {
-	t.Helper()
-
+// targetHasColumn also returns its error, for the same reason as
+// fetchReplicaTestRows.
+func targetHasColumn(ctx context.Context, conn pglib.Querier, table, column string) (bool, error) {
 	var found bool
 	err := conn.QueryRow(ctx, []any{&found}, `SELECT EXISTS(
 		SELECT 1 FROM information_schema.columns
 		WHERE table_name = $1 AND column_name = $2)`, table, column)
-	require.NoError(t, err)
-	return found
+	return found, err
 }

--- a/pkg/stream/integration/pg_replica_integration_test.go
+++ b/pkg/stream/integration/pg_replica_integration_test.go
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/testcontainers"
+	pgsnapshotgenerator "github.com/xataio/pgstream/pkg/snapshot/generator/postgres/data"
+	"github.com/xataio/pgstream/pkg/snapshot/generator/postgres/schema/pgdumprestore"
+	"github.com/xataio/pgstream/pkg/stream"
+	"github.com/xataio/pgstream/pkg/wal/listener/snapshot/adapter"
+	snapshotbuilder "github.com/xataio/pgstream/pkg/wal/listener/snapshot/builder"
+	pgreplication "github.com/xataio/pgstream/pkg/wal/replication/postgres"
+)
+
+// Test_ReplicaSourceSnapshotAndReplication runs the whole pipeline — snapshot
+// and replication — against a physical standby rather than the primary, which
+// is how a deployment keeps snapshot load off a primary that cannot afford it.
+//
+// The arrangement rests on one property that is worth pinning down with a test,
+// because it is not obvious: pgstream's DDL replication keeps working even
+// though its event trigger can only ever run on the primary. The trigger emits
+// DDL through pg_logical_emit_message, which writes an ordinary WAL record; the
+// standby replays that record like any other, so a logical slot on the standby
+// decodes it. Nothing has to be (or can be) installed on the standby itself.
+func Test_ReplicaSourceSnapshotAndReplication(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	var primaryURL, replicaURL string
+	pgcleanup, err := testcontainers.SetupPostgresPrimaryReplica(context.Background(), &primaryURL, &replicaURL)
+	require.NoError(t, err)
+	defer pgcleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const testTable = "replica_source_integration_test"
+
+	// pgstream's internal state goes on the primary. The standby is read only,
+	// and an event trigger there would never fire anyway: WAL replay is
+	// physical redo, not command execution. MigrationsOnly skips creating a
+	// slot on the primary, since the slot this test uses lives on the standby.
+	require.NoError(t, stream.Init(ctx, &stream.InitConfig{
+		PostgresURL:    primaryURL,
+		MigrationsOnly: true,
+	}))
+
+	// seed on the primary before the snapshot, so the snapshot has pre-existing
+	// rows to copy rather than picking them up through replication
+	execQueryWithURL(t, ctx, primaryURL, fmt.Sprintf(
+		`CREATE TABLE %s(id serial PRIMARY KEY, name TEXT)`, testTable))
+	execQueryWithURL(t, ctx, primaryURL, fmt.Sprintf(
+		`INSERT INTO %s(name) VALUES('a'),('b')`, testTable))
+
+	waitForStandbyReplay(t, ctx, primaryURL, replicaURL)
+
+	slotName := createLogicalSlotOnStandby(t, ctx, primaryURL, replicaURL)
+
+	cfg := &stream.Config{
+		Listener:  replicaListenerCfg(replicaURL, targetPGURL, slotName, []string{testTable}),
+		Processor: testPostgresProcessorCfgWithTargetURL(targetPGURL),
+	}
+	runStream(t, ctx, cfg)
+
+	targetConn, err := pglib.NewConn(ctx, targetPGURL)
+	require.NoError(t, err)
+	defer targetConn.Close(ctx)
+
+	// the snapshot reads from the standby, including the parallel path that
+	// exports a transaction snapshot and imports it on sibling connections
+	require.Eventually(t, func() bool {
+		rows := fetchReplicaTestRows(t, ctx, targetConn, testTable, false)
+		return len(rows) == 2
+	}, 60*time.Second, time.Second, "timeout waiting for snapshot from standby")
+
+	require.ElementsMatch(t,
+		[]replicaTestRow{{id: 1, name: "a"}, {id: 2, name: "b"}},
+		fetchReplicaTestRows(t, ctx, targetConn, testTable, false))
+
+	// DDL runs on the primary, so the event trigger fires there. If the emitted
+	// logical message survives the trip through physical replication and out of
+	// the standby's logical slot, the new column shows up on the target.
+	execQueryWithURL(t, ctx, primaryURL, fmt.Sprintf(
+		`ALTER TABLE %s ADD COLUMN email TEXT`, testTable))
+	execQueryWithURL(t, ctx, primaryURL, fmt.Sprintf(
+		`INSERT INTO %s(name, email) VALUES('c','c@test.com')`, testTable))
+
+	require.Eventually(t, func() bool {
+		if !targetHasColumn(t, ctx, targetConn, testTable, "email") {
+			return false
+		}
+		return len(fetchReplicaTestRows(t, ctx, targetConn, testTable, true)) == 3
+	}, 60*time.Second, time.Second, "timeout waiting for DDL and DML replicated from standby")
+
+	require.ElementsMatch(t, []replicaTestRow{
+		{id: 1, name: "a"},
+		{id: 2, name: "b"},
+		{id: 3, name: "c", email: "c@test.com"},
+	}, fetchReplicaTestRows(t, ctx, targetConn, testTable, true))
+
+	// A logical slot on a standby is invalidated by recovery conflicts unless
+	// hot_standby_feedback keeps the primary from vacuuming rows the decoder
+	// still needs. Without this check the test would pass simply by being fast,
+	// and hide a setup that falls over on a busier primary.
+	requireSlotNotConflicting(t, ctx, replicaURL, slotName)
+}
+
+func replicaListenerCfg(sourceURL, targetURL, slotName string, tables []string) stream.ListenerConfig {
+	return stream.ListenerConfig{
+		Postgres: &stream.PostgresListenerConfig{
+			URL: sourceURL,
+			Replication: pgreplication.Config{
+				PostgresURL:         sourceURL,
+				ReplicationSlotName: slotName,
+			},
+			Snapshot: &snapshotbuilder.SnapshotListenerConfig{
+				Data: &pgsnapshotgenerator.Config{
+					URL: sourceURL,
+					// exercise the parallel path, so the test covers
+					// SET TRANSACTION SNAPSHOT against a standby rather than
+					// quietly passing through a single connection
+					SchemaWorkers: 2,
+					TableWorkers:  2,
+				},
+				Adapter: adapter.SnapshotConfig{
+					Tables: tables,
+				},
+				Schema: &snapshotbuilder.SchemaSnapshotConfig{
+					DumpRestore: &pgdumprestore.Config{
+						SourcePGURL: sourceURL,
+						TargetPGURL: targetURL,
+					},
+				},
+			},
+		},
+	}
+}
+
+// waitForStandbyReplay blocks until the standby has replayed everything the
+// primary had written when it was called. Any assertion that follows a write on
+// the primary needs this, otherwise it races replication.
+func waitForStandbyReplay(t *testing.T, ctx context.Context, primaryURL, replicaURL string) {
+	t.Helper()
+
+	primaryConn, err := pglib.NewConn(ctx, primaryURL)
+	require.NoError(t, err)
+	defer primaryConn.Close(ctx)
+
+	var primaryLSN string
+	require.NoError(t, primaryConn.QueryRow(ctx, []any{&primaryLSN}, "SELECT pg_current_wal_lsn()::text"))
+
+	replicaConn, err := pglib.NewConn(ctx, replicaURL)
+	require.NoError(t, err)
+	defer replicaConn.Close(ctx)
+
+	require.Eventually(t, func() bool {
+		var replayed bool
+		if err := replicaConn.QueryRow(ctx, []any{&replayed},
+			"SELECT pg_last_wal_replay_lsn() >= $1::pg_lsn", primaryLSN); err != nil {
+			return false
+		}
+		return replayed
+	}, 60*time.Second, 200*time.Millisecond, "standby did not replay up to %s", primaryLSN)
+}
+
+// createLogicalSlotOnStandby creates the slot pgstream will stream from, on the
+// standby rather than the primary.
+//
+// Creating a logical slot on a standby blocks until the primary emits an
+// xl_running_xacts record, which is what lets the standby build a consistent
+// catalog snapshot. A quiet primary may never emit one on its own, so this
+// nudges it with pg_log_standby_snapshot() until the slot appears. Skipping
+// that turns an idle primary into an indefinite hang rather than a failure.
+func createLogicalSlotOnStandby(t *testing.T, ctx context.Context, primaryURL, replicaURL string) string {
+	t.Helper()
+
+	slotName := fmt.Sprintf("pgstream_replica_it_%d", time.Now().UnixNano())
+
+	created := make(chan error, 1)
+	go func() {
+		conn, err := pglib.NewConn(ctx, replicaURL)
+		if err != nil {
+			created <- err
+			return
+		}
+		defer conn.Close(ctx)
+
+		var name string
+		created <- conn.QueryRow(ctx, []any{&name},
+			"SELECT slot_name FROM pg_create_logical_replication_slot($1, 'wal2json')", slotName)
+	}()
+
+	primaryConn, err := pglib.NewConn(ctx, primaryURL)
+	require.NoError(t, err)
+	defer primaryConn.Close(ctx)
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	timeout := time.NewTimer(90 * time.Second)
+	defer timeout.Stop()
+
+	for {
+		select {
+		case err := <-created:
+			// no cleanup registered for the slot: it lives on the standby
+			// container, which this test owns and tears down on the way out. A
+			// t.Cleanup here would run after the containers are already gone.
+			require.NoError(t, err, "creating logical replication slot on standby")
+			return slotName
+		case <-ticker.C:
+			// best effort: the slot creation is the thing being waited on, and
+			// a failed nudge just means the next tick tries again
+			_, _ = primaryConn.Exec(ctx, "SELECT pg_log_standby_snapshot()")
+		case <-timeout.C:
+			t.Fatal("timeout creating logical replication slot on standby")
+			return ""
+		}
+	}
+}
+
+func requireSlotNotConflicting(t *testing.T, ctx context.Context, replicaURL, slotName string) {
+	t.Helper()
+
+	conn, err := pglib.NewConn(ctx, replicaURL)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	var conflicting *bool
+	require.NoError(t, conn.QueryRow(ctx, []any{&conflicting},
+		"SELECT conflicting FROM pg_replication_slots WHERE slot_name = $1", slotName),
+		"logical slot %s is gone from the standby", slotName)
+
+	if conflicting != nil {
+		require.False(t, *conflicting,
+			"logical slot %s was invalidated by a recovery conflict on the standby", slotName)
+	}
+}
+
+type replicaTestRow struct {
+	id    int
+	name  string
+	email string
+}
+
+func fetchReplicaTestRows(t *testing.T, ctx context.Context, conn pglib.Querier, table string, withEmail bool) []replicaTestRow {
+	t.Helper()
+
+	query := fmt.Sprintf("SELECT id, name FROM %s ORDER BY id", table)
+	if withEmail {
+		query = fmt.Sprintf("SELECT id, name, COALESCE(email,'') FROM %s ORDER BY id", table)
+	}
+
+	rows, err := conn.Query(ctx, query)
+	if err != nil {
+		// the table may not exist yet while the snapshot is still running
+		return nil
+	}
+	defer rows.Close()
+
+	result := []replicaTestRow{}
+	for rows.Next() {
+		row := replicaTestRow{}
+		if withEmail {
+			require.NoError(t, rows.Scan(&row.id, &row.name, &row.email))
+		} else {
+			require.NoError(t, rows.Scan(&row.id, &row.name))
+		}
+		result = append(result, row)
+	}
+	require.NoError(t, rows.Err())
+	return result
+}
+
+func targetHasColumn(t *testing.T, ctx context.Context, conn pglib.Querier, table, column string) bool {
+	t.Helper()
+
+	var found bool
+	err := conn.QueryRow(ctx, []any{&found}, `SELECT EXISTS(
+		SELECT 1 FROM information_schema.columns
+		WHERE table_name = $1 AND column_name = $2)`, table, column)
+	require.NoError(t, err)
+	return found
+}

--- a/pkg/stream/integration/pg_replica_integration_test.go
+++ b/pkg/stream/integration/pg_replica_integration_test.go
@@ -185,18 +185,16 @@ func createLogicalSlotOnStandby(t *testing.T, ctx context.Context, primaryURL, r
 
 	slotName := fmt.Sprintf("pgstream_replica_it_%d", time.Now().UnixNano())
 
+	// slot-only init is what makes this workable against a standby: it creates
+	// the slot without attempting the pgstream schema or migrations, which
+	// would fail on a read only server
 	created := make(chan error, 1)
 	go func() {
-		conn, err := pglib.NewConn(ctx, replicaURL)
-		if err != nil {
-			created <- err
-			return
-		}
-		defer conn.Close(ctx)
-
-		var name string
-		created <- conn.QueryRow(ctx, []any{&name},
-			"SELECT slot_name FROM pg_create_logical_replication_slot($1, 'wal2json')", slotName)
+		created <- stream.Init(ctx, &stream.InitConfig{
+			PostgresURL:         replicaURL,
+			ReplicationSlotName: slotName,
+			SlotOnly:            true,
+		})
 	}()
 
 	primaryConn, err := pglib.NewConn(ctx, primaryURL)

--- a/pkg/stream/stream_init.go
+++ b/pkg/stream/stream_init.go
@@ -22,6 +22,7 @@ type InitConfig struct {
 	ReplicationSlotName       string
 	InjectorMigrationsEnabled bool
 	MigrationsOnly            bool
+	SlotOnly                  bool
 	Upgrade                   bool
 	// PhaseTracker is optional runtime state for stream.Run; Init/Destroy ignore it.
 	PhaseTracker *phase.Tracker
@@ -32,6 +33,12 @@ type InitOption func(*InitConfig)
 func WithMigrationsOnly() InitOption {
 	return func(cfg *InitConfig) {
 		cfg.MigrationsOnly = true
+	}
+}
+
+func WithSlotOnly() InitOption {
+	return func(cfg *InitConfig) {
+		cfg.SlotOnly = true
 	}
 }
 
@@ -53,13 +60,19 @@ const (
 	pgstreamSchema = "pgstream"
 )
 
-var errMissingPostgresURL = errors.New("postgres URL is required")
+var (
+	errMissingPostgresURL    = errors.New("postgres URL is required")
+	errMigrationsAndSlotOnly = errors.New("migrations-only and slot-only are mutually exclusive")
+)
 
 // Init initialises the pgstream state in the postgres database provided, along
 // with creating the relevant replication slot if it doesn't already exist.
 func Init(ctx context.Context, config *InitConfig) error {
 	if config.PostgresURL == "" {
 		return errMissingPostgresURL
+	}
+	if config.MigrationsOnly && config.SlotOnly {
+		return errMigrationsAndSlotOnly
 	}
 
 	conn, err := newPGConn(ctx, config.PostgresURL)
@@ -68,36 +81,40 @@ func Init(ctx context.Context, config *InitConfig) error {
 	}
 	defer conn.Close(ctx)
 
-	// first create the pgstream schema so that the migrations table is
-	// created under it
-	if err := createPGStreamSchema(ctx, conn); err != nil {
-		return fmt.Errorf("failed to create pgstream schema: %w", err)
-	}
-
-	if config.Upgrade {
-		if err := cleanupV09xState(ctx, conn); err != nil {
-			return fmt.Errorf("failed to clean up v0.9.x state: %w", err)
+	// the schema and migrations are skipped entirely in slot-only mode: the
+	// target may be a read only standby, where every statement below would fail
+	if !config.SlotOnly {
+		// first create the pgstream schema so that the migrations table is
+		// created under it
+		if err := createPGStreamSchema(ctx, conn); err != nil {
+			return fmt.Errorf("failed to create pgstream schema: %w", err)
 		}
-	}
 
-	migrationAssets := []*migratorlib.MigrationAssets{
-		migratorlib.GetCoreMigrationAssets(),
-	}
-	if config.InjectorMigrationsEnabled {
-		migrationAssets = append(migrationAssets, migratorlib.GetInjectorMigrationAssets())
-	}
-	migrator, err := migratorlib.NewPGMigrator(config.PostgresURL, migrationAssets)
-	if err != nil {
-		return fmt.Errorf("error creating postgres migrator: %w", err)
-	}
+		if config.Upgrade {
+			if err := cleanupV09xState(ctx, conn); err != nil {
+				return fmt.Errorf("failed to clean up v0.9.x state: %w", err)
+			}
+		}
 
-	if err := migrator.Up(); err != nil && !errors.Is(err, migratorlib.ErrNoChange) {
-		return fmt.Errorf("failed to run internal pgstream migrations: %w", err)
-	}
+		migrationAssets := []*migratorlib.MigrationAssets{
+			migratorlib.GetCoreMigrationAssets(),
+		}
+		if config.InjectorMigrationsEnabled {
+			migrationAssets = append(migrationAssets, migratorlib.GetInjectorMigrationAssets())
+		}
+		migrator, err := migratorlib.NewPGMigrator(config.PostgresURL, migrationAssets)
+		if err != nil {
+			return fmt.Errorf("error creating postgres migrator: %w", err)
+		}
 
-	// if only migrations need to be run, return early
-	if config.MigrationsOnly {
-		return nil
+		if err := migrator.Up(); err != nil && !errors.Is(err, migratorlib.ErrNoChange) {
+			return fmt.Errorf("failed to run internal pgstream migrations: %w", err)
+		}
+
+		// if only migrations need to be run, return early
+		if config.MigrationsOnly {
+			return nil
+		}
 	}
 
 	if config.ReplicationSlotName == "" {
@@ -134,12 +151,21 @@ func Destroy(ctx context.Context, config *InitConfig) error {
 	if config.PostgresURL == "" {
 		return errMissingPostgresURL
 	}
+	if config.MigrationsOnly && config.SlotOnly {
+		return errMigrationsAndSlotOnly
+	}
 
 	conn, err := newPGConn(ctx, config.PostgresURL)
 	if err != nil {
 		return err
 	}
 	defer conn.Close(ctx)
+
+	// in slot-only mode the pgstream schema is left in place, so the emit_ddl
+	// event trigger keeps working for anything still replicating from it
+	if config.SlotOnly {
+		return dropConfiguredReplicationSlot(ctx, conn, config)
+	}
 
 	migrationAssets := []*migratorlib.MigrationAssets{
 		migratorlib.GetCoreMigrationAssets(),
@@ -171,7 +197,14 @@ func Destroy(ctx context.Context, config *InitConfig) error {
 		return fmt.Errorf("failed to drop pgstream schema: %w", err)
 	}
 
+	return dropConfiguredReplicationSlot(ctx, conn, config)
+}
+
+// dropConfiguredReplicationSlot resolves the slot name the same way Init does,
+// defaulting it from the database name when it isn't configured, and drops it.
+func dropConfiguredReplicationSlot(ctx context.Context, conn *pgx.Conn, config *InitConfig) error {
 	if config.ReplicationSlotName == "" {
+		var err error
 		config.ReplicationSlotName, err = getReplicationSlotName(config.PostgresURL)
 		if err != nil {
 			return err
@@ -182,11 +215,7 @@ func Destroy(ctx context.Context, config *InitConfig) error {
 		return err
 	}
 
-	if err := dropReplicationSlot(ctx, conn, config.ReplicationSlotName); err != nil {
-		return err
-	}
-
-	return nil
+	return dropReplicationSlot(ctx, conn, config.ReplicationSlotName)
 }
 
 func createPGStreamSchema(ctx context.Context, conn *pgx.Conn) error {

--- a/pkg/stream/stream_init.go
+++ b/pkg/stream/stream_init.go
@@ -6,10 +6,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	migratorlib "github.com/xataio/pgstream/internal/migrator"
 	"github.com/xataio/pgstream/internal/phase"
 	pglib "github.com/xataio/pgstream/internal/postgres"
+	loglib "github.com/xataio/pgstream/pkg/log"
 
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/jackc/pgerrcode"
@@ -26,9 +28,20 @@ type InitConfig struct {
 	Upgrade                   bool
 	// PhaseTracker is optional runtime state for stream.Run; Init/Destroy ignore it.
 	PhaseTracker *phase.Tracker
+	// Logger is optional. Init uses it to report progress that would otherwise
+	// be invisible, such as a replication slot creation that is blocked rather
+	// than slow. Defaults to a no-op logger.
+	Logger loglib.Logger
 }
 
 type InitOption func(*InitConfig)
+
+// WithInitLogger sets the logger Init and Destroy report progress through.
+func WithInitLogger(logger loglib.Logger) InitOption {
+	return func(cfg *InitConfig) {
+		cfg.Logger = logger
+	}
+}
 
 func WithMigrationsOnly() InitOption {
 	return func(cfg *InitConfig) {
@@ -63,7 +76,22 @@ const (
 var (
 	errMissingPostgresURL    = errors.New("postgres URL is required")
 	errMigrationsAndSlotOnly = errors.New("migrations-only and slot-only are mutually exclusive")
+	// upgrade only cleans up v0.9.x schema state, which slot-only skips
+	// entirely, so accepting both would silently drop the upgrade
+	errUpgradeAndSlotOnly = errors.New("upgrade and slot-only are mutually exclusive")
 )
+
+// validateRestrictions rejects flag combinations that select disjoint halves of
+// the work, so a caller never gets one silently ignored.
+func (c *InitConfig) validateRestrictions() error {
+	if c.MigrationsOnly && c.SlotOnly {
+		return errMigrationsAndSlotOnly
+	}
+	if c.Upgrade && c.SlotOnly {
+		return errUpgradeAndSlotOnly
+	}
+	return nil
+}
 
 // Init initialises the pgstream state in the postgres database provided, along
 // with creating the relevant replication slot if it doesn't already exist.
@@ -71,8 +99,8 @@ func Init(ctx context.Context, config *InitConfig) error {
 	if config.PostgresURL == "" {
 		return errMissingPostgresURL
 	}
-	if config.MigrationsOnly && config.SlotOnly {
-		return errMigrationsAndSlotOnly
+	if err := config.validateRestrictions(); err != nil {
+		return err
 	}
 
 	conn, err := newPGConn(ctx, config.PostgresURL)
@@ -138,11 +166,51 @@ func Init(ctx context.Context, config *InitConfig) error {
 		return nil
 	}
 
-	if err := createReplicationSlot(ctx, conn, config.ReplicationSlotName); err != nil {
+	stopHint := warnOnSlowSlotCreation(ctx, config)
+	err = createReplicationSlot(ctx, conn, config.ReplicationSlotName)
+	stopHint()
+	if err != nil {
 		return fmt.Errorf("failed to create replication slot: %w", err)
 	}
 
 	return nil
+}
+
+// slotCreationHintDelay is how long slot creation is allowed to run before the
+// hint is logged. Long enough that a normally slow creation stays quiet, short
+// enough to reach someone still watching the command.
+const slotCreationHintDelay = 10 * time.Second
+
+// warnOnSlowSlotCreation logs a hint if slot creation has not finished within
+// slotCreationHintDelay, and returns a function that cancels it.
+//
+// Creating a logical slot on a standby blocks until the primary emits an
+// xl_running_xacts record, which is what lets the standby build a consistent
+// catalog snapshot. A primary taking writes emits one within seconds, but one
+// that has gone quiet may never emit one at all — so the call can wait forever
+// with no error and no timeout. Without this hint that is indistinguishable
+// from a slow connection, and the fix (a statement on a different server) is
+// not something a caller would guess.
+func warnOnSlowSlotCreation(ctx context.Context, config *InitConfig) (stop func()) {
+	logger := config.Logger
+	if logger == nil {
+		return func() {}
+	}
+
+	hintCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		select {
+		case <-hintCtx.Done():
+		case <-time.After(slotCreationHintDelay):
+			logger.Warn(nil, "still waiting to create the replication slot", loglib.Fields{
+				"slot_name": config.ReplicationSlotName,
+				"hint": "if the source is a read replica, this waits for a running-xacts record from its primary. " +
+					"Run 'SELECT pg_log_standby_snapshot()' on the primary to unblock it",
+			})
+		}
+	}()
+
+	return cancel
 }
 
 // Destroy removes the pgstream state from the postgres database provided,
@@ -151,8 +219,8 @@ func Destroy(ctx context.Context, config *InitConfig) error {
 	if config.PostgresURL == "" {
 		return errMissingPostgresURL
 	}
-	if config.MigrationsOnly && config.SlotOnly {
-		return errMigrationsAndSlotOnly
+	if err := config.validateRestrictions(); err != nil {
+		return err
 	}
 
 	conn, err := newPGConn(ctx, config.PostgresURL)

--- a/pkg/stream/stream_init_test.go
+++ b/pkg/stream/stream_init_test.go
@@ -176,6 +176,31 @@ func TestWithUpgrade(t *testing.T) {
 	require.True(t, cfg.Upgrade)
 }
 
+func TestWithSlotOnly(t *testing.T) {
+	t.Parallel()
+
+	cfg := &InitConfig{}
+	WithSlotOnly()(cfg)
+	require.True(t, cfg.SlotOnly)
+}
+
+// TestInit_MigrationsOnlyAndSlotOnly checks the two restrictions are rejected
+// together rather than one silently winning: they select disjoint halves of the
+// work, so asking for both is always a configuration mistake.
+func TestInit_MigrationsOnlyAndSlotOnly(t *testing.T) {
+	t.Parallel()
+
+	cfg := &InitConfig{
+		PostgresURL:    "postgres://user:pass@localhost:5432/db",
+		MigrationsOnly: true,
+		SlotOnly:       true,
+	}
+
+	// no connection is attempted: the conflict is caught before any I/O
+	require.ErrorIs(t, Init(context.Background(), cfg), errMigrationsAndSlotOnly)
+	require.ErrorIs(t, Destroy(context.Background(), cfg), errMigrationsAndSlotOnly)
+}
+
 // setupV09xState creates the database objects that v0.9.x would have created.
 func setupV09xState(t *testing.T, ctx context.Context, conn *pgx.Conn) {
 	t.Helper()

--- a/pkg/stream/stream_init_test.go
+++ b/pkg/stream/stream_init_test.go
@@ -184,21 +184,41 @@ func TestWithSlotOnly(t *testing.T) {
 	require.True(t, cfg.SlotOnly)
 }
 
-// TestInit_MigrationsOnlyAndSlotOnly checks the two restrictions are rejected
-// together rather than one silently winning: they select disjoint halves of the
-// work, so asking for both is always a configuration mistake.
-func TestInit_MigrationsOnlyAndSlotOnly(t *testing.T) {
+// TestInit_ConflictingRestrictions checks conflicting flags are rejected rather
+// than one silently winning. Each pair selects disjoint halves of the work, so
+// asking for both is always a configuration mistake: --migrations-only is the
+// complement of --slot-only, and --upgrade only cleans up schema state that
+// --slot-only skips entirely.
+func TestInit_ConflictingRestrictions(t *testing.T) {
 	t.Parallel()
 
-	cfg := &InitConfig{
-		PostgresURL:    "postgres://user:pass@localhost:5432/db",
-		MigrationsOnly: true,
-		SlotOnly:       true,
+	const url = "postgres://user:pass@localhost:5432/db"
+
+	tests := []struct {
+		name    string
+		cfg     *InitConfig
+		wantErr error
+	}{
+		{
+			name:    "migrations-only with slot-only",
+			cfg:     &InitConfig{PostgresURL: url, MigrationsOnly: true, SlotOnly: true},
+			wantErr: errMigrationsAndSlotOnly,
+		},
+		{
+			name:    "upgrade with slot-only",
+			cfg:     &InitConfig{PostgresURL: url, Upgrade: true, SlotOnly: true},
+			wantErr: errUpgradeAndSlotOnly,
+		},
 	}
 
-	// no connection is attempted: the conflict is caught before any I/O
-	require.ErrorIs(t, Init(context.Background(), cfg), errMigrationsAndSlotOnly)
-	require.ErrorIs(t, Destroy(context.Background(), cfg), errMigrationsAndSlotOnly)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// no connection is attempted: the conflict is caught before any I/O
+			require.ErrorIs(t, Init(context.Background(), tc.cfg), tc.wantErr)
+			require.ErrorIs(t, Destroy(context.Background(), tc.cfg), tc.wantErr)
+		})
+	}
 }
 
 // setupV09xState creates the database objects that v0.9.x would have created.


### PR DESCRIPTION
#### Description

This adds an integration test for doing snapshot+streaming from a read-replica instead of from the primary. Also adds a docs page to have the procedure documented.

The only code change besides the tests is a new tiny feature: `pgstream init` gets a `--slot-only` flag. This is the equivalent of running:

```
SELECT pg_create_logical_replication_slot('pgstream_<db>_slot', 'wal2json');
```

And it simplifies a bit the setup instructions. 

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

