### PR TITLE
Classify the neosync transformers for uniqueness

### DIFF
--- a/pkg/transformers/builder/transformer_uniqueness_test.go
+++ b/pkg/transformers/builder/transformer_uniqueness_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/pkg/transformers"
+)
+
+// the definition feeds the docs and transformers-definition.json while the
+// method feeds rule validation; nothing else keeps the two in step
+func TestTransformers_UniquenessMatchesDefinition(t *testing.T) {
+	t.Parallel()
+
+	cases := map[transformers.TransformerType]transformers.ParameterValues{
+		transformers.Masking:                {"type": "default"},
+		transformers.Email:                  {},
+		transformers.Template:               {"template": "{{ .GetValue }}"},
+		transformers.JSON:                   {"operations": []any{map[string]any{"operation": "set", "path": "a", "value": "b"}}},
+		transformers.Hstore:                 {"operations": []any{map[string]any{"operation": "set", "key": "a", "value": "b"}}},
+		transformers.PhoneNumber:            {"prefix": "+1", "min_length": 9, "max_length": 12},
+		transformers.LiteralString:          {"literal": "fixed"},
+		transformers.String:                 {},
+		transformers.EncryptedAESSIV:        {"key_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"},
+		transformers.GreenmaskString:        {"min_length": 2, "max_length": 12},
+		transformers.GreenmaskFirstName:     {},
+		transformers.GreenmaskInteger:       {"min_value": 0, "max_value": 1000},
+		transformers.GreenmaskFloat:         {"min_value": 0.0, "max_value": 1000.0},
+		transformers.GreenmaskUUID:          {},
+		transformers.GreenmaskBoolean:       {},
+		transformers.GreenmaskChoice:        {"choices": []any{"alpha", "beta"}},
+		transformers.GreenmaskUnixTimestamp: {"min_value": "946684800", "max_value": "1893456000"},
+		transformers.GreenmaskDate:          {"min_value": "2020-01-01", "max_value": "2024-12-31"},
+		transformers.GreenmaskUTCTimestamp:  {"min_timestamp": "2020-01-01T00:00:00Z", "max_timestamp": "2024-12-31T23:59:59Z"},
+		transformers.NeosyncString:          {},
+		transformers.NeosyncFirstName:       {},
+		transformers.NeosyncLastName:        {},
+		transformers.NeosyncFullName:        {},
+		transformers.NeosyncEmail:           {},
+		transformers.PGAnonymizer:           {"anon_function": "anon.fake_email()", "postgres_url": "postgres://user:pass@localhost:5432/db"},
+	}
+
+	for transformerType := range TransformersMap {
+		_, found := cases[transformerType]
+		require.True(t, found, "transformer %q is missing a uniqueness test case", transformerType)
+	}
+
+	builder := NewTransformerBuilder()
+	for transformerType, params := range cases {
+		t.Run(string(transformerType), func(t *testing.T) {
+			t.Parallel()
+
+			transformer, err := builder.New(&transformers.Config{Name: transformerType, Parameters: params})
+			require.NoError(t, err)
+			require.Equal(t, TransformersMap[transformerType].Definition.Uniqueness, transformers.UniquenessOf(transformer))
+		})
+	}
+}

--- a/pkg/transformers/neosync/neosync_email_transformer.go
+++ b/pkg/transformers/neosync/neosync_email_transformer.go
@@ -150,6 +150,10 @@ func (t *EmailTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncEmail
 }
 
+func (t *EmailTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessNotGuaranteed
+}
+
 func (t *EmailTransformer) Close() error {
 	return nil
 }
@@ -158,5 +162,6 @@ func EmailTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: emailCompatibleTypes,
 		Parameters:     emailParams,
+		Uniqueness:     transformers.UniquenessNotGuaranteed,
 	}
 }

--- a/pkg/transformers/neosync/neosync_firstname_transformer.go
+++ b/pkg/transformers/neosync/neosync_firstname_transformer.go
@@ -105,6 +105,10 @@ func (t *FirstNameTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncFirstName
 }
 
+func (t *FirstNameTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessLossy
+}
+
 func (t *FirstNameTransformer) Close() error {
 	return nil
 }
@@ -113,5 +117,6 @@ func FirstNameTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: firstNameCompatibleTypes,
 		Parameters:     firstNameParams,
+		Uniqueness:     transformers.UniquenessLossy,
 	}
 }

--- a/pkg/transformers/neosync/neosync_fullname_transformer.go
+++ b/pkg/transformers/neosync/neosync_fullname_transformer.go
@@ -136,6 +136,10 @@ func (t *FullNameTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncFullName
 }
 
+func (t *FullNameTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessLossy
+}
+
 func (t *FullNameTransformer) Close() error {
 	return nil
 }
@@ -144,6 +148,7 @@ func FullNameTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: fullNameCompatibleTypes,
 		Parameters:     fullNameParams,
+		Uniqueness:     transformers.UniquenessLossy,
 	}
 }
 

--- a/pkg/transformers/neosync/neosync_lastname_transformer.go
+++ b/pkg/transformers/neosync/neosync_lastname_transformer.go
@@ -104,6 +104,10 @@ func (t *LastNameTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncLastName
 }
 
+func (t *LastNameTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessLossy
+}
+
 func (t *LastNameTransformer) Close() error {
 	return nil
 }
@@ -112,5 +116,6 @@ func LastNameTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: lastNameCompatibleTypes,
 		Parameters:     lastNameParams,
+		Uniqueness:     transformers.UniquenessLossy,
 	}
 }

--- a/pkg/transformers/neosync/neosync_string_transformer.go
+++ b/pkg/transformers/neosync/neosync_string_transformer.go
@@ -88,6 +88,10 @@ func (t *StringTransformer) Type() transformers.TransformerType {
 	return transformers.NeosyncString
 }
 
+func (t *StringTransformer) Uniqueness() transformers.Uniqueness {
+	return transformers.UniquenessNotGuaranteed
+}
+
 func (t *StringTransformer) Close() error {
 	return nil
 }
@@ -96,5 +100,6 @@ func StringTransformerDefinition() *transformers.Definition {
 	return &transformers.Definition{
 		SupportedTypes: stringCompatibleTypes,
 		Parameters:     stringParams,
+		Uniqueness:     transformers.UniquenessNotGuaranteed,
 	}
 }

--- a/transformers-definition.json
+++ b/transformers-definition.json
@@ -549,7 +549,7 @@
         "string",
         "citext"
       ],
-      "uniqueness": "unspecified",
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "seed",
@@ -618,7 +618,7 @@
       "supported_types": [
         "string"
       ],
-      "uniqueness": "unspecified",
+      "uniqueness": "lossy",
       "parameters": [
         {
           "name": "seed",
@@ -648,7 +648,7 @@
       "supported_types": [
         "string"
       ],
-      "uniqueness": "unspecified",
+      "uniqueness": "lossy",
       "parameters": [
         {
           "name": "seed",
@@ -678,7 +678,7 @@
       "supported_types": [
         "string"
       ],
-      "uniqueness": "unspecified",
+      "uniqueness": "lossy",
       "parameters": [
         {
           "name": "seed",
@@ -708,7 +708,7 @@
       "supported_types": [
         "string"
       ],
-      "uniqueness": "unspecified",
+      "uniqueness": "not_guaranteed",
       "parameters": [
         {
           "name": "seed",


### PR DESCRIPTION
#### Description

Part 4 of the uniqueness stack, and the last of the classification PRs.

#### Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🧪 Test coverage improvement

#### Changes Made

- `neosync_firstname`, `neosync_lastname` and `neosync_fullname` are `lossy` — fixed dictionaries.
- `neosync_string` and `neosync_email` are `not_guaranteed` — output depends on the configured length and domain set.
- With every transformer now classified, added a test asserting each one's `Uniqueness()` agrees with the `Uniqueness` published in its `Definition`. Those are two independent declarations of the same fact — one feeds rule validation, the other feeds the docs and `transformers-definition.json` — and nothing else keeps them in step.

#### Testing

- [x] Unit tests added/updated
- [x] All existing tests pass

The parity test was mutation-checked: flipping one transformer's `Definition` makes it fail.

#### Additional Notes

Targets `pr3-greenmask-uniqueness`.