### PR TITLE
Add uniqueness information to transformers

### DIFF
--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -328,9 +328,10 @@ type TableTransformersConfig struct {
 }
 
 type ColumnTransformersConfig struct {
-	Name              string         `mapstructure:"name" yaml:"name"`
-	Parameters        map[string]any `mapstructure:"parameters" yaml:"parameters"`
-	DynamicParameters map[string]any `mapstructure:"dynamic_parameters" yaml:"dynamic_parameters"`
+	Name                string         `mapstructure:"name" yaml:"name"`
+	Parameters          map[string]any `mapstructure:"parameters" yaml:"parameters"`
+	DynamicParameters   map[string]any `mapstructure:"dynamic_parameters" yaml:"dynamic_parameters"`
+	AllowUniquenessLoss bool           `mapstructure:"allow_uniqueness_loss" yaml:"allow_uniqueness_loss"`
 }
 
 // postgres source modes
@@ -885,9 +886,10 @@ func (c TransformationsConfig) parseTransformationConfig() (*transformer.Config,
 		columnRules := make(map[string]transformer.TransformerRules, len(t.ColumnRules))
 		for column, cr := range t.ColumnRules {
 			columnRules[column] = transformer.TransformerRules{
-				Name:              cr.Name,
-				Parameters:        cr.Parameters,
-				DynamicParameters: cr.DynamicParameters,
+				Name:                cr.Name,
+				Parameters:          cr.Parameters,
+				DynamicParameters:   cr.DynamicParameters,
+				AllowUniquenessLoss: cr.AllowUniquenessLoss,
 			}
 		}
 		rules = append(rules, transformer.TableRules{

--- a/cmd/validate_cmd.go
+++ b/cmd/validate_cmd.go
@@ -68,10 +68,13 @@ var validateRulesCmd = &cobra.Command{
 				return err
 			}
 
-			if len(rulesStatus.Errors) == 0 {
-				sp.Success("transformation rules are valid")
-			} else {
+			switch {
+			case len(rulesStatus.Errors) > 0:
 				sp.Warning("pgstream validation check identified issues: ", strings.Join(rulesStatus.Errors, ", "))
+			case len(rulesStatus.Warnings) > 0:
+				sp.Warning("transformation rules are valid, with warnings: ", strings.Join(rulesStatus.Warnings, ", "))
+			default:
+				sp.Success("transformation rules are valid")
 			}
 
 			err = print(cmd, rulesStatus)

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -6,6 +6,82 @@ pgstream supports column value transformations to anonymize or mask sensitive da
 
 pgstream integrates with existing transformer open source libraries, such as [greenmask](https://github.com/GreenmaskIO/greenmask), [neosync](https://github.com/nucleuscloud/neosync) and [go-masker](https://github.com/ggwhite/go-masker), to leverage a large amount of transformation capabilities, as well as having support for custom transformations.
 
+⚠️ Most transformers do **not** preserve uniqueness. Applying one to a column covered by a unique index or primary key produces duplicate key violations. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
+
+## Uniqueness and unique indexes
+
+Anonymization is lossy by design, and that conflicts directly with unique constraints. Masking `609898123456` with `masking` type `id` yields `609898****`: the transformer keeps a 6 character prefix, so **every** source value sharing that prefix becomes the same masked value. On a column covered by a unique index the load then fails with `duplicate key value violates unique constraint`, part way through the data, long after the run started.
+
+Each transformer declares how it behaves with respect to uniqueness:
+
+| Uniqueness       | Meaning                                                                                                                                                              | Validation |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `preserved`      | Distinct inputs always produce distinct outputs. Safe on unique columns.                                                                                             | passes     |
+| `not_guaranteed` | Output is random, hashed, or driven by user supplied logic. Duplicates are possible, at the birthday bound of the output space (which usually depends on parameters). | warns      |
+| `lossy`          | Distinct inputs are mapped to the same output by construction: partial masks, fixed literals, small value sets, name dictionaries.                                    | errors     |
+
+| Transformer                | Uniqueness       |
+| -------------------------- | ---------------- |
+| `encrypted_aes_siv`        | `preserved`      |
+| `email`                    | `not_guaranteed` |
+| `greenmask_date`           | `not_guaranteed` |
+| `greenmask_float`          | `not_guaranteed` |
+| `greenmask_integer`        | `not_guaranteed` |
+| `greenmask_string`         | `not_guaranteed` |
+| `greenmask_unix_timestamp` | `not_guaranteed` |
+| `greenmask_utc_timestamp`  | `not_guaranteed` |
+| `greenmask_uuid`           | `not_guaranteed` |
+| `hstore`                   | `not_guaranteed` |
+| `json`                     | `not_guaranteed` |
+| `neosync_email`            | `not_guaranteed` |
+| `neosync_string`           | `not_guaranteed` |
+| `pg_anonymizer`            | `not_guaranteed` |
+| `phone_number`             | `not_guaranteed` |
+| `string`                   | `not_guaranteed` |
+| `template`                 | `not_guaranteed` |
+| `greenmask_boolean`        | `lossy`          |
+| `greenmask_choice`         | `lossy`          |
+| `greenmask_firstname`      | `lossy`          |
+| `literal_string`           | `lossy`          |
+| `masking`                  | `lossy`          |
+| `neosync_firstname`        | `lossy`          |
+| `neosync_fullname`         | `lossy`          |
+| `neosync_lastname`         | `lossy`          |
+
+When a source Postgres URL is configured, pgstream reads the unique indexes, unique constraints and primary keys of every table in the transformation rules and checks them against the configured transformers. Columns with no rule, or with a `noop` rule, keep their original value and are never flagged. Run the check on its own with:
+
+```sh
+pgstream validate rules -c pg2pg.yaml
+```
+
+With a **Postgres target**, a `lossy` transformer on a covered column fails the rules with `transformation rules break a unique index`, because the target recreates the source's indexes and the load would hit a duplicate key. With any **other target** (Kafka, Elasticsearch/OpenSearch, webhooks) there is no unique index to violate, so the same finding is reported as a warning and does not block the pipeline. A `not_guaranteed` transformer is always a warning.
+
+To keep a `lossy` transformer on a covered column anyway — because the target does not enforce that index, or because the values are known not to collide — set `allow_uniqueness_loss` on that column rule:
+
+```yaml
+column_transformers:
+  pms_patient_id:
+    name: masking
+    parameters:
+      type: id
+    allow_uniqueness_loss: true
+```
+
+### Keeping a column unique
+
+If you need an anonymized column to stay unique, use `encrypted_aes_siv`: it is deterministic, so equality relationships survive across rows, tables and runs, and no two distinct inputs share a token. Its output is a base64 token rather than a value in the original format.
+
+⚠️ `encrypted_aes_siv` is **pseudonymization, not anonymization**. The output is reversible by anyone holding `key_hex`, so it remains personal data, and because tokens are stable they can be correlated across tables and across successive dumps. Treat `key_hex` as a secret: inject it from a secret store rather than committing it in the rules file, use a different key per environment, and set `associated_data` (for example `schema.table.column`) so tokens cannot be correlated between columns.
+
+### What the check does not cover
+
+- **Expression indexes.** A unique index over an expression, such as `lower(email)`, cannot be resolved to a column, so pgstream reports a warning naming the index and leaves it to you to verify.
+- **Target-only indexes.** The check reads the *source* catalog. A unique index that exists only on the target is not seen.
+- **Indexes created after startup.** Rules are validated once when the pipeline starts. A unique index added to the source later is not re-checked.
+- **Exclusion constraints** with equality semantics (`EXCLUDE (email WITH =)`) are not treated as unique indexes.
+
+If a load fails with `duplicate key value violates unique constraint` on a transformed column, run `pgstream validate rules` against the source to see which rules the check flags.
+
 ## Supported transformers
 
 ### PostgreSQL Anonymizer
@@ -142,6 +218,8 @@ transformations:
 
 **Description:** Generates random or deterministic boolean values (`true` or `false`).
 
+**Uniqueness:** `lossy`. The output space has two values. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
+
 | Supported PostgreSQL types |
 | -------------------------- |
 | `boolean`                  |
@@ -178,6 +256,8 @@ transformations:
   <summary>greenmask_choice</summary>
 
 **Description:** Randomly selects a value from a predefined list of choices.
+
+**Uniqueness:** `lossy`. Any table with more rows than choices produces duplicates. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
 
 | Supported PostgreSQL types          |
 | ----------------------------------- |
@@ -257,6 +337,8 @@ transformations:
   <summary>greenmask_firstname</summary>
 
 **Description:** Generates random or deterministic first names, optionally filtered by gender.
+
+**Uniqueness:** `lossy`. Names come from a fixed dictionary and repeat well before a table of any size is exhausted. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
 
 | Supported PostgreSQL types          |
 | ----------------------------------- |
@@ -488,6 +570,8 @@ transformations:
 
 **Description:** Generates anonymized first names while optionally preserving length.
 
+**Uniqueness:** `lossy`. Names come from a fixed dictionary and repeat well before a table of any size is exhausted. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
+
 | Supported PostgreSQL types          |
 | ----------------------------------- |
 | `text`, `varchar`, `char`, `bpchar` |
@@ -518,6 +602,8 @@ transformations:
 
 **Description:** Generates anonymized last names while optionally preserving length.
 
+**Uniqueness:** `lossy`. Names come from a fixed dictionary and repeat well before a table of any size is exhausted. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
+
 | Supported PostgreSQL types          |
 | ----------------------------------- |
 | `text`, `varchar`, `char`, `bpchar` |
@@ -547,6 +633,8 @@ transformations:
   <summary>neosync_fullname</summary>
 
 **Description:** Generates anonymized full names while optionally preserving length.
+
+**Uniqueness:** `lossy`. Names come from fixed dictionaries, so even first/last combinations repeat well before a large table is exhausted. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
 
 | Supported PostgreSQL types          |
 | ----------------------------------- |
@@ -660,6 +748,10 @@ transformations:
   <summary>masking</summary>
 
 **Description:** Masks string values using the provided masking function.
+
+**Uniqueness:** `lossy`. Every type replaces part of the value with `*`, so all values sharing the untouched part collapse to the same output — `type: id` keeps only a 6 character prefix. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
+
+A `custom` mask that would cover zero characters (for example `mask_begin: 3` with `mask_end: 3`, or `unmask_begin: 0`) is rejected at startup: it leaves values completely unmasked, which silently defeats anonymization. Use the `noop` transformer if passing a column through untouched is what you want.
 
 | Supported PostgreSQL types          |
 | ----------------------------------- |
@@ -1001,6 +1093,8 @@ the hstore transformer with above config produces output:
 
 **Description:** Transforms all values into the given constant value.
 
+**Uniqueness:** `lossy`. Every value becomes the same literal. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
+
 | Supported PostgreSQL types             |
 | -------------------------------------- |
 | All types with a string representation |
@@ -1114,6 +1208,8 @@ transformations:
 
 **Description:** Encrypts values with AES-SIV (RFC 5297), a deterministic authenticated encryption scheme. The same input, key and associated data always produce the same token, so equality relationships between column values are preserved across rows, tables and runs — while remaining reversible by holders of the key, unlike hashing. Tokens are authenticated: tampered or forged values fail decryption. The output is the ciphertext encoded as unpadded base64url, safe for URLs and file names.
 
+**Uniqueness:** `preserved`. Encryption is reversible with the key, so two distinct plaintexts cannot share a token. This is the only transformer that never collides on a column covered by a unique index. Note that being reversible makes it pseudonymization rather than anonymization — see [Keeping a column unique](#keeping-a-column-unique).
+
 | Supported PostgreSQL types                   |
 | -------------------------------------------- |
 | `text`, `varchar`, `char`, `bpchar`, `bytea` |
@@ -1176,6 +1272,7 @@ transformations:
       column_transformers: # List of column transformations
         <column_name>: # Name of the column to which the transformation will be applied
           name: <transformer_name> # Name of the transformer to be applied to the column. If no transformer needs to be applied on strict validation mode, it can be left empty or use `noop`
+          allow_uniqueness_loss: false # Whether to allow a transformer that can produce duplicates on a column covered by a unique index. Defaults to false. See "Uniqueness and unique indexes"
           parameters: # Transformer parameters as defined in the supported transformers documentation
             <transformer_parameter>: <transformer_parameter_value>
 ```

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -208,12 +208,24 @@ func addProcessorModifiers(ctx context.Context, config *Config, logger loglib.Lo
 		pgURL := config.SourcePostgresURL()
 		if pgURL != "" {
 			var parser transformer.ParseFn
-			pgParser, err := transformer.NewPostgresTransformerParser(ctx, pgURL, transformerBuilder, config.RequiredTables())
+			parserOpts := []transformer.ParserOption{}
+			// only a postgres target enforces the source's unique indexes
+			if config.Processor.Postgres != nil {
+				parserOpts = append(parserOpts, transformer.WithUniquenessEnforcement())
+			}
+			pgParser, err := transformer.NewPostgresTransformerParser(ctx, pgURL, transformerBuilder, config.RequiredTables(), parserOpts...)
 			if err != nil {
 				return nil, nil, fmt.Errorf("creating transformer validator: %w", err)
 			}
 			closerAgg.addCloserFn(pgParser.Close)
-			parser = pgParser.ParseAndValidate
+			// warnings only reach the caller here
+			parser = func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
+				transformerMap, err := pgParser.ParseAndValidate(ctx, rules)
+				for _, warning := range pgParser.Warnings() {
+					logger.Warn(nil, warning)
+				}
+				return transformerMap, err
+			}
 
 			// wrap the parser to add inferred rules if enabled. This requires a
 			// live connection to the source db and will query the security

--- a/pkg/stream/stream_status.go
+++ b/pkg/stream/stream_status.go
@@ -20,8 +20,9 @@ type ConfigStatus struct {
 }
 
 type TransformationRulesStatus struct {
-	Valid  bool
-	Errors []string
+	Valid    bool
+	Errors   []string
+	Warnings []string
 }
 
 type SourceStatus struct {
@@ -212,6 +213,9 @@ func (trs *TransformationRulesStatus) PrettyPrint() string {
 	fmt.Fprintf(&prettyPrint, " - Valid: %t\n", trs.Valid)
 	if len(trs.Errors) > 0 {
 		fmt.Fprintf(&prettyPrint, " - Errors: %s\n", trs.Errors)
+	}
+	if len(trs.Warnings) > 0 {
+		fmt.Fprintf(&prettyPrint, " - Warnings: %s\n", trs.Warnings)
 	}
 
 	// trim the last newline character

--- a/pkg/stream/stream_status_checker.go
+++ b/pkg/stream/stream_status_checker.go
@@ -26,10 +26,13 @@ type StatusChecker struct {
 	connBuilder          pglib.QuerierBuilder
 	configParser         func(pgURL string) (*pgx.ConnConfig, error)
 	migratorBuilder      func(*InitConfig) (migrator, error)
-	ruleValidatorBuilder func(context.Context, string, []string) (ruleValidator, error)
+	ruleValidatorBuilder func(context.Context, string, []string, ...transformer.ParserOption) (ruleValidator, error)
 }
 
-type ruleValidator func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error)
+type ruleValidator interface {
+	ParseAndValidate(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error)
+	Warnings() []string
+}
 
 type migrator interface {
 	Status() ([]migratorlib.MigrationStatus, error)
@@ -58,12 +61,8 @@ func NewStatusChecker() *StatusChecker {
 			}
 			return migratorlib.NewPGMigrator(cfg.PostgresURL, migrationAssets)
 		},
-		ruleValidatorBuilder: func(ctx context.Context, pgURL string, requiredTables []string) (ruleValidator, error) {
-			validator, err := transformer.NewPostgresTransformerParser(ctx, pgURL, builder.NewTransformerBuilder(), requiredTables)
-			if err != nil {
-				return nil, err
-			}
-			return validator.ParseAndValidate, nil
+		ruleValidatorBuilder: func(ctx context.Context, pgURL string, requiredTables []string, opts ...transformer.ParserOption) (ruleValidator, error) {
+			return transformer.NewPostgresTransformerParser(ctx, pgURL, builder.NewTransformerBuilder(), requiredTables, opts...)
 		},
 	}
 }
@@ -203,7 +202,12 @@ func (s *StatusChecker) TransformationRulesStatus(ctx context.Context, config *C
 	status := &TransformationRulesStatus{
 		Valid: true,
 	}
-	validator, err := s.ruleValidatorBuilder(ctx, pgURL, config.RequiredTables())
+	parserOpts := []transformer.ParserOption{}
+	// mirror the run path: only a postgres target enforces unique indexes
+	if config.Processor.Postgres != nil {
+		parserOpts = append(parserOpts, transformer.WithUniquenessEnforcement())
+	}
+	validator, err := s.ruleValidatorBuilder(ctx, pgURL, config.RequiredTables(), parserOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +215,7 @@ func (s *StatusChecker) TransformationRulesStatus(ctx context.Context, config *C
 		Transformers:   config.Processor.Transformer.TransformerRules,
 		ValidationMode: config.Processor.Transformer.ValidationMode,
 	}
-	if _, err := validator(ctx, rules); err != nil {
+	if _, err := validator.ParseAndValidate(ctx, rules); err != nil {
 		status.Valid = false
 		switch {
 		case errors.Is(err, syscall.ECONNREFUSED):
@@ -220,6 +224,7 @@ func (s *StatusChecker) TransformationRulesStatus(ctx context.Context, config *C
 			status.Errors = append(status.Errors, err.Error())
 		}
 	}
+	status.Warnings = validator.Warnings()
 
 	return status, nil
 }

--- a/pkg/stream/stream_status_checker_test.go
+++ b/pkg/stream/stream_status_checker_test.go
@@ -21,6 +21,19 @@ import (
 	replicationpg "github.com/xataio/pgstream/pkg/wal/replication/postgres"
 )
 
+type mockRuleValidator struct {
+	parseAndValidateFn func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error)
+	warnings           []string
+}
+
+func (m *mockRuleValidator) ParseAndValidate(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
+	return m.parseAndValidateFn(ctx, rules)
+}
+
+func (m *mockRuleValidator) Warnings() []string {
+	return m.warnings
+}
+
 func TestStatusChecker_Status(t *testing.T) {
 	t.Parallel()
 
@@ -111,9 +124,11 @@ func TestStatusChecker_Status(t *testing.T) {
 		}, nil
 	}
 
-	validRuleValidatorBuilder := func(context.Context, string, []string) (ruleValidator, error) {
-		return func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
-			return nil, nil
+	validRuleValidatorBuilder := func(context.Context, string, []string, ...transformer.ParserOption) (ruleValidator, error) {
+		return &mockRuleValidator{
+			parseAndValidateFn: func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
+				return nil, nil
+			},
 		}, nil
 	}
 
@@ -122,7 +137,7 @@ func TestStatusChecker_Status(t *testing.T) {
 		connBuilder          pglib.QuerierBuilder
 		migratorBuilder      func(*InitConfig) (migrator, error)
 		config               *Config
-		ruleValidatorBuilder func(context.Context, string, []string) (ruleValidator, error)
+		ruleValidatorBuilder func(context.Context, string, []string, ...transformer.ParserOption) (ruleValidator, error)
 
 		wantStatus *Status
 		wantErr    error
@@ -193,7 +208,7 @@ func TestStatusChecker_Status(t *testing.T) {
 			connBuilder:     validConnBuilder,
 			migratorBuilder: validMigratorBuilder,
 			config:          validConfig,
-			ruleValidatorBuilder: func(ctx context.Context, s string, r []string) (ruleValidator, error) {
+			ruleValidatorBuilder: func(ctx context.Context, s string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
 				return nil, errTest
 			},
 
@@ -636,16 +651,18 @@ func TestStatusChecker_transformationRulesStatus(t *testing.T) {
 
 	tests := []struct {
 		name                 string
-		ruleValidatorBuilder func(context.Context, string, []string) (ruleValidator, error)
+		ruleValidatorBuilder func(context.Context, string, []string, ...transformer.ParserOption) (ruleValidator, error)
 		config               *Config
 		wantStatus           *TransformationRulesStatus
 		wantErr              error
 	}{
 		{
 			name: "ok - valid transformation rules",
-			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string) (ruleValidator, error) {
-				return func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
-					return nil, nil
+			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
+				return &mockRuleValidator{
+					parseAndValidateFn: func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
+						return nil, nil
+					},
 				}, nil
 			},
 			config: &Config{
@@ -666,8 +683,36 @@ func TestStatusChecker_transformationRulesStatus(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "ok - valid transformation rules with warnings",
+			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
+				return &mockRuleValidator{
+					parseAndValidateFn: func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
+						return nil, nil
+					},
+					warnings: []string{"a transformer might break a unique index"},
+				}, nil
+			},
+			config: &Config{
+				Processor: ProcessorConfig{
+					Transformer: &transformer.Config{
+						TransformerRules: []transformer.TableRules{},
+					},
+				},
+				Listener: ListenerConfig{
+					Postgres: &PostgresListenerConfig{
+						URL: "postgres://user:password@localhost:5432/db",
+					},
+				},
+			},
+			wantStatus: &TransformationRulesStatus{
+				Valid:    true,
+				Warnings: []string{"a transformer might break a unique index"},
+			},
+			wantErr: nil,
+		},
+		{
 			name: "ok - no transformer configured",
-			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string) (ruleValidator, error) {
+			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
 				return nil, errors.New("unexpected call to ruleValidatorBuilder")
 			},
 			config: &Config{
@@ -685,7 +730,7 @@ func TestStatusChecker_transformationRulesStatus(t *testing.T) {
 		},
 		{
 			name: "error - source postgres URL not provided",
-			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string) (ruleValidator, error) {
+			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
 				return nil, errors.New("unexpected call to ruleValidatorBuilder")
 			},
 			config: &Config{
@@ -708,9 +753,11 @@ func TestStatusChecker_transformationRulesStatus(t *testing.T) {
 		},
 		{
 			name: "error - rule validation failure",
-			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string) (ruleValidator, error) {
-				return func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
-					return nil, errTest
+			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
+				return &mockRuleValidator{
+					parseAndValidateFn: func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
+						return nil, errTest
+					},
 				}, nil
 			},
 			config: &Config{
@@ -733,7 +780,7 @@ func TestStatusChecker_transformationRulesStatus(t *testing.T) {
 		},
 		{
 			name: "error - ruleValidatorBuilder failure",
-			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string) (ruleValidator, error) {
+			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
 				return nil, errTest
 			},
 			config: &Config{

--- a/pkg/transformers/builder/transformer_uniqueness_test.go
+++ b/pkg/transformers/builder/transformer_uniqueness_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/pkg/transformers"
+)
+
+// the definition feeds the docs and transformers-definition.json while the
+// method feeds rule validation; nothing else keeps the two in step
+func TestTransformers_UniquenessMatchesDefinition(t *testing.T) {
+	t.Parallel()
+
+	cases := map[transformers.TransformerType]transformers.ParameterValues{
+		transformers.Masking:                {"type": "default"},
+		transformers.Email:                  {},
+		transformers.Template:               {"template": "{{ .GetValue }}"},
+		transformers.JSON:                   {"operations": []any{map[string]any{"operation": "set", "path": "a", "value": "b"}}},
+		transformers.Hstore:                 {"operations": []any{map[string]any{"operation": "set", "key": "a", "value": "b"}}},
+		transformers.PhoneNumber:            {"prefix": "+1", "min_length": 9, "max_length": 12},
+		transformers.LiteralString:          {"literal": "fixed"},
+		transformers.String:                 {},
+		transformers.EncryptedAESSIV:        {"key_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"},
+		transformers.GreenmaskString:        {"min_length": 2, "max_length": 12},
+		transformers.GreenmaskFirstName:     {},
+		transformers.GreenmaskInteger:       {"min_value": 0, "max_value": 1000},
+		transformers.GreenmaskFloat:         {"min_value": 0.0, "max_value": 1000.0},
+		transformers.GreenmaskUUID:          {},
+		transformers.GreenmaskBoolean:       {},
+		transformers.GreenmaskChoice:        {"choices": []any{"alpha", "beta"}},
+		transformers.GreenmaskUnixTimestamp: {"min_value": "946684800", "max_value": "1893456000"},
+		transformers.GreenmaskDate:          {"min_value": "2020-01-01", "max_value": "2024-12-31"},
+		transformers.GreenmaskUTCTimestamp:  {"min_timestamp": "2020-01-01T00:00:00Z", "max_timestamp": "2024-12-31T23:59:59Z"},
+		transformers.NeosyncString:          {},
+		transformers.NeosyncFirstName:       {},
+		transformers.NeosyncLastName:        {},
+		transformers.NeosyncFullName:        {},
+		transformers.NeosyncEmail:           {},
+		transformers.PGAnonymizer:           {"anon_function": "anon.fake_email()", "postgres_url": "postgres://user:pass@localhost:5432/db"},
+	}
+
+	for transformerType := range TransformersMap {
+		_, found := cases[transformerType]
+		require.True(t, found, "transformer %q is missing a uniqueness test case", transformerType)
+	}
+
+	builder := NewTransformerBuilder()
+	for transformerType, params := range cases {
+		t.Run(string(transformerType), func(t *testing.T) {
+			t.Parallel()
+
+			transformer, err := builder.New(&transformers.Config{Name: transformerType, Parameters: params})
+			require.NoError(t, err)
+			require.Equal(t, TransformersMap[transformerType].Definition.Uniqueness, transformers.UniquenessOf(transformer))
+		})
+	}
+}

--- a/pkg/transformers/email_transformer.go
+++ b/pkg/transformers/email_transformer.go
@@ -176,6 +176,10 @@ func (et *EmailTransformer) IsDynamic() bool {
 	return false
 }
 
+func (et *EmailTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (et *EmailTransformer) Close() error {
 	return nil
 }
@@ -184,5 +188,6 @@ func EmailTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: emailCompatibleTypes,
 		Parameters:     emailParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/encrypted_aes_siv_transformer.go
+++ b/pkg/transformers/encrypted_aes_siv_transformer.go
@@ -149,6 +149,10 @@ func (est *EncryptedAESSIVTransformer) IsDynamic() bool {
 	return false
 }
 
+func (est *EncryptedAESSIVTransformer) Uniqueness() Uniqueness {
+	return UniquenessPreserved
+}
+
 func (est *EncryptedAESSIVTransformer) Close() error {
 	return nil
 }
@@ -157,5 +161,6 @@ func EncryptedAESSIVTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: encryptedAESSIVCompatibleTypes,
 		Parameters:     encryptedAESSIVParams,
+		Uniqueness:     UniquenessPreserved,
 	}
 }

--- a/pkg/transformers/greenmask/greenmask_boolean_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_boolean_transformer.go
@@ -74,6 +74,10 @@ func (bt *BooleanTransformer) IsDynamic() bool {
 	return false
 }
 
+func (bt *BooleanTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessLossy
+}
+
 func (bt *BooleanTransformer) Close() error {
 	return nil
 }
@@ -82,5 +86,6 @@ func BooleanTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: booleanCompatibleTypes,
 		Parameters:     booleanParams,
+		Uniqueness:     transformers.UniquenessLossy,
 	}
 }

--- a/pkg/transformers/greenmask/greenmask_choice_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_choice_transformer.go
@@ -100,6 +100,10 @@ func (t *ChoiceTransformer) IsDynamic() bool {
 	return false
 }
 
+func (t *ChoiceTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessLossy
+}
+
 func (t *ChoiceTransformer) Close() error {
 	return nil
 }
@@ -108,5 +112,6 @@ func ChoiceTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: choiceCompatibleTypes,
 		Parameters:     choiceParams,
+		Uniqueness:     transformers.UniquenessLossy,
 	}
 }

--- a/pkg/transformers/greenmask/greenmask_date_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_date_transformer.go
@@ -127,6 +127,10 @@ func (t *DateTransformer) IsDynamic() bool {
 	return false
 }
 
+func (t *DateTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessNotGuaranteed
+}
+
 func (t *DateTransformer) Close() error {
 	return nil
 }
@@ -135,5 +139,6 @@ func DateTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: dateCompatibleTypes,
 		Parameters:     dateParams,
+		Uniqueness:     transformers.UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/greenmask/greenmask_firstname_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_firstname_transformer.go
@@ -117,6 +117,10 @@ func (fnt *FirstNameTransformer) IsDynamic() bool {
 	return len(fnt.dynamicParams) > 0
 }
 
+func (fnt *FirstNameTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessLossy
+}
+
 func (fnt *FirstNameTransformer) Close() error {
 	return nil
 }
@@ -125,5 +129,6 @@ func FirstNameTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: firstNameCompatibleTypes,
 		Parameters:     firstNameParams,
+		Uniqueness:     transformers.UniquenessLossy,
 	}
 }

--- a/pkg/transformers/greenmask/greenmask_float_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_float_transformer.go
@@ -120,6 +120,10 @@ func (ft *FloatTransformer) IsDynamic() bool {
 	return false
 }
 
+func (ft *FloatTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessNotGuaranteed
+}
+
 func (ft *FloatTransformer) Close() error {
 	return nil
 }
@@ -128,6 +132,7 @@ func FloatTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: floatCompatibleTypes,
 		Parameters:     floatParams,
+		Uniqueness:     transformers.UniquenessNotGuaranteed,
 	}
 }
 

--- a/pkg/transformers/greenmask/greenmask_integer_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_integer_transformer.go
@@ -170,6 +170,10 @@ func (t *IntegerTransformer) IsDynamic() bool {
 	return false
 }
 
+func (t *IntegerTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessNotGuaranteed
+}
+
 func (t *IntegerTransformer) Close() error {
 	return nil
 }
@@ -178,6 +182,7 @@ func IntegerTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: integerCompatibleTypes,
 		Parameters:     integerParams,
+		Uniqueness:     transformers.UniquenessNotGuaranteed,
 	}
 }
 

--- a/pkg/transformers/greenmask/greenmask_string_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_string_transformer.go
@@ -127,6 +127,10 @@ func (st *StringTransformer) IsDynamic() bool {
 	return false
 }
 
+func (st *StringTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessNotGuaranteed
+}
+
 func (st *StringTransformer) Close() error {
 	return nil
 }
@@ -135,5 +139,6 @@ func StringTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: stringCompatibleTypes,
 		Parameters:     stringParams,
+		Uniqueness:     transformers.UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_timestamp_transformer.go
@@ -132,6 +132,10 @@ func (t *UTCTimestampTransformer) IsDynamic() bool {
 	return false
 }
 
+func (t *UTCTimestampTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessNotGuaranteed
+}
+
 func (t *UTCTimestampTransformer) Close() error {
 	return nil
 }
@@ -140,5 +144,6 @@ func UTCTimestampTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: utcTimestampCompatibleTypes,
 		Parameters:     utcTimestampParams,
+		Uniqueness:     transformers.UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_unix_timestamp_transformer.go
@@ -98,5 +98,6 @@ func UnixTimestampTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: unixTimestampCompatibleTypes,
 		Parameters:     unixTimestampParams,
+		Uniqueness:     transformers.UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/greenmask/greenmask_uuid_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_uuid_transformer.go
@@ -76,6 +76,10 @@ func (ut *UUIDTransformer) IsDynamic() bool {
 	return false
 }
 
+func (ut *UUIDTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessNotGuaranteed
+}
+
 func (ut *UUIDTransformer) Close() error {
 	return nil
 }
@@ -84,5 +88,6 @@ func UUIDTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: uuidCompatibleTypes,
 		Parameters:     uuidParams,
+		Uniqueness:     transformers.UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/hstore_transformer.go
+++ b/pkg/transformers/hstore_transformer.go
@@ -139,6 +139,10 @@ func (t *HstoreTransformer) IsDynamic() bool {
 	return true
 }
 
+func (t *HstoreTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (t *HstoreTransformer) Close() error {
 	return nil
 }
@@ -147,6 +151,7 @@ func HstoreTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: hstoreCompatibleTypes,
 		Parameters:     hstoreParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }
 

--- a/pkg/transformers/instrumentation/instrumented_transformer.go
+++ b/pkg/transformers/instrumentation/instrumented_transformer.go
@@ -72,6 +72,12 @@ func (i *Transformer) IsDynamic() bool {
 	return i.inner.IsDynamic()
 }
 
+// forwarded so wrapping a transformer for instrumentation does not downgrade
+// its uniqueness classification to unknown
+func (i *Transformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessOf(i.inner)
+}
+
 func (i *Transformer) Close() error {
 	return i.inner.Close()
 }

--- a/pkg/transformers/json_transformer.go
+++ b/pkg/transformers/json_transformer.go
@@ -123,6 +123,10 @@ func (jt *JSONTransformer) IsDynamic() bool {
 	return true
 }
 
+func (jt *JSONTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (jt *JSONTransformer) Close() error {
 	return nil
 }
@@ -131,6 +135,7 @@ func JSONTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: jsonCompatibleTypes,
 		Parameters:     jsonParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }
 

--- a/pkg/transformers/literal_string_transformer.go
+++ b/pkg/transformers/literal_string_transformer.go
@@ -58,6 +58,10 @@ func (lst *LiteralStringTransformer) IsDynamic() bool {
 	return false
 }
 
+func (lst *LiteralStringTransformer) Uniqueness() Uniqueness {
+	return UniquenessLossy
+}
+
 func (lst *LiteralStringTransformer) Close() error {
 	return nil
 }
@@ -66,5 +70,6 @@ func LiteralStringTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: literalStringCompatibleTypes,
 		Parameters:     literalStringParams,
+		Uniqueness:     UniquenessLossy,
 	}
 }

--- a/pkg/transformers/masking_transformer.go
+++ b/pkg/transformers/masking_transformer.go
@@ -31,6 +31,7 @@ var (
 		"type must be one of 'custom', 'password', 'name', 'address', 'email', 'mobile', 'tel', 'id', 'credit_card', 'url' or 'default'",
 	)
 	errMaskUnmaskCannotBeUsedTogether = errors.New("masking: mask and unmask parameters cannot be used together")
+	errMaskCoversNoCharacters         = errors.New("masking: the configured mask covers no characters and would leave values unmasked; use the noop transformer if passthrough is intended")
 	maskingCompatibleTypes            = []SupportedDataType{
 		StringDataType,
 		ByteArrayDataType,
@@ -159,10 +160,15 @@ func (t *MaskingTransformer) IsDynamic() bool {
 	return false
 }
 
+func (t *MaskingTransformer) Uniqueness() Uniqueness {
+	return UniquenessLossy
+}
+
 func MaskingTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: maskingCompatibleTypes,
 		Parameters:     maskingParams,
+		Uniqueness:     UniquenessLossy,
 	}
 }
 
@@ -218,6 +224,12 @@ func getCustomMaskingFn(params ParameterValues) (maskingFunction, error) {
 			return nil, fmt.Errorf("masking: unable to read mask_end: %w", err)
 		}
 	}
+	// a mask covering no characters leaves values unmasked, which silently
+	// defeats anonymization; noop is the way to pass a column through
+	if masksNothing(mask, begin, beginAbs, end, endAbs) {
+		return nil, errMaskCoversNoCharacters
+	}
+
 	return func(v string) string {
 		var beginIndex, endIndex int
 		length := len(v)
@@ -242,6 +254,13 @@ func getCustomMaskingFn(params ParameterValues) (maskingFunction, error) {
 		}
 		return strings.Repeat("*", beginIndex) + v[beginIndex:endIndex] + strings.Repeat("*", length-endIndex)
 	}, nil
+}
+
+func masksNothing(mask bool, begin int, beginAbs bool, end int, endAbs bool) bool {
+	if mask {
+		return beginAbs == endAbs && begin == end
+	}
+	return begin <= 0 && !endAbs && end >= 100
 }
 
 func getIntegerInRange(v, min, max int) int {

--- a/pkg/transformers/masking_transformer_test.go
+++ b/pkg/transformers/masking_transformer_test.go
@@ -228,3 +228,87 @@ func TestMaskingTransformer_Transform(t *testing.T) {
 		})
 	}
 }
+
+func TestMaskingTransformer_Uniqueness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params ParameterValues
+	}{
+		{
+			name:   "default masks the whole value",
+			params: ParameterValues{},
+		},
+		{
+			name:   "id keeps a 6 character prefix",
+			params: ParameterValues{"type": "id"},
+		},
+		{
+			name:   "credit_card keeps a 6 character prefix",
+			params: ParameterValues{"type": "credit_card"},
+		},
+		{
+			name:   "custom mask range",
+			params: ParameterValues{"type": "custom", "mask_begin": "2", "mask_end": "6"},
+		},
+		{
+			name:   "custom mask range mixing an absolute and a percentage bound",
+			params: ParameterValues{"type": "custom", "mask_begin": "50", "mask_end": "50%"},
+		},
+		{
+			name:   "custom unmask range leaving a masked prefix",
+			params: ParameterValues{"type": "custom", "unmask_begin": "4"},
+		},
+		{
+			name:   "custom unmask range leaving a masked suffix",
+			params: ParameterValues{"type": "custom", "unmask_end": "4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			transformer, err := NewMaskingTransformer(tt.params)
+			require.NoError(t, err)
+			require.Equal(t, UniquenessLossy, transformer.Uniqueness())
+		})
+	}
+}
+
+func TestMaskingTransformer_rejectsMaskCoveringNoCharacters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params ParameterValues
+	}{
+		{
+			name:   "mask range of zero characters",
+			params: ParameterValues{"type": "custom", "mask_begin": "3", "mask_end": "3"},
+		},
+		{
+			name:   "mask range of zero characters, percentages",
+			params: ParameterValues{"type": "custom", "mask_begin": "50%", "mask_end": "50%"},
+		},
+		{
+			name:   "unmask range covering the whole value",
+			params: ParameterValues{"type": "custom", "unmask_begin": "0", "unmask_end": "100%"},
+		},
+		{
+			name:   "unmask range covering the whole value by default",
+			params: ParameterValues{"type": "custom", "unmask_begin": "0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			transformer, err := NewMaskingTransformer(tt.params)
+			require.ErrorIs(t, err, errMaskCoversNoCharacters)
+			require.Nil(t, transformer)
+		})
+	}
+}

--- a/pkg/transformers/mocks/mock_transformer.go
+++ b/pkg/transformers/mocks/mock_transformer.go
@@ -12,6 +12,7 @@ type Transformer struct {
 	TransformFn       func(transformers.Value) (any, error)
 	IsDynamicFn       func() bool
 	CompatibleTypesFn func() []transformers.SupportedDataType
+	UniquenessFn      func() transformers.Uniqueness
 }
 
 func (m *Transformer) Transform(_ context.Context, val transformers.Value) (any, error) {
@@ -31,6 +32,13 @@ func (m *Transformer) IsDynamic() bool {
 		return m.IsDynamicFn()
 	}
 	return false
+}
+
+func (m *Transformer) Uniqueness() transformers.Uniqueness {
+	if m.UniquenessFn != nil {
+		return m.UniquenessFn()
+	}
+	return transformers.UniquenessPreserved
 }
 
 func (m *Transformer) Close() error {

--- a/pkg/transformers/neosync/neosync_email_transformer.go
+++ b/pkg/transformers/neosync/neosync_email_transformer.go
@@ -150,6 +150,10 @@ func (t *EmailTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncEmail
 }
 
+func (t *EmailTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessNotGuaranteed
+}
+
 func (t *EmailTransformer) Close() error {
 	return nil
 }
@@ -158,5 +162,6 @@ func EmailTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: emailCompatibleTypes,
 		Parameters:     emailParams,
+		Uniqueness:     transformers.UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/neosync/neosync_firstname_transformer.go
+++ b/pkg/transformers/neosync/neosync_firstname_transformer.go
@@ -105,6 +105,10 @@ func (t *FirstNameTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncFirstName
 }
 
+func (t *FirstNameTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessLossy
+}
+
 func (t *FirstNameTransformer) Close() error {
 	return nil
 }
@@ -113,5 +117,6 @@ func FirstNameTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: firstNameCompatibleTypes,
 		Parameters:     firstNameParams,
+		Uniqueness:     transformers.UniquenessLossy,
 	}
 }

--- a/pkg/transformers/neosync/neosync_fullname_transformer.go
+++ b/pkg/transformers/neosync/neosync_fullname_transformer.go
@@ -136,6 +136,10 @@ func (t *FullNameTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncFullName
 }
 
+func (t *FullNameTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessLossy
+}
+
 func (t *FullNameTransformer) Close() error {
 	return nil
 }
@@ -144,6 +148,7 @@ func FullNameTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: fullNameCompatibleTypes,
 		Parameters:     fullNameParams,
+		Uniqueness:     transformers.UniquenessLossy,
 	}
 }
 

--- a/pkg/transformers/neosync/neosync_lastname_transformer.go
+++ b/pkg/transformers/neosync/neosync_lastname_transformer.go
@@ -104,6 +104,10 @@ func (t *LastNameTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncLastName
 }
 
+func (t *LastNameTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessLossy
+}
+
 func (t *LastNameTransformer) Close() error {
 	return nil
 }
@@ -112,5 +116,6 @@ func LastNameTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: lastNameCompatibleTypes,
 		Parameters:     lastNameParams,
+		Uniqueness:     transformers.UniquenessLossy,
 	}
 }

--- a/pkg/transformers/neosync/neosync_string_transformer.go
+++ b/pkg/transformers/neosync/neosync_string_transformer.go
@@ -88,6 +88,10 @@ func (t *StringTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncString
 }
 
+func (t *StringTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessNotGuaranteed
+}
+
 func (t *StringTransformer) Close() error {
 	return nil
 }
@@ -96,5 +100,6 @@ func StringTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: stringCompatibleTypes,
 		Parameters:     stringParams,
+		Uniqueness:     transformers.UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/pg_anonymizer_transformer.go
+++ b/pkg/transformers/pg_anonymizer_transformer.go
@@ -392,6 +392,10 @@ func (t *PGAnonymizerTransformer) IsDynamic() bool {
 	return false
 }
 
+func (t *PGAnonymizerTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (t *PGAnonymizerTransformer) Close() error {
 	return t.conn.Close(context.Background())
 }
@@ -576,6 +580,7 @@ func PGAnonymizerTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: pgAnonymizerCompatibleTypes,
 		Parameters:     pgAnonymizerParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }
 

--- a/pkg/transformers/phone_number_transformer.go
+++ b/pkg/transformers/phone_number_transformer.go
@@ -175,6 +175,10 @@ func (t *PhoneNumberTransformer) Type() TransformerType {
 	return PhoneNumber
 }
 
+func (t *PhoneNumberTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (t *PhoneNumberTransformer) IsDynamic() bool {
 	return len(t.dynamicParams) > 0
 }
@@ -187,5 +191,6 @@ func PhoneNumberTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: phoneNumberCompatibleTypes,
 		Parameters:     phoneNumberParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/string_transformer.go
+++ b/pkg/transformers/string_transformer.go
@@ -62,6 +62,10 @@ func (st *StringTransformer) IsDynamic() bool {
 	return false
 }
 
+func (st *StringTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (st *StringTransformer) Close() error {
 	return nil
 }
@@ -70,5 +74,6 @@ func StringTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: stringCompatibleTypes,
 		Parameters:     stringParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/template_transformer.go
+++ b/pkg/transformers/template_transformer.go
@@ -68,6 +68,10 @@ func (t *TemplateTransformer) IsDynamic() bool {
 	return true
 }
 
+func (t *TemplateTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (t *TemplateTransformer) Close() error {
 	return nil
 }
@@ -76,5 +80,6 @@ func TemplateTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: templateCompatibleTypes,
 		Parameters:     templateParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -16,6 +16,23 @@ type Transformer interface {
 	Close() error
 }
 
+// optional so that Transformer implementations outside this module keep
+// compiling; UniquenessOf treats a non-implementer as unknown
+type UniquenessReporter interface {
+	Uniqueness() Uniqueness
+}
+
+// UniquenessOf reports what t guarantees about the uniqueness of its output.
+// A transformer that does not classify itself is assumed to be capable of
+// producing duplicates, but not known to.
+func UniquenessOf(t Transformer) Uniqueness {
+	reporter, ok := t.(UniquenessReporter)
+	if !ok {
+		return UniquenessNotGuaranteed
+	}
+	return reporter.Uniqueness()
+}
+
 type Value struct {
 	TransformValue any
 	TransformType  string
@@ -95,6 +112,7 @@ const (
 type Definition struct {
 	SupportedTypes []SupportedDataType
 	Parameters     []Parameter
+	Uniqueness     Uniqueness
 }
 
 type Parameter struct {

--- a/pkg/transformers/uniqueness.go
+++ b/pkg/transformers/uniqueness.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformers
+
+// validated against unique indexes
+type Uniqueness int
+
+const (
+	UniquenessLossy Uniqueness = iota
+	UniquenessNotGuaranteed
+	UniquenessPreserved
+)
+
+func (u Uniqueness) String() string {
+	switch u {
+	case UniquenessLossy:
+		return "lossy"
+	case UniquenessNotGuaranteed:
+		return "not_guaranteed"
+	case UniquenessPreserved:
+		return "preserved"
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
@@ -21,36 +21,80 @@ type PostgresTransformerParser struct {
 	builder        transformerBuilder
 	pgtypeMap      *pglib.Mapper
 	requiredTables []string
+
+	warnings []string
+	// only a postgres target actually enforces a unique index; elsewhere the
+	// same findings are reported but must not block the pipeline
+	enforceUniqueness bool
+}
+
+type ParserOption func(*PostgresTransformerParser)
+
+// WithUniquenessEnforcement makes transformation rules that break a unique
+// index a hard error instead of a warning. Enable it when the target enforces
+// unique indexes, which today means a postgres target.
+func WithUniquenessEnforcement() ParserOption {
+	return func(v *PostgresTransformerParser) {
+		v.enforceUniqueness = true
+	}
 }
 
 const (
 	fieldDescriptionsQuery = "SELECT * FROM %s LIMIT 0"
 	schemaTablesQuery      = "SELECT tablename FROM pg_tables WHERE schemaname=$1"
-	publicSchema           = "public"
-	wildcard               = "*"
+	// expression columns have attnum 0 and no pg_attribute row, so the LEFT
+	// JOIN yields a NULL attname rather than dropping the index entirely.
+	// indkey also carries INCLUDE columns, which do not enforce uniqueness;
+	// only the first indnkeyatts entries do
+	uniqueIndexQuery = `SELECT idx.relname, i.indisprimary, a.attname
+	FROM pg_index i
+	JOIN pg_class c ON c.oid = i.indrelid
+	JOIN pg_class idx ON idx.oid = i.indexrelid
+	JOIN pg_namespace n ON n.oid = c.relnamespace
+	JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord) ON true
+	LEFT JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum
+	WHERE i.indisunique AND i.indisvalid AND i.indislive
+	AND k.ord <= i.indnkeyatts
+	AND n.nspname = $1 AND c.relname = $2
+	ORDER BY idx.relname, k.ord`
+	publicSchema = "public"
+	wildcard     = "*"
 )
 
 var errInvalidTableName = errors.New("invalid table name, expected format: schema.table or table")
 
-func NewPostgresTransformerParser(ctx context.Context, pgURL string, builder transformerBuilder, requiredTables []string) (*PostgresTransformerParser, error) {
+func NewPostgresTransformerParser(ctx context.Context, pgURL string, builder transformerBuilder, requiredTables []string, opts ...ParserOption) (*PostgresTransformerParser, error) {
 	pool, err := pglib.NewConnPool(ctx, pgURL)
 	if err != nil {
 		return nil, err
 	}
-	return &PostgresTransformerParser{
+	parser := &PostgresTransformerParser{
 		conn:           pool,
 		connURL:        pgURL,
 		builder:        builder,
 		pgtypeMap:      pglib.NewMapper(pool),
 		requiredTables: requiredTables,
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(parser)
+	}
+	return parser, nil
+}
+
+func (v *PostgresTransformerParser) Warnings() []string {
+	return v.warnings
 }
 
 func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules Rules) (*TransformerMap, error) {
+	// reset before any early return, so a failed call cannot leave the
+	// previous call's warnings visible through Warnings
+	v.warnings = nil
+
 	// validate that all required tables are present in the rules
 	if err := v.validateAllRequiredTables(ctx, rules); err != nil {
 		return nil, err
 	}
+	var uniquenessErrs []string
 	transformerMap := NewTransformerMap()
 	for _, table := range rules.Transformers {
 		fieldDescriptions, err := v.getFieldDescriptions(context.Background(), table.Schema, table.Table)
@@ -109,8 +153,71 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 			// add the transformer to the map
 			transformerMap.AddActiveTransformer(table.Schema, table.Table, colName, transformer)
 		}
+
+		// catch collisions before the load
+		uniqueIndexes, err := v.getUniqueIndexes(ctx, table.Schema, table.Table)
+		if err != nil {
+			return nil, err
+		}
+		columnTransformers, _ := transformerMap.GetActiveColumnTransformers(table.Schema, table.Table)
+		findings := validateUniqueness(table.Schema, table.Table, uniqueIndexes, columnTransformers, allowUniquenessLossColumns(table))
+		if v.enforceUniqueness {
+			uniquenessErrs = append(uniquenessErrs, findings.errors...)
+		} else {
+			v.warnings = append(v.warnings, findings.errors...)
+		}
+		v.warnings = append(v.warnings, findings.warnings...)
 	}
+
+	if len(uniquenessErrs) > 0 {
+		return nil, fmt.Errorf("%w: %s", ErrUniquenessNotPreserved, strings.Join(uniquenessErrs, "; "))
+	}
+
 	return transformerMap, nil
+}
+
+func allowUniquenessLossColumns(table TableRules) map[string]bool {
+	allowed := make(map[string]bool, len(table.ColumnRules))
+	for colName, colRules := range table.ColumnRules {
+		if colRules.AllowUniquenessLoss {
+			allowed[colName] = true
+		}
+	}
+	return allowed
+}
+
+func (v *PostgresTransformerParser) getUniqueIndexes(ctx context.Context, schema, table string) ([]uniqueIndex, error) {
+	rows, err := v.conn.Query(ctx, uniqueIndexQuery, schema, table)
+	if err != nil {
+		return nil, fmt.Errorf("querying unique indexes for table %q.%q: %w", schema, table, err)
+	}
+	defer rows.Close()
+
+	// rows arrive grouped by index
+	var indexes []uniqueIndex
+	for rows.Next() {
+		var indexName string
+		var columnName *string
+		var primary bool
+		if err := rows.Scan(&indexName, &primary, &columnName); err != nil {
+			return nil, fmt.Errorf("scanning unique index for table %q.%q: %w", schema, table, err)
+		}
+		if len(indexes) == 0 || indexes[len(indexes)-1].name != indexName {
+			indexes = append(indexes, uniqueIndex{name: indexName, primary: primary})
+		}
+		current := &indexes[len(indexes)-1]
+		if columnName == nil {
+			current.hasExpressions = true
+			continue
+		}
+		current.columns = append(current.columns, *columnName)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading unique indexes for table %q.%q: %w", schema, table, err)
+	}
+
+	return indexes, nil
 }
 
 func (v *PostgresTransformerParser) validateAllRequiredTables(ctx context.Context, rules Rules) error {

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -59,6 +60,12 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 							return nil
 						},
 						ErrFn: func() error { return nil },
+					}, nil
+				case uniqueIndexQuery:
+					return &pgmocks.Rows{
+						CloseFn: func() {},
+						NextFn:  func(i uint) bool { return false },
+						ErrFn:   func() error { return nil },
 					}, nil
 				case "SELECT nspname FROM pg_catalog.pg_namespace WHERE nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast', 'pgstream') AND nspname NOT LIKE 'pg_temp_%' AND nspname NOT LIKE 'pg_toast_temp_%'":
 					return &pgmocks.Rows{
@@ -432,6 +439,167 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 			for _, col := range tc.wantNoopTransformersFor {
 				require.Contains(t, noopColumnTransformers, col)
 			}
+		})
+	}
+}
+
+func TestPostgresTransformerParser_uniqueIndexValidation(t *testing.T) {
+	t.Parallel()
+
+	// two indexes over the same table, so the row-grouping loop has to start a
+	// new index when the name changes and keep column order within each
+	type indexRow struct {
+		index   string
+		primary bool
+		column  *string
+	}
+	name, email := "name", "email"
+	indexRows := []indexRow{
+		{index: "test_name_email_key", column: &name},
+		{index: "test_name_email_key", column: &email},
+		{index: "test_pkey", primary: true, column: &email},
+	}
+
+	testQuerier := func() *pgmocks.Querier {
+		return &pgmocks.Querier{
+			QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
+				switch query {
+				case "SELECT * FROM \"public\".\"test\" LIMIT 0":
+					return &pgmocks.Rows{
+						FieldDescriptionsFn: func() []pgconn.FieldDescription {
+							return []pgconn.FieldDescription{
+								{Name: "name", DataTypeOID: pgtype.TextOID},
+								{Name: "email", DataTypeOID: pgtype.TextOID},
+							}
+						},
+						CloseFn: func() {},
+						ErrFn:   func() error { return nil },
+					}, nil
+				case uniqueIndexQuery:
+					require.Equal(t, []any{"public", "test"}, args)
+					return &pgmocks.Rows{
+						CloseFn: func() {},
+						NextFn:  func(i uint) bool { return i <= uint(len(indexRows)) },
+						ScanFn: func(i uint, dest ...any) error {
+							require.Len(t, dest, 3)
+							indexName, ok := dest[0].(*string)
+							require.True(t, ok)
+							primary, ok := dest[1].(*bool)
+							require.True(t, ok)
+							columnName, ok := dest[2].(**string)
+							require.True(t, ok)
+							row := indexRows[i-1]
+							*indexName = row.index
+							*primary = row.primary
+							*columnName = row.column
+							return nil
+						},
+						ErrFn: func() error { return nil },
+					}, nil
+				default:
+					return nil, fmt.Errorf("unexpected query: %s", query)
+				}
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		columnRules map[string]TransformerRules
+		enforce     bool
+
+		wantErr      error
+		wantErrMsg   string
+		wantWarnings []string
+	}{
+		{
+			name: "error - masking on a column of the unique index",
+			columnRules: map[string]TransformerRules{
+				"name": {Name: "masking", Parameters: map[string]any{"type": "id"}},
+			},
+			enforce:    true,
+			wantErr:    ErrUniquenessNotPreserved,
+			wantErrMsg: `unique index "test_name_email_key" (name, email) is covered by a transformer that maps distinct values to the same output ("name" uses "masking")`,
+		},
+		{
+			name: "warning - masking is not enforced without a postgres target",
+			columnRules: map[string]TransformerRules{
+				"name": {Name: "masking", Parameters: map[string]any{"type": "id"}},
+			},
+			wantWarnings: []string{
+				`"public"."test": unique index "test_name_email_key" (name, email) is covered by a transformer that maps distinct values to the same output ("name" uses "masking"), ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, or set allow_uniqueness_loss on the column to override`,
+			},
+		},
+		{
+			name: "error - masking on the primary key column",
+			columnRules: map[string]TransformerRules{
+				"email": {Name: "masking", Parameters: map[string]any{"type": "id"}},
+			},
+			enforce:    true,
+			wantErr:    ErrUniquenessNotPreserved,
+			wantErrMsg: `primary key "test_pkey" (email) is covered by a transformer`,
+		},
+		{
+			name: "ok - masking with allow_uniqueness_loss",
+			columnRules: map[string]TransformerRules{
+				"name": {Name: "masking", Parameters: map[string]any{"type": "id"}, AllowUniquenessLoss: true},
+			},
+			enforce: true,
+		},
+		{
+			name: "ok - encrypted_aes_siv preserves uniqueness",
+			columnRules: map[string]TransformerRules{
+				"name": {Name: "encrypted_aes_siv", Parameters: map[string]any{"key_hex": strings.Repeat("ab", 64)}},
+			},
+			enforce: true,
+		},
+		{
+			name: "warning - random string does not guarantee uniqueness",
+			columnRules: map[string]TransformerRules{
+				"name": {Name: "string"},
+			},
+			enforce: true,
+			wantWarnings: []string{
+				`"public"."test": unique index "test_name_email_key" (name, email) is covered by a transformer that does not guarantee unique output ("name" uses "string"), so duplicate key violations are possible`,
+			},
+		},
+		{
+			name: "ok - noop rule on a column of the unique index",
+			columnRules: map[string]TransformerRules{
+				"name": {Name: "noop"},
+			},
+			enforce: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parser := PostgresTransformerParser{
+				conn:              testQuerier(),
+				builder:           builder.NewTransformerBuilder(),
+				pgtypeMap:         pglib.NewMapper(testQuerier()),
+				enforceUniqueness: tc.enforce,
+			}
+
+			_, err := parser.ParseAndValidate(context.Background(), Rules{
+				ValidationMode: validationModeRelaxed,
+				Transformers: []TableRules{
+					{
+						Schema:         "public",
+						Table:          "test",
+						ValidationMode: validationModeRelaxed,
+						ColumnRules:    tc.columnRules,
+					},
+				},
+			})
+			require.ErrorIs(t, err, tc.wantErr)
+			if tc.wantErrMsg != "" {
+				require.Contains(t, err.Error(), tc.wantErrMsg)
+			}
+			require.Equal(t, tc.wantWarnings, parser.Warnings())
 		})
 	}
 }

--- a/pkg/wal/processor/transformer/wal_transformer.go
+++ b/pkg/wal/processor/transformer/wal_transformer.go
@@ -52,6 +52,8 @@ const (
 var (
 	errValidatorRequiredForStrictMode = errors.New("strict validation mode requires a validator function")
 	errDDLNotSupportedInStrictMode    = errors.New("DDL events are not supported in strict validation mode, update the transformation rules to include the new table/column before applying DDL changes")
+
+	ErrUniquenessNotPreserved = errors.New("transformation rules break a unique index")
 )
 
 // New will return a transformer processor wrapper that will transform incoming

--- a/pkg/wal/processor/transformer/wal_transformer_rules.go
+++ b/pkg/wal/processor/transformer/wal_transformer_rules.go
@@ -15,7 +15,8 @@ type TableRules struct {
 }
 
 type TransformerRules struct {
-	Name              string         `yaml:"name"`
-	Parameters        map[string]any `yaml:"parameters"`
-	DynamicParameters map[string]any `yaml:"dynamic_parameters"`
+	Name                string         `yaml:"name"`
+	Parameters          map[string]any `yaml:"parameters"`
+	DynamicParameters   map[string]any `yaml:"dynamic_parameters"`
+	AllowUniquenessLoss bool           `yaml:"allow_uniqueness_loss"`
 }

--- a/pkg/wal/processor/transformer/wal_transformer_uniqueness.go
+++ b/pkg/wal/processor/transformer/wal_transformer_uniqueness.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformer
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/xataio/pgstream/pkg/transformers"
+)
+
+type uniqueIndex struct {
+	name    string
+	primary bool
+	columns []string
+	// an expression element, e.g. lower(email), resolves to no column
+	hasExpressions bool
+}
+
+func (i uniqueIndex) describe() string {
+	kind := "unique index"
+	if i.primary {
+		kind = "primary key"
+	}
+	columns := i.columns
+	if i.hasExpressions {
+		columns = append(append([]string{}, columns...), "<expression>")
+	}
+	return fmt.Sprintf("%s %q (%s)", kind, i.name, strings.Join(columns, ", "))
+}
+
+// errors will collide, warnings might
+type uniquenessFindings struct {
+	errors   []string
+	warnings []string
+}
+
+func validateUniqueness(schema, table string, indexes []uniqueIndex, columnTransformers ColumnTransformers, allowUniquenessLoss map[string]bool) uniquenessFindings {
+	findings := uniquenessFindings{}
+	for _, index := range indexes {
+		var lossy, notGuaranteed []string
+		for _, col := range index.columns {
+			if allowUniquenessLoss[col] {
+				continue
+			}
+			t, found := columnTransformers[col]
+			// untransformed columns cannot collide
+			if !found || t == nil {
+				continue
+			}
+			switch transformers.UniquenessOf(t) {
+			case transformers.UniquenessLossy:
+				lossy = append(lossy, fmt.Sprintf("%q uses %q", col, t.Type()))
+			case transformers.UniquenessNotGuaranteed:
+				notGuaranteed = append(notGuaranteed, fmt.Sprintf("%q uses %q", col, t.Type()))
+			}
+		}
+
+		// the expression could reference any transformed column, so the check
+		// cannot clear this index either way; say so rather than stay silent
+		if index.hasExpressions && len(columnTransformers) > 0 {
+			findings.warnings = append(findings.warnings, fmt.Sprintf(
+				"%s: %s contains expression columns that pgstream cannot analyse, so it is not checked for uniqueness; verify it by hand",
+				schemaTableKey(schema, table), index.describe()))
+		}
+
+		switch {
+		case len(lossy) > 0:
+			findings.errors = append(findings.errors, fmt.Sprintf(
+				"%s: %s is covered by a transformer that maps distinct values to the same output (%s), which will cause duplicate key violations. "+
+					"Use a transformer that preserves uniqueness, such as encrypted_aes_siv, or set allow_uniqueness_loss on the column to override",
+				schemaTableKey(schema, table), index.describe(), strings.Join(lossy, ", ")))
+		case len(notGuaranteed) > 0:
+			findings.warnings = append(findings.warnings, fmt.Sprintf(
+				"%s: %s is covered by a transformer that does not guarantee unique output (%s), so duplicate key violations are possible",
+				schemaTableKey(schema, table), index.describe(), strings.Join(notGuaranteed, ", ")))
+		}
+	}
+
+	sort.Strings(findings.errors)
+	sort.Strings(findings.warnings)
+	return findings
+}

--- a/pkg/wal/processor/transformer/wal_transformer_uniqueness_integration_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_uniqueness_integration_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformer
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/testcontainers"
+	"github.com/xataio/pgstream/pkg/transformers/builder"
+)
+
+// the unique index lookup is a raw catalog query, so the mocked unit tests
+// cannot tell whether it actually selects the right indexes and columns
+func TestPostgresTransformerParser_getUniqueIndexes_Integration(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx := context.Background()
+
+	var pgURL string
+	cleanup, err := testcontainers.SetupPostgresContainer(ctx, &pgURL, testcontainers.Postgres17)
+	require.NoError(t, err)
+	defer cleanup()
+
+	adminConn, err := pglib.NewConn(ctx, pgURL)
+	require.NoError(t, err)
+	defer adminConn.Close(ctx)
+
+	_, err = adminConn.Exec(ctx, `
+		CREATE TABLE public.patients (
+			id bigint PRIMARY KEY,
+			pms_patient_id text,
+			pms_type text,
+			email text,
+			display_name text,
+			nickname text
+		);
+		CREATE UNIQUE INDEX patients_pms_idx ON public.patients (pms_patient_id, pms_type);
+		CREATE UNIQUE INDEX patients_lower_email ON public.patients (lower(email));
+		CREATE UNIQUE INDEX patients_id_incl ON public.patients (id) INCLUDE (display_name);
+		CREATE INDEX patients_nickname_idx ON public.patients (nickname);
+	`)
+	require.NoError(t, err)
+
+	// an invalid index, as left behind by a failed CREATE INDEX CONCURRENTLY:
+	// pg_dump skips it, so the target never enforces it
+	_, err = adminConn.Exec(ctx, `
+		INSERT INTO public.patients (id, nickname) VALUES (1, 'dup'), (2, 'dup');
+		CREATE UNIQUE INDEX CONCURRENTLY patients_nickname_key ON public.patients (nickname);
+	`)
+	require.Error(t, err, "expected the concurrent unique index build to fail on duplicates")
+
+	parser, err := NewPostgresTransformerParser(ctx, pgURL, builder.NewTransformerBuilder(), nil)
+	require.NoError(t, err)
+	defer parser.Close()
+
+	indexes, err := parser.getUniqueIndexes(ctx, "public", "patients")
+	require.NoError(t, err)
+
+	byName := make(map[string]uniqueIndex, len(indexes))
+	for _, index := range indexes {
+		byName[index.name] = index
+	}
+
+	// composite unique index: both key columns, in index order
+	require.Equal(t, uniqueIndex{
+		name:    "patients_pms_idx",
+		columns: []string{"pms_patient_id", "pms_type"},
+	}, byName["patients_pms_idx"])
+
+	// primary key, flagged as such
+	require.Equal(t, uniqueIndex{
+		name:    "patients_pkey",
+		primary: true,
+		columns: []string{"id"},
+	}, byName["patients_pkey"])
+
+	// INCLUDE columns do not enforce uniqueness, so display_name must not appear
+	require.Equal(t, uniqueIndex{
+		name:    "patients_id_incl",
+		columns: []string{"id"},
+	}, byName["patients_id_incl"])
+
+	// an expression index resolves to no column, but must still be reported so
+	// the caller can warn rather than silently pass the table
+	require.Equal(t, uniqueIndex{
+		name:           "patients_lower_email",
+		hasExpressions: true,
+	}, byName["patients_lower_email"])
+
+	// non-unique and invalid indexes are not constraints to preserve
+	require.NotContains(t, byName, "patients_nickname_idx")
+	require.NotContains(t, byName, "patients_nickname_key")
+	require.Len(t, indexes, 4)
+}

--- a/pkg/wal/processor/transformer/wal_transformer_uniqueness_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_uniqueness_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/pkg/transformers"
+	transformermocks "github.com/xataio/pgstream/pkg/transformers/mocks"
+)
+
+func newUniquenessMock(i transformers.Uniqueness) *transformermocks.Transformer {
+	return &transformermocks.Transformer{
+		TransformFn:  func(transformers.Value) (any, error) { return nil, nil },
+		UniquenessFn: func() transformers.Uniqueness { return i },
+	}
+}
+
+func TestValidateUniqueness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		indexes             []uniqueIndex
+		columnTransformers  ColumnTransformers
+		allowUniquenessLoss map[string]bool
+
+		wantErrors   []string
+		wantWarnings []string
+	}{
+		{
+			name:               "ok - no unique indexes",
+			indexes:            nil,
+			columnTransformers: ColumnTransformers{"id": newUniquenessMock(transformers.UniquenessLossy)},
+		},
+		{
+			name:               "ok - unique index on untransformed column",
+			indexes:            []uniqueIndex{{name: "users_email_key", columns: []string{"email"}}},
+			columnTransformers: ColumnTransformers{"name": newUniquenessMock(transformers.UniquenessLossy)},
+		},
+		{
+			name:               "ok - uniqueness preserving transformer on unique index",
+			indexes:            []uniqueIndex{{name: "users_email_key", columns: []string{"email"}}},
+			columnTransformers: ColumnTransformers{"email": newUniquenessMock(transformers.UniquenessPreserved)},
+		},
+		{
+			name:               "ok - noop transformer on unique index",
+			indexes:            []uniqueIndex{{name: "users_email_key", columns: []string{"email"}}},
+			columnTransformers: ColumnTransformers{"email": nil},
+		},
+		{
+			name:               "error - lossy transformer on unique index",
+			indexes:            []uniqueIndex{{name: "users_email_key", columns: []string{"email"}}},
+			columnTransformers: ColumnTransformers{"email": newUniquenessMock(transformers.UniquenessLossy)},
+			wantErrors: []string{
+				`"public"."users": unique index "users_email_key" (email) is covered by a transformer that maps distinct values to the same output ("email" uses "mock"), ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`or set allow_uniqueness_loss on the column to override`,
+			},
+		},
+		{
+			name:               "error - lossy transformer on one column of a composite unique index",
+			indexes:            []uniqueIndex{{name: "patients_pms_idx", columns: []string{"pms_patient_id", "pms_type"}}},
+			columnTransformers: ColumnTransformers{"pms_patient_id": newUniquenessMock(transformers.UniquenessLossy)},
+			wantErrors: []string{
+				`"public"."users": unique index "patients_pms_idx" (pms_patient_id, pms_type) is covered by a transformer that maps distinct values to the same output ` +
+					`("pms_patient_id" uses "mock"), which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`or set allow_uniqueness_loss on the column to override`,
+			},
+		},
+		{
+			name:               "error - primary key described as such",
+			indexes:            []uniqueIndex{{name: "users_pkey", primary: true, columns: []string{"id"}}},
+			columnTransformers: ColumnTransformers{"id": newUniquenessMock(transformers.UniquenessLossy)},
+			wantErrors: []string{
+				`"public"."users": primary key "users_pkey" (id) is covered by a transformer that maps distinct values to the same output ("id" uses "mock"), ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`or set allow_uniqueness_loss on the column to override`,
+			},
+		},
+		{
+			name:               "warning - not guaranteed transformer on unique index",
+			indexes:            []uniqueIndex{{name: "users_email_key", columns: []string{"email"}}},
+			columnTransformers: ColumnTransformers{"email": newUniquenessMock(transformers.UniquenessNotGuaranteed)},
+			wantWarnings: []string{
+				`"public"."users": unique index "users_email_key" (email) is covered by a transformer that does not guarantee unique output ("email" uses "mock"), ` +
+					`so duplicate key violations are possible`,
+			},
+		},
+		{
+			name:    "error - lossy takes precedence over not guaranteed on the same index",
+			indexes: []uniqueIndex{{name: "users_idx", columns: []string{"email", "name"}}},
+			columnTransformers: ColumnTransformers{
+				"email": newUniquenessMock(transformers.UniquenessNotGuaranteed),
+				"name":  newUniquenessMock(transformers.UniquenessLossy),
+			},
+			wantErrors: []string{
+				`"public"."users": unique index "users_idx" (email, name) is covered by a transformer that maps distinct values to the same output ("name" uses "mock"), ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`or set allow_uniqueness_loss on the column to override`,
+			},
+		},
+		{
+			name:                "ok - lossy transformer with allow_uniqueness_loss",
+			indexes:             []uniqueIndex{{name: "users_email_key", columns: []string{"email"}}},
+			columnTransformers:  ColumnTransformers{"email": newUniquenessMock(transformers.UniquenessLossy)},
+			allowUniquenessLoss: map[string]bool{"email": true},
+		},
+		{
+			name: "findings sorted for stable output",
+			indexes: []uniqueIndex{
+				{name: "users_z_key", columns: []string{"z"}},
+				{name: "users_a_key", columns: []string{"a"}},
+			},
+			columnTransformers: ColumnTransformers{
+				"z": newUniquenessMock(transformers.UniquenessLossy),
+				"a": newUniquenessMock(transformers.UniquenessLossy),
+			},
+			wantErrors: []string{
+				`"public"."users": unique index "users_a_key" (a) is covered by a transformer that maps distinct values to the same output ("a" uses "mock"), ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`or set allow_uniqueness_loss on the column to override`,
+				`"public"."users": unique index "users_z_key" (z) is covered by a transformer that maps distinct values to the same output ("z" uses "mock"), ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`or set allow_uniqueness_loss on the column to override`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			findings := validateUniqueness("public", "users", tc.indexes, tc.columnTransformers, tc.allowUniquenessLoss)
+			require.Equal(t, tc.wantErrors, findings.errors)
+			require.Equal(t, tc.wantWarnings, findings.warnings)
+		})
+	}
+}
+
+func TestValidateUniqueness_transformerTypesAreClassified(t *testing.T) {
+	t.Parallel()
+
+	maskingTransformer, err := transformers.NewMaskingTransformer(transformers.ParameterValues{"type": "id"})
+	require.NoError(t, err)
+	require.Equal(t, transformers.UniquenessLossy, maskingTransformer.Uniqueness())
+
+	findings := validateUniqueness("public", "patients",
+		[]uniqueIndex{{name: "patients_pms_idx", columns: []string{"pms_patient_id"}}},
+		ColumnTransformers{"pms_patient_id": maskingTransformer},
+		nil)
+
+	require.Len(t, findings.errors, 1)
+	require.Contains(t, findings.errors[0], `"pms_patient_id" uses "masking"`)
+	require.Empty(t, findings.warnings)
+}

--- a/tools/transformer-definition/build-transformers-definition.go
+++ b/tools/transformer-definition/build-transformers-definition.go
@@ -21,6 +21,7 @@ type Result struct {
 type Transformer struct {
 	Name           string      `json:"name"`
 	SupportedTypes []string    `json:"supported_types"`
+	Uniqueness     string      `json:"uniqueness"`
 	Parameters     []Parameter `json:"parameters"`
 }
 
@@ -66,6 +67,7 @@ func extractTransformers(transformersMap map[transformers.TransformerType]struct
 		transformersList = append(transformersList, Transformer{
 			Name:           trName,
 			SupportedTypes: extractSupportedTypes(transformer.Definition.SupportedTypes),
+			Uniqueness:     transformer.Definition.Uniqueness.String(),
 			Parameters:     extractParameters(transformer.Definition.Parameters),
 		})
 	}

--- a/transformers-definition.json
+++ b/transformers-definition.json
@@ -7,6 +7,7 @@
         "string",
         "citext"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "replacement_domain",
@@ -37,6 +38,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "preserved",
       "parameters": [
         {
           "name": "key_hex",
@@ -60,6 +62,7 @@
         "boolean",
         "byte_array"
       ],
+      "uniqueness": "lossy",
       "parameters": [
         {
           "name": "generator",
@@ -80,6 +83,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "lossy",
       "parameters": [
         {
           "name": "choices",
@@ -108,6 +112,7 @@
         "byte_array",
         "date"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "generator",
@@ -142,6 +147,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "lossy",
       "parameters": [
         {
           "name": "generator",
@@ -175,6 +181,7 @@
         "float64",
         "byte_array"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "generator",
@@ -225,6 +232,7 @@
         "float32",
         "float64"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "generator",
@@ -270,6 +278,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "symbols",
@@ -320,6 +329,7 @@
         "float32",
         "float64"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "generator",
@@ -355,6 +365,7 @@
         "byte_array",
         "string"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "generator",
@@ -409,6 +420,7 @@
         "uuid",
         "uint8_array_of_16"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "generator",
@@ -430,6 +442,7 @@
         "byte_array",
         "hstore"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "operations",
@@ -445,6 +458,7 @@
       "supported_types": [
         "json"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "operations",
@@ -460,6 +474,7 @@
       "supported_types": [
         "all"
       ],
+      "uniqueness": "lossy",
       "parameters": [
         {
           "name": "literal",
@@ -476,6 +491,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "lossy",
       "parameters": [
         {
           "name": "type",
@@ -533,6 +549,7 @@
         "string",
         "citext"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "seed",
@@ -601,6 +618,7 @@
       "supported_types": [
         "string"
       ],
+      "uniqueness": "lossy",
       "parameters": [
         {
           "name": "seed",
@@ -630,6 +648,7 @@
       "supported_types": [
         "string"
       ],
+      "uniqueness": "lossy",
       "parameters": [
         {
           "name": "seed",
@@ -659,6 +678,7 @@
       "supported_types": [
         "string"
       ],
+      "uniqueness": "lossy",
       "parameters": [
         {
           "name": "seed",
@@ -688,6 +708,7 @@
       "supported_types": [
         "string"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "seed",
@@ -724,6 +745,7 @@
       "supported_types": [
         "all"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "anon_function",
@@ -873,6 +895,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "prefix",
@@ -914,6 +937,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": []
     },
     {
@@ -922,6 +946,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "template",


### PR DESCRIPTION
#### Description

Anonymization is lossy by design, which conflicts with unique constraints: `masking` with `type: id` keeps a 6-character prefix, so every value sharing that prefix collapses to the same output. Applied to a column covered by a unique index, this surfaces as `duplicate key value violates unique constraint` part-way through a data load, hours after the run started.

This adds a `Uniqueness` classification to every transformer and validates transformation rules against the source's unique indexes, primary keys and unique constraints, so the problem is caught at rule-parsing time instead of mid-import.

#### Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Added `transformers.Uniqueness` with three levels:`lossy`, `not_guaranteed`, `preserved` (only `encrypted_aes_siv`)
- Added a per-column `allow_uniqueness_loss` escape hatch.
- `masking` now rejects a `custom` mask covering zero characters
- Warnings surface through `pgstream validate rules`, `pgstream status` (incl. `--json`) and the run-time log.
- Published `uniqueness` per transformer in `transformers-definition.json`

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
