### PR TITLE
Pin the data snapshot to the columns the schema snapshot saw

### DIFF
--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -19,6 +20,11 @@ import (
 	"github.com/xataio/pgstream/pkg/wal/processor"
 	"golang.org/x/sync/errgroup"
 )
+
+const allColumns = "*"
+
+// ErrSchemaChangedDuringSnapshot: re-snapshot needed.
+var ErrSchemaChangedDuringSnapshot = errors.New("source schema changed during the snapshot")
 
 type SnapshotGenerator struct {
 	logger  loglib.Logger
@@ -51,6 +57,7 @@ type tableInfo struct {
 	avgPageBytes  int64
 	avgRowBytes   int64
 	batchPageSize uint
+	columns       []string
 }
 
 type pageRange struct {
@@ -61,12 +68,16 @@ type pageRange struct {
 type schemaTables struct {
 	schema string
 	tables []string
+	// nil without a schema snapshot
+	columns pglib.SchemaTableColumns
 }
 
 type table struct {
 	schema  string
 	name    string
 	rowSize int64
+	// one list per page range
+	columns []string
 }
 
 type snapshotTableFn func(ctx context.Context, snapshotID string, table *table) error
@@ -169,8 +180,9 @@ func (sg *SnapshotGenerator) CreateSnapshot(ctx context.Context, ss *snapshot.Sn
 			continue
 		}
 		schemaTablesChan <- &schemaTables{
-			schema: schema,
-			tables: tables,
+			schema:  schema,
+			tables:  tables,
+			columns: ss.TableColumns,
 		}
 	}
 	close(schemaTablesChan)
@@ -222,8 +234,9 @@ func (sg *SnapshotGenerator) createSchemaSnapshot(ctx context.Context, schemaTab
 
 		for _, tableName := range schemaTables.tables {
 			tableChan <- &table{
-				schema: schemaTables.schema,
-				name:   tableName,
+				schema:  schemaTables.schema,
+				name:    tableName,
+				columns: sg.pinnedColumns(schemaTables, tableName),
 			}
 		}
 
@@ -232,6 +245,41 @@ func (sg *SnapshotGenerator) createSchemaSnapshot(ctx context.Context, schemaTab
 
 		return sg.collectTableErrors(schemaTables.schema, workerTableErrs)
 	}, snapshotTxOptions())
+}
+
+// pinnedColumns warns on uncaptured tables.
+func (sg *SnapshotGenerator) pinnedColumns(schemaTables *schemaTables, tableName string) []string {
+	if schemaTables.columns == nil {
+		return nil
+	}
+
+	columns := schemaTables.columns.ColumnsFor(schemaTables.schema, tableName)
+	if len(columns) == 0 {
+		sg.logger.Warn(nil, "no columns captured by the schema snapshot for this table, falling back to the columns it has now: it was created after the capture, or its name did not resolve to a catalog entry",
+			loglib.Fields{"schema": schemaTables.schema, "table": tableName})
+	}
+	return columns
+}
+
+// readableColumns intersects; drops don't abort.
+// The flag reports a pin with nothing left.
+func readableColumns(pinned, live []string) ([]string, bool) {
+	if len(pinned) == 0 {
+		return live, false
+	}
+
+	liveSet := make(map[string]struct{}, len(live))
+	for _, column := range live {
+		liveSet[column] = struct{}{}
+	}
+
+	readable := make([]string, 0, len(pinned))
+	for _, column := range pinned {
+		if _, found := liveSet[column]; found {
+			readable = append(readable, column)
+		}
+	}
+	return readable, len(readable) == 0
 }
 
 func (sg *SnapshotGenerator) createSnapshotWorker(ctx context.Context, wg *sync.WaitGroup, snapshotID string, tableChan <-chan *table, tableErrMap map[string]error) {
@@ -298,6 +346,15 @@ func (sg *SnapshotGenerator) snapshotTable(ctx context.Context, snapshotID strin
 	}
 	table.rowSize = tableInfo.avgRowBytes
 
+	// an empty intersection must not fall back to SELECT *
+	columns, pinLost := readableColumns(table.columns, tableInfo.columns)
+	if pinLost {
+		return fmt.Errorf("%w: no captured column of %s.%s exists on the source",
+			ErrSchemaChangedDuringSnapshot,
+			pglib.UnquoteIdentifier(table.schema), pglib.UnquoteIdentifier(table.name))
+	}
+	table.columns = columns
+
 	// If one page range fails, we abort the entire table snapshot. The
 	// snapshot relies on the transaction snapshot id to ensure all workers
 	// have the same table view, which allows us to use the ctid to
@@ -333,7 +390,21 @@ func (sg *SnapshotGenerator) snapshotTableRangeWorker(ctx context.Context, snaps
 	return nil
 }
 
-var pageRangeQuery = "SELECT * FROM ONLY %s WHERE ctid BETWEEN '(%d,0)' AND '(%d,0)'"
+const pageRangeQuery = "SELECT %s FROM ONLY %s WHERE ctid BETWEEN '(%d,0)' AND '(%d,0)'"
+
+// buildPageRangeQuery spells columns out.
+func buildPageRangeQuery(t *table, r pageRange) string {
+	quotedTable := pglib.QuoteQualifiedIdentifier(t.schema, t.name)
+	if len(t.columns) == 0 {
+		return fmt.Sprintf(pageRangeQuery, allColumns, quotedTable, r.start, r.end)
+	}
+
+	quotedColumns := make([]string, len(t.columns))
+	for i, column := range t.columns {
+		quotedColumns[i] = pglib.QuoteRawIdentifier(column)
+	}
+	return fmt.Sprintf(pageRangeQuery, strings.Join(quotedColumns, ", "), quotedTable, r.start, r.end)
+}
 
 func (sg *SnapshotGenerator) snapshotTableRange(ctx context.Context, snapshotID string, table *table, pageRange pageRange) error {
 	return sg.execInSnapshotTx(ctx, snapshotID, func(tx pglib.Tx) error {
@@ -341,9 +412,14 @@ func (sg *SnapshotGenerator) snapshotTableRange(ctx context.Context, snapshotID 
 			"schema": table.schema, "table": table.name, "snapshotID": snapshotID,
 		})
 
-		query := fmt.Sprintf(pageRangeQuery, pglib.QuoteQualifiedIdentifier(table.schema, table.name), pageRange.start, pageRange.end)
+		query := buildPageRangeQuery(table, pageRange)
 		rows, err := tx.Query(ctx, query)
 		if err != nil {
+			// something this query names vanished
+			var relationErr *pglib.ErrRelationDoesNotExist
+			if errors.As(err, &relationErr) {
+				return fmt.Errorf("%w: querying table rows: %w", ErrSchemaChangedDuringSnapshot, err)
+			}
 			return fmt.Errorf("querying table rows: %w", err)
 		}
 		defer rows.Close()
@@ -409,20 +485,28 @@ func (sg *SnapshotGenerator) markProgressBarCompleted(schema string) {
 	sg.progressBars.Delete(schema)
 }
 
+// tableInfoQuery shares the capture rule.
+var tableInfoQuery = fmt.Sprintf(tableInfoQueryFmt, pglib.SelectStarColumnPredicate)
+
 const (
 	// use pg_table_size instead of pg_total_relation_size since we only care about the size of the table itself and toast tables, not indices.
 	// pg_relation_size will return only the size of the table itself, without toast tables.
-	tableInfoQuery = `SELECT
+	tableInfoQueryFmt = `SELECT
   (pg_table_size(c.oid) / COALESCE(NULLIF(c.relpages, 0),1)) AS avg_page_size_bytes,
   CASE
 	WHEN c.reltuples > 0 THEN
 		ROUND(pg_table_size(c.oid) / c.reltuples)
 	ELSE
 		0
-  END AS avg_row_size
+  END AS avg_row_size,
+  ARRAY(
+    SELECT a.attname::text FROM pg_catalog.pg_attribute a
+    WHERE a.attrelid = c.oid AND %s
+    ORDER BY a.attnum
+  ) AS columns
 FROM
-  pg_class c
-  JOIN pg_namespace n ON n.oid = c.relnamespace
+  pg_catalog.pg_class c
+  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 WHERE
   c.relname = $1
   AND n.nspname = $2
@@ -439,7 +523,7 @@ func (sg *SnapshotGenerator) getTableInfo(ctx context.Context, schemaName, table
 		// make sure the schema and table names are unquoted since the system
 		// catalogs store unquoted names
 		err := tx.QueryRow(ctx,
-			[]any{&tableInfo.avgPageBytes, &tableInfo.avgRowBytes},
+			[]any{&tableInfo.avgPageBytes, &tableInfo.avgRowBytes, &tableInfo.columns},
 			tableInfoQuery,
 			pglib.UnquoteIdentifier(tableName),
 			pglib.UnquoteIdentifier(schemaName))

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_integration_test.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	pglib "github.com/xataio/pgstream/internal/postgres"
 	"github.com/xataio/pgstream/internal/testcontainers"
 	"github.com/xataio/pgstream/pkg/snapshot"
 	"github.com/xataio/pgstream/pkg/wal"
@@ -65,6 +66,65 @@ func Test_PostgresSnapshotGenerator(t *testing.T) {
 		newTestEvent(testTable, 3, "charlie"),
 	}
 	require.Equal(t, wantEvents, rows)
+}
+
+// added column must not read
+func Test_PostgresSnapshotGenerator_pinnedColumns(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var pgurl string
+	pgCleanup, err := testcontainers.SetupPostgresContainer(ctx, &pgurl, testcontainers.Postgres14)
+	require.NoError(t, err)
+	defer pgCleanup()
+
+	mockProcessor := &mockProcessor{
+		eventChan: make(chan *wal.Event),
+	}
+
+	generator, err := NewSnapshotGenerator(ctx, &Config{URL: pgurl}, mockProcessor)
+	require.NoError(t, err)
+	defer generator.Close()
+
+	testTable := "snapshot_generator_pinned_columns_test"
+	execQuery(t, ctx, pgurl, fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s(id SERIAL PRIMARY KEY, name TEXT)", testTable))
+	execQuery(t, ctx, pgurl, fmt.Sprintf("INSERT INTO %s(name) VALUES('alice')", testTable))
+	execQuery(t, ctx, pgurl, fmt.Sprintf("INSERT INTO %s(name) VALUES('bob')", testTable))
+
+	execQuery(t, ctx, pgurl, fmt.Sprintf("ALTER TABLE %s ADD COLUMN added_later TEXT DEFAULT 'new'", testTable))
+
+	// require here would hang
+	var snapshotErr error
+	go func() {
+		defer mockProcessor.Close()
+		snapshotErr = generator.CreateSnapshot(ctx, &snapshot.Snapshot{
+			SchemaTables: map[string][]string{
+				"public": {testTable},
+			},
+			TableColumns: pglib.SchemaTableColumns{
+				"public": {testTable: {"id", "name"}},
+			},
+		})
+	}()
+
+	rows := make([]*wal.Event, 0, 2)
+	for event := range mockProcessor.eventChan {
+		rows = append(rows, event)
+	}
+	require.NoError(t, snapshotErr)
+
+	require.Len(t, rows, 2)
+	wantColumns := [][]wal.Column{
+		{{Name: "id", Type: "int4", Value: int32(1)}, {Name: "name", Type: "text", Value: "alice"}},
+		{{Name: "id", Type: "int4", Value: int32(2)}, {Name: "name", Type: "text", Value: "bob"}},
+	}
+	for i, row := range rows {
+		require.Equal(t, wantColumns[i], row.Data.Columns)
+	}
 }
 
 func newTestEvent(tableName string, id int32, name string) *wal.Event {

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_test.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_test.go
@@ -40,6 +40,13 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 		},
 	}
 	quotedSchemaTable1 := pglib.QuoteQualifiedIdentifier(testSchema, testTable1)
+	testTableColumnNames := []string{"id", "name"}
+
+	// independent of buildPageRangeQuery
+	wantPageRangeQuery := func(start, end uint) string {
+		return fmt.Sprintf(`SELECT "id", "name" FROM ONLY %s WHERE ctid BETWEEN '(%d,0)' AND '(%d,0)'`,
+			quotedSchemaTable1, start, end)
+	}
 
 	txOptions := pglib.TxOptions{
 		IsolationLevel: pglib.RepeatableRead,
@@ -72,13 +79,16 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 	}
 
 	validTableInfoScanFn := func(args ...any) error {
-		require.Len(t, args, 2)
+		require.Len(t, args, 3)
 		pageAvgBytes, ok := args[0].(*int64)
 		require.True(t, ok, fmt.Sprintf("pageAvgBytes, expected *int64, got %T", args[0]))
 		*pageAvgBytes = testPageAvgBytes
 		rowAvgBytes, ok := args[1].(*int64)
 		require.True(t, ok, fmt.Sprintf("rowAvgBytes, expected *int64, got %T", args[1]))
 		*rowAvgBytes = testRowBytes
+		columns, ok := args[2].(*[]string)
+		require.True(t, ok, fmt.Sprintf("columns, expected *[]string, got %T", args[2]))
+		*columns = testTableColumnNames
 		return nil
 	}
 
@@ -154,7 +164,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 								return pglib.CommandTag{}, nil
 							},
 							QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
-								require.Equal(t, fmt.Sprintf(pageRangeQuery, quotedSchemaTable1, 0, 1), query)
+								require.Equal(t, wantPageRangeQuery(0, 1), query)
 								require.Len(t, args, 0)
 								return &pgmocks.Rows{
 									CloseFn: func() {},
@@ -181,6 +191,246 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 
 			wantErr:    nil,
 			wantEvents: []*wal.Event{testEvent(testTable1, testColumns)},
+		},
+		{
+			name: "ok - columns pinned by the schema snapshot",
+			snapshot: &snapshot.Snapshot{
+				SchemaTables: map[string][]string{
+					testSchema: {testTable1},
+				},
+				TableColumns: pglib.SchemaTableColumns{
+					testSchema: {testTable1: {"id"}},
+				},
+			},
+			querier: &pgmocks.Querier{
+				ExecInTxWithOptionsFn: func(_ context.Context, i uint, f func(tx pglib.Tx) error, to pglib.TxOptions) error {
+					require.Equal(t, txOptions, to)
+					switch i {
+					case 1:
+						mockTx := pgmocks.Tx{
+							QueryRowFn: func(_ context.Context, dest []any, query string, args ...any) error {
+								require.Equal(t, exportSnapshotQuery, query)
+								snapshotID, ok := dest[0].(*string)
+								require.True(t, ok)
+								*snapshotID = testSnapshotID
+								return nil
+							},
+						}
+						return f(&mockTx)
+					case 2:
+						mockTx := pgmocks.Tx{
+							ExecFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.CommandTag, error) {
+								return pglib.CommandTag{}, nil
+							},
+							QueryRowFn: validTableInfoQueryRowFn,
+						}
+						return f(&mockTx)
+					case 3:
+						mockTx := pgmocks.Tx{
+							ExecFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.CommandTag, error) {
+								return pglib.CommandTag{}, nil
+							},
+							QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
+								require.Equal(t, buildPageRangeQuery(&table{
+									schema:  testSchema,
+									name:    testTable1,
+									columns: []string{"id"},
+								}, pageRange{start: 0, end: 1}), query)
+								return &pgmocks.Rows{
+									CloseFn: func() {},
+									NextFn:  func(i uint) bool { return i == 1 },
+									FieldDescriptionsFn: func() []pgconn.FieldDescription {
+										return []pgconn.FieldDescription{
+											{Name: "id", DataTypeOID: pgtype.UUIDOID},
+										}
+									},
+									ValuesFn: func() ([]any, error) {
+										return []any{testUUID}, nil
+									},
+									ErrFn: func() error { return nil },
+								}, nil
+							},
+						}
+						return f(&mockTx)
+					default:
+						return fmt.Errorf("unexpected call to ExecInTxWithOptions: %d", i)
+					}
+				},
+			},
+
+			wantErr: nil,
+			wantEvents: []*wal.Event{testEvent(testTable1, []wal.Column{
+				{Name: "id", Type: "uuid", Value: testUUID},
+			})},
+		},
+		{
+			name: "ok - pinned column dropped from the source is not read",
+			snapshot: &snapshot.Snapshot{
+				SchemaTables: map[string][]string{
+					testSchema: {testTable1},
+				},
+				TableColumns: pglib.SchemaTableColumns{
+					testSchema: {testTable1: {"id", "dropped"}},
+				},
+			},
+			querier: &pgmocks.Querier{
+				ExecInTxWithOptionsFn: func(_ context.Context, i uint, f func(tx pglib.Tx) error, to pglib.TxOptions) error {
+					switch i {
+					case 1:
+						mockTx := pgmocks.Tx{
+							QueryRowFn: func(_ context.Context, dest []any, query string, args ...any) error {
+								snapshotID, ok := dest[0].(*string)
+								require.True(t, ok)
+								*snapshotID = testSnapshotID
+								return nil
+							},
+						}
+						return f(&mockTx)
+					case 2:
+						mockTx := pgmocks.Tx{
+							ExecFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.CommandTag, error) {
+								return pglib.CommandTag{}, nil
+							},
+							QueryRowFn: validTableInfoQueryRowFn,
+						}
+						return f(&mockTx)
+					case 3:
+						mockTx := pgmocks.Tx{
+							ExecFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.CommandTag, error) {
+								return pglib.CommandTag{}, nil
+							},
+							QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
+								require.Equal(t, fmt.Sprintf(
+									`SELECT "id" FROM ONLY %s WHERE ctid BETWEEN '(0,0)' AND '(1,0)'`,
+									quotedSchemaTable1), query)
+								return &pgmocks.Rows{
+									CloseFn: func() {},
+									NextFn:  func(i uint) bool { return i == 1 },
+									FieldDescriptionsFn: func() []pgconn.FieldDescription {
+										return []pgconn.FieldDescription{{Name: "id", DataTypeOID: pgtype.UUIDOID}}
+									},
+									ValuesFn: func() ([]any, error) { return []any{testUUID}, nil },
+									ErrFn:    func() error { return nil },
+								}, nil
+							},
+						}
+						return f(&mockTx)
+					default:
+						return fmt.Errorf("unexpected call to ExecInTxWithOptions: %d", i)
+					}
+				},
+			},
+
+			wantErr: nil,
+			wantEvents: []*wal.Event{testEvent(testTable1, []wal.Column{
+				{Name: "id", Type: "uuid", Value: testUUID},
+			})},
+		},
+		{
+			name: "error - every pinned column is gone",
+			snapshot: &snapshot.Snapshot{
+				SchemaTables: map[string][]string{
+					testSchema: {testTable1},
+				},
+				// none of these survive; the table must fail rather than
+				// fall back to reading whatever it has now
+				TableColumns: pglib.SchemaTableColumns{
+					testSchema: {testTable1: {"old_a", "old_b"}},
+				},
+			},
+			querier: &pgmocks.Querier{
+				ExecInTxWithOptionsFn: func(_ context.Context, i uint, f func(tx pglib.Tx) error, to pglib.TxOptions) error {
+					switch i {
+					case 1:
+						mockTx := pgmocks.Tx{
+							QueryRowFn: func(_ context.Context, dest []any, query string, args ...any) error {
+								snapshotID, ok := dest[0].(*string)
+								require.True(t, ok)
+								*snapshotID = testSnapshotID
+								return nil
+							},
+						}
+						return f(&mockTx)
+					case 2:
+						mockTx := pgmocks.Tx{
+							ExecFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.CommandTag, error) {
+								return pglib.CommandTag{}, nil
+							},
+							QueryRowFn: validTableInfoQueryRowFn,
+						}
+						return f(&mockTx)
+					default:
+						return fmt.Errorf("no page range should be queried: %d", i)
+					}
+				},
+			},
+
+			wantErr: snapshot.Errors{
+				testSchema: &snapshot.SchemaErrors{
+					Schema: testSchema,
+					TableErrors: map[string]string{
+						testTable1: fmt.Sprintf("%s: no captured column of %s.%s exists on the source",
+							ErrSchemaChangedDuringSnapshot, testSchema, testTable1),
+					},
+				},
+			},
+			wantEvents: []*wal.Event{},
+		},
+		{
+			name: "error - column dropped after the column list was resolved",
+			snapshot: &snapshot.Snapshot{
+				SchemaTables: map[string][]string{
+					testSchema: {testTable1},
+				},
+			},
+			querier: &pgmocks.Querier{
+				ExecInTxWithOptionsFn: func(_ context.Context, i uint, f func(tx pglib.Tx) error, to pglib.TxOptions) error {
+					switch i {
+					case 1:
+						mockTx := pgmocks.Tx{
+							QueryRowFn: func(_ context.Context, dest []any, query string, args ...any) error {
+								snapshotID, ok := dest[0].(*string)
+								require.True(t, ok)
+								*snapshotID = testSnapshotID
+								return nil
+							},
+						}
+						return f(&mockTx)
+					case 2:
+						mockTx := pgmocks.Tx{
+							ExecFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.CommandTag, error) {
+								return pglib.CommandTag{}, nil
+							},
+							QueryRowFn: validTableInfoQueryRowFn,
+						}
+						return f(&mockTx)
+					case 3:
+						mockTx := pgmocks.Tx{
+							ExecFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.CommandTag, error) {
+								return pglib.CommandTag{}, nil
+							},
+							// race the intersection cannot close
+							QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
+								return nil, &pglib.ErrRelationDoesNotExist{Details: `column "name" does not exist`}
+							},
+						}
+						return f(&mockTx)
+					default:
+						return fmt.Errorf("unexpected call to ExecInTxWithOptions: %d", i)
+					}
+				},
+			},
+
+			wantErr: snapshot.Errors{
+				testSchema: &snapshot.SchemaErrors{
+					Schema: testSchema,
+					TableErrors: map[string]string{
+						testTable1: fmt.Sprintf("%s: querying table rows: relation does not exist: %s",
+							ErrSchemaChangedDuringSnapshot, `column "name" does not exist`),
+					},
+				},
+			},
+			wantEvents: []*wal.Event{},
 		},
 		{
 			name: "error - closing processor",
@@ -215,7 +465,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 								return pglib.CommandTag{}, nil
 							},
 							QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
-								require.Equal(t, fmt.Sprintf(pageRangeQuery, quotedSchemaTable1, 0, 1), query)
+								require.Equal(t, wantPageRangeQuery(0, 1), query)
 								return &pgmocks.Rows{
 									CloseFn: func() {},
 									NextFn:  func(i uint) bool { return i == 1 },
@@ -278,7 +528,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 								return pglib.CommandTag{}, nil
 							},
 							QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
-								require.Equal(t, fmt.Sprintf(pageRangeQuery, quotedSchemaTable1, 0, 1), query)
+								require.Equal(t, wantPageRangeQuery(0, 1), query)
 								require.Len(t, args, 0)
 								return &pgmocks.Rows{
 									CloseFn: func() {},
@@ -374,7 +624,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 								return pglib.CommandTag{}, nil
 							},
 							QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
-								require.Equal(t, fmt.Sprintf(pageRangeQuery, quotedSchemaTable1, 0, 1), query)
+								require.Equal(t, wantPageRangeQuery(0, 1), query)
 								require.Len(t, args, 0)
 								return &pgmocks.Rows{
 									CloseFn: func() {},
@@ -504,7 +754,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 								return pglib.CommandTag{}, nil
 							},
 							QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
-								require.Equal(t, fmt.Sprintf(pageRangeQuery, quotedSchemaTable1, 0, 1), query)
+								require.Equal(t, wantPageRangeQuery(0, 1), query)
 								require.Len(t, args, 0)
 								return &pgmocks.Rows{
 									CloseFn: func() {},
@@ -581,7 +831,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 								return pglib.CommandTag{}, nil
 							},
 							QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
-								require.Equal(t, fmt.Sprintf(pageRangeQuery, quotedSchemaTable1, 0, 1), query)
+								require.Equal(t, wantPageRangeQuery(0, 1), query)
 								require.Len(t, args, 0)
 								return &pgmocks.Rows{
 									CloseFn:             func() {},
@@ -601,7 +851,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 								return pglib.CommandTag{}, nil
 							},
 							QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
-								require.Equal(t, fmt.Sprintf(pageRangeQuery, quotedSchemaTable1, 1, 2), query)
+								require.Equal(t, wantPageRangeQuery(1, 2), query)
 								require.Len(t, args, 0)
 								return &pgmocks.Rows{
 									CloseFn:             func() {},
@@ -658,7 +908,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 								return pglib.CommandTag{}, nil
 							},
 							QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
-								require.Equal(t, fmt.Sprintf(pageRangeQuery, quotedSchemaTable1, 0, 1), query)
+								require.Equal(t, wantPageRangeQuery(0, 1), query)
 								require.Len(t, args, 0)
 								return &pgmocks.Rows{
 									CloseFn:             func() {},
@@ -882,7 +1132,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 								return pglib.CommandTag{}, nil
 							},
 							QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
-								require.Equal(t, fmt.Sprintf(pageRangeQuery, quotedSchemaTable1, 0, 1), query)
+								require.Equal(t, wantPageRangeQuery(0, 1), query)
 								require.Len(t, args, 0)
 								return nil, errTest
 							},
@@ -1266,6 +1516,107 @@ func TestSnapshotQueriesDoNotIncludeInheritedRows(t *testing.T) {
 	require.Contains(t, maxPageQuery, " FROM ONLY %s")
 }
 
+func TestReadableColumns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		pinned      []string
+		live        []string
+		want        []string
+		wantPinLost bool
+	}{
+		{
+			name:   "nothing pinned falls back to the live columns",
+			pinned: nil,
+			live:   []string{"id", "name"},
+			want:   []string{"id", "name"},
+		},
+		{
+			name:   "a column added after the capture is not read",
+			pinned: []string{"id", "name"},
+			live:   []string{"id", "name", "added_later"},
+			want:   []string{"id", "name"},
+		},
+		{
+			name:   "a column dropped after the capture is not read",
+			pinned: []string{"id", "dropped", "name"},
+			live:   []string{"id", "name"},
+			want:   []string{"id", "name"},
+		},
+		{
+			name:   "the pinned order wins over the live order",
+			pinned: []string{"name", "id"},
+			live:   []string{"id", "name"},
+			want:   []string{"name", "id"},
+		},
+		{
+			// must not silently become SELECT *
+			name:        "a table replaced wholesale loses the pin",
+			pinned:      []string{"id"},
+			live:        []string{"other"},
+			want:        []string{},
+			wantPinLost: true,
+		},
+		{
+			name:        "a zero column table is not a lost pin",
+			pinned:      nil,
+			live:        []string{},
+			want:        []string{},
+			wantPinLost: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			readable, pinLost := readableColumns(tc.pinned, tc.live)
+			require.Equal(t, tc.want, readable)
+			require.Equal(t, tc.wantPinLost, pinLost)
+		})
+	}
+}
+
+func TestBuildPageRangeQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		table *table
+		want  string
+	}{
+		{
+			name:  "explicit columns are quoted and kept in order",
+			table: &table{schema: "test_schema", name: "test_table", columns: []string{"id", "name"}},
+			want:  `SELECT "id", "name" FROM ONLY "test_schema"."test_table" WHERE ctid BETWEEN '(0,0)' AND '(5,0)'`,
+		},
+		{
+			name:  "column names needing quoting are escaped",
+			table: &table{schema: "test_schema", name: "test_table", columns: []string{`we"ird`, "Mixed Case"}},
+			want:  `SELECT "we""ird", "Mixed Case" FROM ONLY "test_schema"."test_table" WHERE ctid BETWEEN '(0,0)' AND '(5,0)'`,
+		},
+		{
+			name:  "column name that looks pre-quoted is quoted again",
+			table: &table{schema: "test_schema", name: "test_table", columns: []string{`"id"`}},
+			want:  `SELECT """id""" FROM ONLY "test_schema"."test_table" WHERE ctid BETWEEN '(0,0)' AND '(5,0)'`,
+		},
+		{
+			name:  "no columns falls back to the wildcard",
+			table: &table{schema: "test_schema", name: "test_table"},
+			want:  `SELECT * FROM ONLY "test_schema"."test_table" WHERE ctid BETWEEN '(0,0)' AND '(5,0)'`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.want, buildPageRangeQuery(tc.table, pageRange{start: 0, end: 5}))
+		})
+	}
+}
+
 func TestSnapshotGenerator_snapshotTableRange(t *testing.T) {
 	t.Parallel()
 
@@ -1314,7 +1665,7 @@ func TestSnapshotGenerator_snapshotTableRange(t *testing.T) {
 							return pglib.CommandTag{}, nil
 						},
 						QueryFn: func(ctx context.Context, query string, args ...any) (pglib.Rows, error) {
-							require.Equal(t, fmt.Sprintf(pageRangeQuery, quotedSchemaTable, 0, 5), query)
+							require.Equal(t, fmt.Sprintf(pageRangeQuery, allColumns, quotedSchemaTable, 0, 5), query)
 							return &pgmocks.Rows{
 								CloseFn: func() {},
 								NextFn:  func(i uint) bool { return i == 1 },

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -263,10 +263,17 @@ func (s *SnapshotGenerator) CreateSnapshot(ctx context.Context, ss *snapshot.Sna
 
 	// DUMP
 
+	// pin before the dump
+	if err := s.captureTableColumns(ctx, ss, dumpSchemas); err != nil {
+		return err
+	}
+
 	dump, err := s.dumpSchema(ctx, dataSchemas, schemaOnly, ss.SchemaExcludedTables)
 	if err != nil {
 		return err
 	}
+
+	s.warnOnCaptureDrift(ctx, ss, dumpSchemas)
 
 	// the schema will include the sequences but will not produce the `SETVAL`
 	// queries since that's considered data and it's a schema only dump. Produce
@@ -430,6 +437,78 @@ func (s *SnapshotGenerator) Close() error {
 	}
 
 	return nil
+}
+
+// captureTableColumns precedes the dump.
+func (s *SnapshotGenerator) captureTableColumns(ctx context.Context, ss *snapshot.Snapshot, dumpSchemas map[string][]string) error {
+	if s.generator == nil {
+		// schema-only snapshot, nothing to pin
+		return nil
+	}
+
+	captureSchemas, captureTables := captureScope(dumpSchemas)
+	tableColumns, err := pglib.DiscoverTableColumns(ctx, s.sourceQuerier, captureSchemas, captureTables)
+	if err != nil {
+		return fmt.Errorf("capturing source table columns: %w", err)
+	}
+
+	ss.TableColumns = tableColumns
+	return nil
+}
+
+// captureScope narrows to dump scope.
+func captureScope(dumpSchemas map[string][]string) (schemas, tables []string) {
+	if !hasWildcardSchema(dumpSchemas) {
+		schemas = make([]string, 0, len(dumpSchemas))
+		for schema := range dumpSchemas {
+			schemas = append(schemas, schema)
+		}
+	}
+
+	for _, schemaTables := range dumpSchemas {
+		if hasWildcardTable(schemaTables) {
+			return schemas, nil
+		}
+		tables = append(tables, schemaTables...)
+	}
+	return schemas, tables
+}
+
+// warnOnCaptureDrift exposes the window.
+func (s *SnapshotGenerator) warnOnCaptureDrift(ctx context.Context, ss *snapshot.Snapshot, dumpSchemas map[string][]string) {
+	if ss.TableColumns == nil {
+		return
+	}
+
+	captureSchemas, captureTables := captureScope(dumpSchemas)
+	current, err := pglib.DiscoverTableColumns(ctx, s.sourceQuerier, captureSchemas, captureTables)
+	if err != nil {
+		s.logger.Warn(err, "checking for source schema drift during the schema dump")
+		return
+	}
+
+	drifted := []string{}
+	for schema, tables := range ss.TableColumns {
+		for table, columns := range tables {
+			if !slices.Equal(columns, current[schema][table]) {
+				drifted = append(drifted, schema+"."+table)
+			}
+		}
+	}
+	for schema, tables := range current {
+		for table := range tables {
+			if _, found := ss.TableColumns[schema][table]; !found {
+				drifted = append(drifted, schema+"."+table)
+			}
+		}
+	}
+	if len(drifted) == 0 {
+		return
+	}
+
+	slices.Sort(drifted)
+	s.logger.Warn(nil, "source schema changed while the schema was being dumped; these tables may be snapshotted with stale columns and need replication to converge, or a re-snapshot if none follows",
+		loglib.Fields{"tables": drifted})
 }
 
 func (s *SnapshotGenerator) dumpSchema(ctx context.Context, schemaTables, schemaOnlyTables, excludedTables map[string][]string) (*dump, error) {

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
@@ -88,6 +88,31 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 		return "", nil
 	}
 
+	testCapturedColumns := map[string]map[string][]string{
+		testSchema: {testTable: {"id"}},
+	}
+
+	tableColumnsRows := func() *mocks.Rows {
+		return &mocks.Rows{
+			CloseFn: func() {},
+			NextFn:  func(i uint) bool { return i == 1 },
+			ScanFn: func(i uint, dest ...any) error {
+				require.Len(t, dest, 3)
+				schemaName, ok := dest[0].(*string)
+				require.True(t, ok)
+				*schemaName = testSchema
+				tableName, ok := dest[1].(*string)
+				require.True(t, ok)
+				*tableName = testTable
+				columnName, ok := dest[2].(*string)
+				require.True(t, ok)
+				*columnName = "id"
+				return nil
+			},
+			ErrFn: func() error { return nil },
+		}
+	}
+
 	validQuerier := func() *mocks.Querier {
 		return &mocks.Querier{
 			ExecFn: func(ctx context.Context, i uint, query string, args ...any) (pglib.CommandTag, error) {
@@ -96,6 +121,9 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 			},
 			QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
 				switch query {
+				case pglib.DiscoverTableColumnsQuery:
+					require.Equal(t, []any{[]string{testSchema}, []string{testTable}}, args)
+					return tableColumnsRows(), nil
 				case selectSchemasQuery:
 					require.Equal(t, []any{[]string{testSchema}}, args)
 					return &mocks.Rows{
@@ -441,6 +469,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 						SchemaTables: map[string][]string{
 							testSchema: {testTable},
 						},
+						TableColumns: testCapturedColumns,
 					}, ss)
 					return nil
 				},
@@ -461,6 +490,8 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 			conn: &mocks.Querier{
 				QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
 					switch query {
+					case pglib.DiscoverTableColumnsQuery:
+						return tableColumnsRows(), nil
 					case selectSchemasQuery:
 						require.Equal(t, []any{[]string{testSchema}}, args)
 						return &mocks.Rows{
@@ -537,9 +568,9 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 
 			generator: &generatormocks.Generator{
 				CreateSnapshotFn: func(ctx context.Context, ss *snapshot.Snapshot) error {
-					// the wrapped generator receives the original snapshot
-					// request untouched
+					// wrapped generator gets captured columns
 					require.Equal(t, &snapshot.Snapshot{
+						TableColumns: testCapturedColumns,
 						SchemaTables: map[string][]string{
 							testSchema: {testTable},
 						},
@@ -604,6 +635,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 						SchemaOnlyTables: map[string][]string{
 							testSchema: {testTable},
 						},
+						TableColumns: testCapturedColumns,
 					}, ss)
 					return nil
 				},
@@ -2248,6 +2280,164 @@ func TestSnapshotGenerator_filterTriggers(t *testing.T) {
 
 			got := s.filterTriggers([]byte(tc.input), tc.excludedSchemas)
 			require.Equal(t, string(tc.want), string(got))
+		})
+	}
+}
+
+func TestCaptureScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		dumpSchemas map[string][]string
+
+		wantSchemas []string
+		wantTables  []string
+	}{
+		{
+			name:        "explicit schemas and tables",
+			dumpSchemas: map[string][]string{"a": {"t1", "t2"}, "b": {"t3"}},
+			wantSchemas: []string{"a", "b"},
+			wantTables:  []string{"t1", "t2", "t3"},
+		},
+		{
+			// a wildcard on one schema drops the table filter for all of them:
+			// the names behind it are only resolved later, by the table finder
+			wantSchemas: []string{"a", "b"},
+			name:        "one schema has a wildcard table",
+			dumpSchemas: map[string][]string{"a": {"t1"}, "b": {wildcard}},
+			wantTables:  nil,
+		},
+		{
+			name:        "wildcard schema keeps the table filter",
+			dumpSchemas: map[string][]string{wildcard: {"t1"}},
+			wantSchemas: nil,
+			wantTables:  []string{"t1"},
+		},
+		{
+			name:        "wildcard on both sides filters nothing",
+			dumpSchemas: map[string][]string{wildcard: {wildcard}},
+			wantSchemas: nil,
+			wantTables:  nil,
+		},
+		{
+			name:        "empty scope",
+			dumpSchemas: map[string][]string{},
+			wantSchemas: []string{},
+			wantTables:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// map iteration order is random, so compare as sets
+			schemas, tables := captureScope(tc.dumpSchemas)
+			require.ElementsMatch(t, tc.wantSchemas, schemas)
+			require.ElementsMatch(t, tc.wantTables, tables)
+			if tc.wantTables == nil {
+				require.Nil(t, tables, "a nil table filter means no filter; empty would match nothing")
+			}
+			if tc.wantSchemas == nil {
+				require.Nil(t, schemas, "a nil schema filter means no filter; empty would match nothing")
+			}
+		})
+	}
+}
+
+// captureLogger records Warn calls so a test can assert on advisory output.
+type captureLogger struct {
+	log.Logger
+	warnings []string
+}
+
+func (l *captureLogger) Warn(err error, msg string, fields ...log.Fields) {
+	l.warnings = append(l.warnings, msg)
+}
+
+func TestWarnOnCaptureDrift(t *testing.T) {
+	t.Parallel()
+
+	testSchema, testTable := "test_schema", "test_table"
+	dumpSchemas := map[string][]string{testSchema: {testTable}}
+	captured := pglib.SchemaTableColumns{testSchema: {testTable: {"id"}}}
+
+	// what the source reports after the dump, i.e. the second read
+	newQuerier := func(afterDump pglib.SchemaTableColumns) *mocks.Querier {
+		return &mocks.Querier{
+			QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
+				require.Equal(t, pglib.DiscoverTableColumnsQuery, query)
+				rows := []struct{ schema, table, column string }{}
+				for schema, tables := range afterDump {
+					for table, columns := range tables {
+						for _, column := range columns {
+							rows = append(rows, struct{ schema, table, column string }{schema, table, column})
+						}
+					}
+				}
+				return &mocks.Rows{
+					CloseFn: func() {},
+					NextFn:  func(i uint) bool { return int(i) <= len(rows) },
+					ScanFn: func(i uint, dest ...any) error {
+						require.Len(t, dest, 3)
+						r := rows[i-1]
+						schema, ok := dest[0].(*string)
+						require.True(t, ok)
+						table, ok := dest[1].(*string)
+						require.True(t, ok)
+						column, ok := dest[2].(*string)
+						require.True(t, ok)
+						*schema, *table, *column = r.schema, r.table, r.column
+						return nil
+					},
+					ErrFn: func() error { return nil },
+				}, nil
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		afterDump pglib.SchemaTableColumns
+		wantWarn  bool
+	}{
+		{
+			name:      "no drift is silent",
+			afterDump: pglib.SchemaTableColumns{testSchema: {testTable: {"id"}}},
+			wantWarn:  false,
+		},
+		{
+			name:      "a column added during the dump warns",
+			afterDump: pglib.SchemaTableColumns{testSchema: {testTable: {"id", "added"}}},
+			wantWarn:  true,
+		},
+		{
+			name:      "a column dropped during the dump warns",
+			afterDump: pglib.SchemaTableColumns{testSchema: {testTable: {}}},
+			wantWarn:  true,
+		},
+		{
+			name:      "a table created during the dump warns",
+			afterDump: pglib.SchemaTableColumns{testSchema: {testTable: {"id"}, "new_table": {"id"}}},
+			wantWarn:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			logger := &captureLogger{Logger: log.NewNoopLogger()}
+			sg := SnapshotGenerator{sourceQuerier: newQuerier(tc.afterDump), logger: logger}
+
+			ss := &snapshot.Snapshot{TableColumns: pglib.SchemaTableColumns{testSchema: {testTable: {"id"}}}}
+			sg.warnOnCaptureDrift(context.Background(), ss, dumpSchemas)
+
+			// advisory only: the pinned columns are never rewritten by drift,
+			// and nothing here can fail the snapshot
+			require.Equal(t, captured, ss.TableColumns)
+			require.Equal(t, tc.wantWarn, len(logger.warnings) > 0, "warnings: %v", logger.warnings)
 		})
 	}
 }

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -2,6 +2,8 @@
 
 package snapshot
 
+import pglib "github.com/xataio/pgstream/internal/postgres"
+
 type Snapshot struct {
 	SchemaTables         map[string][]string
 	SchemaExcludedTables map[string][]string
@@ -10,6 +12,9 @@ type Snapshot struct {
 	// take precedence over a schema-only wildcard match, and
 	// SchemaExcludedTables take precedence over the schema-only list.
 	SchemaOnlyTables map[string][]string
+	// TableColumns pins the dumped columns.
+	// Nil resolves at read time.
+	TableColumns pglib.SchemaTableColumns
 }
 
 type Request struct {

--- a/pkg/stream/integration/snapshot_migration_window_integration_test.go
+++ b/pkg/stream/integration/snapshot_migration_window_integration_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/testcontainers"
+	"github.com/xataio/pgstream/pkg/backoff"
+	"github.com/xataio/pgstream/pkg/snapshot"
+	"github.com/xataio/pgstream/pkg/snapshot/generator"
+	pgsnapshotgenerator "github.com/xataio/pgstream/pkg/snapshot/generator/postgres/data"
+	"github.com/xataio/pgstream/pkg/snapshot/generator/postgres/schema/pgdumprestore"
+	pgtablefinder "github.com/xataio/pgstream/pkg/snapshot/generator/postgres/tablefinder"
+	"github.com/xataio/pgstream/pkg/wal/processor/batch"
+	pgwriter "github.com/xataio/pgstream/pkg/wal/processor/postgres"
+)
+
+// migrationHookGenerator migrates, then delegates.
+type migrationHookGenerator struct {
+	wrapped generator.SnapshotGenerator
+	migrate func()
+}
+
+func (g *migrationHookGenerator) CreateSnapshot(ctx context.Context, ss *snapshot.Snapshot) error {
+	g.migrate()
+	return g.wrapped.CreateSnapshot(ctx, ss)
+}
+
+func (g *migrationHookGenerator) Close() error { return g.wrapped.Close() }
+
+// migration lands after the dump
+// chain assembled to place it
+func Test_SnapshotToPostgres_MigrationBetweenSchemaAndDataSnapshot(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var sourceURL string
+	sourceCleanup, err := testcontainers.SetupPostgresContainer(context.Background(), &sourceURL, testcontainers.Postgres14, "config/postgresql.conf")
+	require.NoError(t, err)
+	defer sourceCleanup()
+
+	var targetURL string
+	targetCleanup, err := testcontainers.SetupPostgresContainer(context.Background(), &targetURL, testcontainers.Postgres17)
+	require.NoError(t, err)
+	defer targetCleanup()
+
+	testTable := fmt.Sprintf("migration_window_%d", time.Now().UnixNano())
+	execQueryWithURL(t, ctx, sourceURL, fmt.Sprintf(
+		`CREATE TABLE %s(id integer PRIMARY KEY, name text NOT NULL)`, testTable))
+	execQueryWithURL(t, ctx, sourceURL, fmt.Sprintf(
+		`INSERT INTO %s(id, name) VALUES (1, 'a'),(2, 'b')`, testTable))
+
+	// runs after dump and restore
+	migrated := false
+	migrate := func() {
+		execQueryWithURL(t, ctx, sourceURL, fmt.Sprintf(
+			`ALTER TABLE %s ADD COLUMN added_later text NOT NULL DEFAULT 'from_migration'`, testTable))
+		migrated = true
+	}
+
+	writer, err := pgwriter.NewBatchWriter(ctx, &pgwriter.Config{
+		URL:         targetURL,
+		BatchConfig: batch.Config{MaxBatchSize: 1},
+		RetryPolicy: backoff.Config{DisableRetries: true},
+	})
+	require.NoError(t, err)
+
+	dataGenerator, err := pgsnapshotgenerator.NewSnapshotGenerator(ctx,
+		&pgsnapshotgenerator.Config{URL: sourceURL}, writer)
+	require.NoError(t, err)
+
+	tableFinder, err := pgtablefinder.NewSnapshotSchemaTableFinder(ctx, sourceURL, dataGenerator)
+	require.NoError(t, err)
+
+	schemaGenerator, err := pgdumprestore.NewSnapshotGenerator(ctx,
+		&pgdumprestore.Config{SourcePGURL: sourceURL, TargetPGURL: targetURL},
+		pgdumprestore.WithLogger(testLogger()),
+		pgdumprestore.WithSnapshotGenerator(&migrationHookGenerator{
+			wrapped: tableFinder,
+			migrate: migrate,
+		}))
+	require.NoError(t, err)
+	defer schemaGenerator.Close()
+
+	err = schemaGenerator.CreateSnapshot(ctx, &snapshot.Snapshot{
+		SchemaTables: map[string][]string{"public": {testTable}},
+	})
+	require.NoError(t, err, "snapshot must survive a migration landing after the schema was dumped")
+	require.True(t, migrated, "the migration hook never ran, so this test proves nothing")
+
+	sourceConn, err := pglib.NewConn(ctx, sourceURL)
+	require.NoError(t, err)
+	defer sourceConn.Close(ctx)
+	targetConn, err := pglib.NewConn(ctx, targetURL)
+	require.NoError(t, err)
+	defer targetConn.Close(ctx)
+
+	// source has it, target doesn't
+	sourceColumns := getInformationSchemaColumns(t, ctx, sourceConn, testTable)
+	require.Len(t, sourceColumns, 3)
+	targetColumns := getInformationSchemaColumns(t, ctx, targetConn, testTable)
+	require.ElementsMatch(t, []*informationSchemaColumn{
+		{name: "id", dataType: "integer", isNullable: "NO"},
+		{name: "name", dataType: "text", isNullable: "NO"},
+	}, targetColumns, "the target must not have the migrated column, or the window under test did not happen")
+
+	rows := getIDNameRows(t, ctx, targetConn, fmt.Sprintf("SELECT id, name FROM %s ORDER BY id", testTable))
+	require.Equal(t, []idNameRow{{id: 1, name: "a"}, {id: 2, name: "b"}}, rows)
+}


### PR DESCRIPTION
 #### Description

  The data snapshot read rows with `SELECT * FROM ONLY <table> WHERE ctid BETWEEN …`. `SET TRANSACTION SNAPSHOT` pins row visibility but not the catalog, and every page range plans its own query, so the column list was re-resolved from the live source catalog throughout the snapshot, while the target's schema stays the same.

This pins each table's read to the columns the schema snapshot captured, so a column added afterwards is simply not read. The `ADD COLUMN` and any backfill arrive over the replication stream, which already starts from an LSN taken before the snapshot.

#### Type of Change
  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 📚 Documentation update
  - [ ] 🔧 Refactoring (no functional changes)
  - [ ] ⚡ Performance improvement
  - [x] 🧪 Test coverage improvement
  - [ ] 🔨 Build/CI changes
  - [ ] 🧹 Code cleanup

  #### Testing

  - [x] Unit tests added/updated
  - [x] Integration tests added/updated
  - [x] Manual testing performed
  - [x] All existing tests pass