### PR TITLE
Add catalog helpers for reading a table's column list

### DIFF
--- a/internal/postgres/pg_utils.go
+++ b/internal/postgres/pg_utils.go
@@ -75,6 +75,11 @@ func QuoteIdentifier(s string) string {
 	return pq.QuoteIdentifier(s)
 }
 
+// QuoteRawIdentifier always quotes.
+func QuoteRawIdentifier(s string) string {
+	return pq.QuoteIdentifier(s)
+}
+
 // UnquoteIdentifier reverses the quoting applied by QuoteIdentifier. If the
 // string is not a quoted identifier, it is returned as-is. If it is a quoted
 // identifier, the leading and trailing quotes are removed, and any embedded
@@ -343,6 +348,73 @@ func DiscoverAllSchemaTables(ctx context.Context, conn Querier, schema string) (
 	}
 
 	return tableNames, nil
+}
+
+// SelectStarColumnPredicate matches SELECT *.
+const SelectStarColumnPredicate = `a.attnum > 0 AND NOT a.attisdropped`
+
+// DiscoverTableColumnsQuery lists table columns.
+var DiscoverTableColumnsQuery = fmt.Sprintf(`SELECT n.nspname, c.relname, a.attname
+	FROM pg_catalog.pg_attribute a
+	JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+	JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+	WHERE c.relkind IN ('r', 'p')
+	AND %s
+	AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast', 'pgstream')
+	AND n.nspname NOT LIKE 'pg\_temp\_%%' AND n.nspname NOT LIKE 'pg\_toast\_temp\_%%'
+	AND ($1::text[] IS NULL OR n.nspname = ANY($1))
+	AND ($2::text[] IS NULL OR c.relname = ANY($2))
+	ORDER BY n.nspname, c.relname, a.attnum`, SelectStarColumnPredicate)
+
+// SchemaTableColumns: unquoted schema, table.
+type SchemaTableColumns map[string]map[string][]string
+
+// ColumnsFor returns recorded columns.
+func (c SchemaTableColumns) ColumnsFor(schema, table string) []string {
+	if c == nil {
+		return nil
+	}
+	return c[UnquoteIdentifier(schema)][UnquoteIdentifier(table)]
+}
+
+// DiscoverTableColumns reads the catalog once.
+// Empty arguments mean no filter.
+func DiscoverTableColumns(ctx context.Context, conn Querier, schemas, tables []string) (SchemaTableColumns, error) {
+	unquote := func(names []string) []string {
+		if len(names) == 0 {
+			// nil filters nothing, empty nothing
+			return nil
+		}
+		unquoted := make([]string, len(names))
+		for i, name := range names {
+			unquoted[i] = UnquoteIdentifier(name)
+		}
+		return unquoted
+	}
+
+	rows, err := conn.Query(ctx, DiscoverTableColumnsQuery, unquote(schemas), unquote(tables))
+	if err != nil {
+		return nil, fmt.Errorf("discovering table columns: %w", err)
+	}
+	defer rows.Close()
+
+	tableColumns := SchemaTableColumns{}
+	for rows.Next() {
+		var schemaName, tableName, columnName string
+		if err := rows.Scan(&schemaName, &tableName, &columnName); err != nil {
+			return nil, fmt.Errorf("scanning table column: %w", err)
+		}
+		if _, found := tableColumns[schemaName]; !found {
+			tableColumns[schemaName] = map[string][]string{}
+		}
+		tableColumns[schemaName][tableName] = append(tableColumns[schemaName][tableName], columnName)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return tableColumns, nil
 }
 
 func ParseConfig(pgurl string) (*pgx.ConnConfig, error) {

--- a/internal/postgres/pg_utils_integration_test.go
+++ b/internal/postgres/pg_utils_integration_test.go
@@ -137,3 +137,66 @@ func Test_WithRawJSONDecoding(t *testing.T) {
 		require.IsType(t, map[string]any{}, values[1])
 	})
 }
+
+func Test_DiscoverTableColumns(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx := context.Background()
+
+	var pgURL string
+	cleanup, err := testcontainers.SetupPostgresContainer(ctx, &pgURL, testcontainers.Postgres17)
+	require.NoError(t, err)
+	defer cleanup()
+
+	conn, err := NewConnPool(ctx, pgURL)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	for _, ddl := range []string{
+		`CREATE SCHEMA other_schema`,
+		`CREATE TABLE public.discover_columns(zeta text, alpha int, to_drop text)`,
+		`ALTER TABLE public.discover_columns DROP COLUMN to_drop`,
+		`CREATE TABLE public."MixedCase"(id int)`,
+		`CREATE TABLE other_schema.elsewhere(id int)`,
+		`CREATE VIEW public.discover_view AS SELECT 1 AS x`,
+	} {
+		_, err = conn.Exec(ctx, ddl)
+		require.NoError(t, err, ddl)
+	}
+
+	t.Run("all schemas", func(t *testing.T) {
+		columns, err := DiscoverTableColumns(ctx, conn, nil, nil)
+		require.NoError(t, err)
+
+		require.Equal(t, []string{"zeta", "alpha"}, columns["public"]["discover_columns"])
+		require.Equal(t, []string{"id"}, columns["public"]["MixedCase"])
+		require.Equal(t, []string{"id"}, columns["other_schema"]["elsewhere"])
+		require.NotContains(t, columns["public"], "discover_view")
+		require.NotContains(t, columns, "pg_catalog")
+	})
+
+	t.Run("scoped to a schema", func(t *testing.T) {
+		columns, err := DiscoverTableColumns(ctx, conn, []string{"other_schema"}, nil)
+		require.NoError(t, err)
+
+		require.Equal(t, SchemaTableColumns{"other_schema": {"elsewhere": {"id"}}}, columns)
+	})
+
+	t.Run("scoped to a schema and table", func(t *testing.T) {
+		columns, err := DiscoverTableColumns(ctx, conn, []string{"public"}, []string{"discover_columns"})
+		require.NoError(t, err)
+
+		require.Equal(t, SchemaTableColumns{"public": {"discover_columns": {"zeta", "alpha"}}}, columns)
+	})
+
+	t.Run("quoted names in the scope resolve to the catalog entry", func(t *testing.T) {
+		columns, err := DiscoverTableColumns(ctx, conn, []string{`"public"`}, []string{`"MixedCase"`})
+		require.NoError(t, err)
+
+		require.Equal(t, SchemaTableColumns{"public": {"MixedCase": {"id"}}}, columns)
+		require.Equal(t, []string{"id"}, columns.ColumnsFor(`"public"`, `"MixedCase"`))
+		require.Equal(t, []string{"id"}, columns.ColumnsFor("public", "MixedCase"))
+	})
+}

--- a/internal/postgres/pg_utils_test.go
+++ b/internal/postgres/pg_utils_test.go
@@ -646,3 +646,55 @@ func Test_UnquoteIdentifier(t *testing.T) {
 		})
 	}
 }
+
+func Test_SchemaTableColumns_ColumnsFor(t *testing.T) {
+	t.Parallel()
+
+	// keys are raw catalog names, lookups may come from configuration
+	columns := SchemaTableColumns{
+		"public":     {"users": {"id", "name"}, "MixedCase": {"id"}},
+		"OtherShema": {"t": {"id"}},
+	}
+
+	tests := []struct {
+		name   string
+		schema string
+		table  string
+		want   []string
+	}{
+		{name: "bare names", schema: "public", table: "users", want: []string{"id", "name"}},
+		{name: "quoted schema", schema: `"public"`, table: "users", want: []string{"id", "name"}},
+		{name: "quoted table", schema: "public", table: `"users"`, want: []string{"id", "name"}},
+		{name: "both quoted", schema: `"public"`, table: `"users"`, want: []string{"id", "name"}},
+		{name: "mixed case preserved", schema: "public", table: "MixedCase", want: []string{"id"}},
+		{name: "mixed case quoted", schema: `"public"`, table: `"MixedCase"`, want: []string{"id"}},
+		{name: "mixed case schema", schema: `"OtherShema"`, table: "t", want: []string{"id"}},
+		{name: "unknown table", schema: "public", table: "nope", want: nil},
+		{name: "unknown schema", schema: "nope", table: "users", want: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.want, columns.ColumnsFor(tc.schema, tc.table))
+		})
+	}
+
+	t.Run("nil receiver", func(t *testing.T) {
+		t.Parallel()
+
+		require.Nil(t, SchemaTableColumns(nil).ColumnsFor("public", "users"))
+	})
+
+	t.Run("a catalog name shaped like a quoted identifier does not round-trip", func(t *testing.T) {
+		t.Parallel()
+
+		// a table whose name literally contains the quotes. UnquoteIdentifier
+		// strips them, so the lookup misses and the caller falls back to
+		// reading the columns the table has now. Documented, not fixed: the
+		// two conventions are indistinguishable from a single string.
+		quoted := SchemaTableColumns{"public": {`"users"`: {"id"}}}
+		require.Nil(t, quoted.ColumnsFor("public", `"users"`))
+	})
+}


### PR DESCRIPTION

#### Description

Groundwork for pinning a data snapshot to the columns its schema dump saw;
no caller yet, and no behaviour change.

DiscoverTableColumns reads the columns of the user tables in the given
schemas at one point in time, keyed by unquoted schema and table name.
SchemaTableColumns carries that shape with the key convention in one place
rather than at every lookup, so a schema or table quoted in configuration
resolves to the same entry as the bare form. SelectStarColumnPredicate is
shared rather than repeated: every query that resolves a column list has to
agree with the others about what a column is, and two copies drift.

QuoteRawIdentifier always quotes. QuoteIdentifier passes through anything
already shaped like a quoted identifier, which is right for configuration
that may arrive pre-quoted, but a catalog value whose own characters
include the quotes would be silently renamed by it: a column literally
named `"x"` becomes "x" and reads the column named x.

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
