### PR TITLE
Add a uniqueness classification to transformers

### DIFF
--- a/pkg/transformers/email_transformer.go
+++ b/pkg/transformers/email_transformer.go
@@ -176,6 +176,10 @@ func (et *EmailTransformer) IsDynamic() bool {
 	return false
 }
 
+func (et *EmailTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (et *EmailTransformer) Close() error {
 	return nil
 }
@@ -184,5 +188,6 @@ func EmailTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: emailCompatibleTypes,
 		Parameters:     emailParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/encrypted_aes_siv_transformer.go
+++ b/pkg/transformers/encrypted_aes_siv_transformer.go
@@ -149,6 +149,10 @@ func (est *EncryptedAESSIVTransformer) IsDynamic() bool {
 	return false
 }
 
+func (est *EncryptedAESSIVTransformer) Uniqueness() Uniqueness {
+	return UniquenessPreserved
+}
+
 func (est *EncryptedAESSIVTransformer) Close() error {
 	return nil
 }
@@ -157,5 +161,6 @@ func EncryptedAESSIVTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: encryptedAESSIVCompatibleTypes,
 		Parameters:     encryptedAESSIVParams,
+		Uniqueness:     UniquenessPreserved,
 	}
 }

--- a/pkg/transformers/hstore_transformer.go
+++ b/pkg/transformers/hstore_transformer.go
@@ -139,6 +139,10 @@ func (t *HstoreTransformer) IsDynamic() bool {
 	return true
 }
 
+func (t *HstoreTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (t *HstoreTransformer) Close() error {
 	return nil
 }
@@ -147,6 +151,7 @@ func HstoreTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: hstoreCompatibleTypes,
 		Parameters:     hstoreParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }
 

--- a/pkg/transformers/instrumentation/instrumented_transformer.go
+++ b/pkg/transformers/instrumentation/instrumented_transformer.go
@@ -72,6 +72,12 @@ func (i *Transformer) IsDynamic() bool {
 	return i.inner.IsDynamic()
 }
 
+// forwarded so wrapping a transformer for instrumentation does not downgrade
+// its uniqueness classification to unknown
+func (i *Transformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessOf(i.inner)
+}
+
 func (i *Transformer) Close() error {
 	return i.inner.Close()
 }

--- a/pkg/transformers/json_transformer.go
+++ b/pkg/transformers/json_transformer.go
@@ -123,6 +123,10 @@ func (jt *JSONTransformer) IsDynamic() bool {
 	return true
 }
 
+func (jt *JSONTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (jt *JSONTransformer) Close() error {
 	return nil
 }
@@ -131,6 +135,7 @@ func JSONTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: jsonCompatibleTypes,
 		Parameters:     jsonParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }
 

--- a/pkg/transformers/literal_string_transformer.go
+++ b/pkg/transformers/literal_string_transformer.go
@@ -58,6 +58,10 @@ func (lst *LiteralStringTransformer) IsDynamic() bool {
 	return false
 }
 
+func (lst *LiteralStringTransformer) Uniqueness() Uniqueness {
+	return UniquenessLossy
+}
+
 func (lst *LiteralStringTransformer) Close() error {
 	return nil
 }
@@ -66,5 +70,6 @@ func LiteralStringTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: literalStringCompatibleTypes,
 		Parameters:     literalStringParams,
+		Uniqueness:     UniquenessLossy,
 	}
 }

--- a/pkg/transformers/mocks/mock_transformer.go
+++ b/pkg/transformers/mocks/mock_transformer.go
@@ -12,6 +12,7 @@ type Transformer struct {
 	TransformFn       func(transformers.Value) (any, error)
 	IsDynamicFn       func() bool
 	CompatibleTypesFn func() []transformers.SupportedDataType
+	UniquenessFn      func() transformers.Uniqueness
 }
 
 func (m *Transformer) Transform(_ context.Context, val transformers.Value) (any, error) {
@@ -31,6 +32,13 @@ func (m *Transformer) IsDynamic() bool {
 		return m.IsDynamicFn()
 	}
 	return false
+}
+
+func (m *Transformer) Uniqueness() transformers.Uniqueness {
+	if m.UniquenessFn != nil {
+		return m.UniquenessFn()
+	}
+	return transformers.UniquenessPreserved
 }
 
 func (m *Transformer) Close() error {

--- a/pkg/transformers/pg_anonymizer_transformer.go
+++ b/pkg/transformers/pg_anonymizer_transformer.go
@@ -392,6 +392,10 @@ func (t *PGAnonymizerTransformer) IsDynamic() bool {
 	return false
 }
 
+func (t *PGAnonymizerTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (t *PGAnonymizerTransformer) Close() error {
 	return t.conn.Close(context.Background())
 }
@@ -576,6 +580,7 @@ func PGAnonymizerTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: pgAnonymizerCompatibleTypes,
 		Parameters:     pgAnonymizerParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }
 

--- a/pkg/transformers/phone_number_transformer.go
+++ b/pkg/transformers/phone_number_transformer.go
@@ -175,6 +175,10 @@ func (t *PhoneNumberTransformer) Type() TransformerType {
 	return PhoneNumber
 }
 
+func (t *PhoneNumberTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (t *PhoneNumberTransformer) IsDynamic() bool {
 	return len(t.dynamicParams) > 0
 }
@@ -187,5 +191,6 @@ func PhoneNumberTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: phoneNumberCompatibleTypes,
 		Parameters:     phoneNumberParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/string_transformer.go
+++ b/pkg/transformers/string_transformer.go
@@ -62,6 +62,10 @@ func (st *StringTransformer) IsDynamic() bool {
 	return false
 }
 
+func (st *StringTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (st *StringTransformer) Close() error {
 	return nil
 }
@@ -70,5 +74,6 @@ func StringTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: stringCompatibleTypes,
 		Parameters:     stringParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/template_transformer.go
+++ b/pkg/transformers/template_transformer.go
@@ -68,6 +68,10 @@ func (t *TemplateTransformer) IsDynamic() bool {
 	return true
 }
 
+func (t *TemplateTransformer) Uniqueness() Uniqueness {
+	return UniquenessNotGuaranteed
+}
+
 func (t *TemplateTransformer) Close() error {
 	return nil
 }
@@ -76,5 +80,6 @@ func TemplateTransformerDefinition() *Definition {
 	return &Definition{
 		SupportedTypes: templateCompatibleTypes,
 		Parameters:     templateParams,
+		Uniqueness:     UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -16,6 +16,27 @@ type Transformer interface {
 	Close() error
 }
 
+// optional so that Transformer implementations outside this module keep
+// compiling; UniquenessOf treats a non-implementer as unknown
+type UniquenessReporter interface {
+	Uniqueness() Uniqueness
+}
+
+// UniquenessOf reports what t guarantees about the uniqueness of its output.
+// A transformer that does not classify itself is assumed to be capable of
+// producing duplicates, but not known to, so that both ways of leaving it
+// unclassified answer the same thing.
+func UniquenessOf(t Transformer) Uniqueness {
+	reporter, ok := t.(UniquenessReporter)
+	if !ok {
+		return UniquenessNotGuaranteed
+	}
+	if u := reporter.Uniqueness(); u != UniquenessUnspecified {
+		return u
+	}
+	return UniquenessNotGuaranteed
+}
+
 type Value struct {
 	TransformValue any
 	TransformType  string
@@ -95,6 +116,7 @@ const (
 type Definition struct {
 	SupportedTypes []SupportedDataType
 	Parameters     []Parameter
+	Uniqueness     Uniqueness
 }
 
 type Parameter struct {

--- a/pkg/transformers/uniqueness.go
+++ b/pkg/transformers/uniqueness.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformers
+
+// validated against unique indexes
+type Uniqueness int
+
+const (
+	// zero value, so a transformer that never classified itself is
+	// distinguishable from one deliberately classified lossy
+	UniquenessUnspecified Uniqueness = iota
+	UniquenessLossy
+	UniquenessNotGuaranteed
+	UniquenessPreserved
+)
+
+func (u Uniqueness) String() string {
+	switch u {
+	case UniquenessLossy:
+		return "lossy"
+	case UniquenessNotGuaranteed:
+		return "not_guaranteed"
+	case UniquenessPreserved:
+		return "preserved"
+	default:
+		return "unspecified"
+	}
+}

--- a/pkg/transformers/uniqueness_test.go
+++ b/pkg/transformers/uniqueness_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUniqueness_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		uniqueness Uniqueness
+		want       string
+	}{
+		{uniqueness: UniquenessUnspecified, want: "unspecified"},
+		{uniqueness: UniquenessLossy, want: "lossy"},
+		{uniqueness: UniquenessNotGuaranteed, want: "not_guaranteed"},
+		{uniqueness: UniquenessPreserved, want: "preserved"},
+		{uniqueness: Uniqueness(99), want: "unspecified"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, tt.uniqueness.String())
+		})
+	}
+}
+
+// the zero value must not read as a deliberate classification, or a
+// transformer whose author forgot to classify it ships as lossy
+func TestUniqueness_ZeroValueIsUnspecified(t *testing.T) {
+	t.Parallel()
+
+	var zero Uniqueness
+	require.Equal(t, UniquenessUnspecified, zero)
+	require.Equal(t, "unspecified", zero.String())
+	require.Equal(t, UniquenessUnspecified, Definition{}.Uniqueness)
+}
+
+type unclassifiedTransformer struct{}
+
+func (unclassifiedTransformer) Transform(context.Context, Value) (any, error) { return nil, nil }
+func (unclassifiedTransformer) IsDynamic() bool                               { return false }
+func (unclassifiedTransformer) CompatibleTypes() []SupportedDataType          { return nil }
+func (unclassifiedTransformer) Type() TransformerType                         { return "unclassified" }
+func (unclassifiedTransformer) Close() error                                  { return nil }
+
+type classifiedTransformer struct {
+	unclassifiedTransformer
+	uniqueness Uniqueness
+}
+
+func (c classifiedTransformer) Uniqueness() Uniqueness { return c.uniqueness }
+
+func TestUniquenessOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		transformer Transformer
+		want        Uniqueness
+	}{
+		{
+			name:        "transformer that does not implement the interface",
+			transformer: unclassifiedTransformer{},
+			want:        UniquenessNotGuaranteed,
+		},
+		{
+			name:        "transformer that reports the zero value",
+			transformer: classifiedTransformer{uniqueness: UniquenessUnspecified},
+			want:        UniquenessNotGuaranteed,
+		},
+		{
+			name:        "lossy",
+			transformer: classifiedTransformer{uniqueness: UniquenessLossy},
+			want:        UniquenessLossy,
+		},
+		{
+			name:        "preserved",
+			transformer: classifiedTransformer{uniqueness: UniquenessPreserved},
+			want:        UniquenessPreserved,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, UniquenessOf(tt.transformer))
+		})
+	}
+}

--- a/tools/transformer-definition/build-transformers-definition.go
+++ b/tools/transformer-definition/build-transformers-definition.go
@@ -21,6 +21,7 @@ type Result struct {
 type Transformer struct {
 	Name           string      `json:"name"`
 	SupportedTypes []string    `json:"supported_types"`
+	Uniqueness     string      `json:"uniqueness"`
 	Parameters     []Parameter `json:"parameters"`
 }
 
@@ -66,6 +67,7 @@ func extractTransformers(transformersMap map[transformers.TransformerType]struct
 		transformersList = append(transformersList, Transformer{
 			Name:           trName,
 			SupportedTypes: extractSupportedTypes(transformer.Definition.SupportedTypes),
+			Uniqueness:     transformer.Definition.Uniqueness.String(),
 			Parameters:     extractParameters(transformer.Definition.Parameters),
 		})
 	}

--- a/transformers-definition.json
+++ b/transformers-definition.json
@@ -7,6 +7,7 @@
         "string",
         "citext"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "replacement_domain",
@@ -37,6 +38,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "preserved",
       "parameters": [
         {
           "name": "key_hex",
@@ -60,6 +62,7 @@
         "boolean",
         "byte_array"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "generator",
@@ -80,6 +83,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "choices",
@@ -108,6 +112,7 @@
         "byte_array",
         "date"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "generator",
@@ -142,6 +147,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "generator",
@@ -175,6 +181,7 @@
         "float64",
         "byte_array"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "generator",
@@ -225,6 +232,7 @@
         "float32",
         "float64"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "generator",
@@ -270,6 +278,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "symbols",
@@ -320,6 +329,7 @@
         "float32",
         "float64"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "generator",
@@ -355,6 +365,7 @@
         "byte_array",
         "string"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "generator",
@@ -409,6 +420,7 @@
         "uuid",
         "uint8_array_of_16"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "generator",
@@ -430,6 +442,7 @@
         "byte_array",
         "hstore"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "operations",
@@ -445,6 +458,7 @@
       "supported_types": [
         "json"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "operations",
@@ -460,6 +474,7 @@
       "supported_types": [
         "all"
       ],
+      "uniqueness": "lossy",
       "parameters": [
         {
           "name": "literal",
@@ -476,6 +491,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "type",
@@ -533,6 +549,7 @@
         "string",
         "citext"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "seed",
@@ -601,6 +618,7 @@
       "supported_types": [
         "string"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "seed",
@@ -630,6 +648,7 @@
       "supported_types": [
         "string"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "seed",
@@ -659,6 +678,7 @@
       "supported_types": [
         "string"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "seed",
@@ -688,6 +708,7 @@
       "supported_types": [
         "string"
       ],
+      "uniqueness": "unspecified",
       "parameters": [
         {
           "name": "seed",
@@ -724,6 +745,7 @@
       "supported_types": [
         "all"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "anon_function",
@@ -873,6 +895,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "prefix",
@@ -914,6 +937,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": []
     },
     {
@@ -922,6 +946,7 @@
         "string",
         "byte_array"
       ],
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "template",


### PR DESCRIPTION
#### Description

Anonymization is lossy by design, which conflicts with unique constraints: `masking` with `type: id` keeps a 6-character prefix, so every value sharing that prefix collapses to the same output. Applied to a column covered by a unique index, this surfaces as `duplicate key value violates unique constraint` part-way through a data load, hours after the run started.

This is the first of a stack that teaches pgstream to catch that at rule-parsing time. It adds the classification only — nothing consumes it yet.

#### Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Added `transformers.Uniqueness` with three levels: `lossy` (collides by construction), `not_guaranteed` (random, hashed or user-driven output) and `preserved` (distinct inputs always give distinct outputs).
- Exposed it as an **optional** `UniquenessReporter` interface read through `transformers.UniquenessOf()`. `Transformer` itself is unchanged, so implementations outside this module keep compiling and default to `not_guaranteed`.
- Classified the root-package transformers and published `uniqueness` per transformer in `transformers-definition.json`.
- The instrumentation wrapper forwards through `UniquenessOf`, so wrapping a transformer does not downgrade its classification.

`masking`, the greenmask set and the neosync set are classified in the following PRs in this stack; until then they report `not_guaranteed`.

#### Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All existing tests pass

No behaviour changes yet — the classification has no consumer until the check lands later in the stack. A test asserting every transformer's `Uniqueness()` agrees with its `Definition` arrives once they are all classified.

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary

#### Additional Notes

Stack, each targeting the previous branch:

1. **this PR** — the classification
2. `pr2-masking-noop-rejection` — reject a `masking` config that masks nothing
3. `pr3-greenmask-uniqueness` / 4. `pr4-neosync-uniqueness` — classify the remaining transformers
5. `pr5-unique-index-check` — read `pg_index` and validate rules against it
6. `pr6-surface-uniqueness-findings` — report through `status` / `validate rules`
7. `pr7-uniqueness-docs` — docs

Split from one 38-file/468-line change so each part stays inside the approval gate's ceilings.
