### PR TITLE
Validate transformation rules against unique indexes

### DIFF
--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -328,9 +328,10 @@ type TableTransformersConfig struct {
 }
 
 type ColumnTransformersConfig struct {
-	Name              string         `mapstructure:"name" yaml:"name"`
-	Parameters        map[string]any `mapstructure:"parameters" yaml:"parameters"`
-	DynamicParameters map[string]any `mapstructure:"dynamic_parameters" yaml:"dynamic_parameters"`
+	Name                string         `mapstructure:"name" yaml:"name"`
+	Parameters          map[string]any `mapstructure:"parameters" yaml:"parameters"`
+	DynamicParameters   map[string]any `mapstructure:"dynamic_parameters" yaml:"dynamic_parameters"`
+	AllowUniquenessLoss bool           `mapstructure:"allow_uniqueness_loss" yaml:"allow_uniqueness_loss"`
 }
 
 // postgres source modes
@@ -885,9 +886,10 @@ func (c TransformationsConfig) parseTransformationConfig() (*transformer.Config,
 		columnRules := make(map[string]transformer.TransformerRules, len(t.ColumnRules))
 		for column, cr := range t.ColumnRules {
 			columnRules[column] = transformer.TransformerRules{
-				Name:              cr.Name,
-				Parameters:        cr.Parameters,
-				DynamicParameters: cr.DynamicParameters,
+				Name:                cr.Name,
+				Parameters:          cr.Parameters,
+				DynamicParameters:   cr.DynamicParameters,
+				AllowUniquenessLoss: cr.AllowUniquenessLoss,
 			}
 		}
 		rules = append(rules, transformer.TableRules{

--- a/cmd/validate_cmd.go
+++ b/cmd/validate_cmd.go
@@ -68,10 +68,13 @@ var validateRulesCmd = &cobra.Command{
 				return err
 			}
 
-			if len(rulesStatus.Errors) == 0 {
-				sp.Success("transformation rules are valid")
-			} else {
+			switch {
+			case len(rulesStatus.Errors) > 0:
 				sp.Warning("pgstream validation check identified issues: ", strings.Join(rulesStatus.Errors, ", "))
+			case len(rulesStatus.Warnings) > 0:
+				sp.Warning("transformation rules are valid, with warnings: ", strings.Join(rulesStatus.Warnings, ", "))
+			default:
+				sp.Success("transformation rules are valid")
 			}
 
 			err = print(cmd, rulesStatus)

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -208,12 +208,24 @@ func addProcessorModifiers(ctx context.Context, config *Config, logger loglib.Lo
 		pgURL := config.SourcePostgresURL()
 		if pgURL != "" {
 			var parser transformer.ParseFn
-			pgParser, err := transformer.NewPostgresTransformerParser(ctx, pgURL, transformerBuilder, config.RequiredTables())
+			parserOpts := []transformer.ParserOption{}
+			// only a postgres target enforces the source's unique indexes
+			if config.Processor.Postgres != nil {
+				parserOpts = append(parserOpts, transformer.WithUniquenessEnforcement())
+			}
+			pgParser, err := transformer.NewPostgresTransformerParser(ctx, pgURL, transformerBuilder, config.RequiredTables(), parserOpts...)
 			if err != nil {
 				return nil, nil, fmt.Errorf("creating transformer validator: %w", err)
 			}
 			closerAgg.addCloserFn(pgParser.Close)
-			parser = pgParser.ParseAndValidate
+			// warnings only reach the caller here
+			parser = func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
+				transformerMap, err := pgParser.ParseAndValidate(ctx, rules)
+				for _, warning := range pgParser.Warnings() {
+					logger.Warn(nil, warning)
+				}
+				return transformerMap, err
+			}
 
 			// wrap the parser to add inferred rules if enabled. This requires a
 			// live connection to the source db and will query the security

--- a/pkg/stream/stream_status.go
+++ b/pkg/stream/stream_status.go
@@ -20,8 +20,9 @@ type ConfigStatus struct {
 }
 
 type TransformationRulesStatus struct {
-	Valid  bool
-	Errors []string
+	Valid    bool
+	Errors   []string
+	Warnings []string
 }
 
 type SourceStatus struct {
@@ -212,6 +213,9 @@ func (trs *TransformationRulesStatus) PrettyPrint() string {
 	fmt.Fprintf(&prettyPrint, " - Valid: %t\n", trs.Valid)
 	if len(trs.Errors) > 0 {
 		fmt.Fprintf(&prettyPrint, " - Errors: %s\n", trs.Errors)
+	}
+	if len(trs.Warnings) > 0 {
+		fmt.Fprintf(&prettyPrint, " - Warnings: %s\n", trs.Warnings)
 	}
 
 	// trim the last newline character

--- a/pkg/stream/stream_status_checker.go
+++ b/pkg/stream/stream_status_checker.go
@@ -26,10 +26,13 @@ type StatusChecker struct {
 	connBuilder          pglib.QuerierBuilder
 	configParser         func(pgURL string) (*pgx.ConnConfig, error)
 	migratorBuilder      func(*InitConfig) (migrator, error)
-	ruleValidatorBuilder func(context.Context, string, []string) (ruleValidator, error)
+	ruleValidatorBuilder func(context.Context, string, []string, ...transformer.ParserOption) (ruleValidator, error)
 }
 
-type ruleValidator func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error)
+type ruleValidator interface {
+	ParseAndValidate(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error)
+	Warnings() []string
+}
 
 type migrator interface {
 	Status() ([]migratorlib.MigrationStatus, error)
@@ -58,12 +61,8 @@ func NewStatusChecker() *StatusChecker {
 			}
 			return migratorlib.NewPGMigrator(cfg.PostgresURL, migrationAssets)
 		},
-		ruleValidatorBuilder: func(ctx context.Context, pgURL string, requiredTables []string) (ruleValidator, error) {
-			validator, err := transformer.NewPostgresTransformerParser(ctx, pgURL, builder.NewTransformerBuilder(), requiredTables)
-			if err != nil {
-				return nil, err
-			}
-			return validator.ParseAndValidate, nil
+		ruleValidatorBuilder: func(ctx context.Context, pgURL string, requiredTables []string, opts ...transformer.ParserOption) (ruleValidator, error) {
+			return transformer.NewPostgresTransformerParser(ctx, pgURL, builder.NewTransformerBuilder(), requiredTables, opts...)
 		},
 	}
 }
@@ -203,7 +202,12 @@ func (s *StatusChecker) TransformationRulesStatus(ctx context.Context, config *C
 	status := &TransformationRulesStatus{
 		Valid: true,
 	}
-	validator, err := s.ruleValidatorBuilder(ctx, pgURL, config.RequiredTables())
+	parserOpts := []transformer.ParserOption{}
+	// mirror the run path: only a postgres target enforces unique indexes
+	if config.Processor.Postgres != nil {
+		parserOpts = append(parserOpts, transformer.WithUniquenessEnforcement())
+	}
+	validator, err := s.ruleValidatorBuilder(ctx, pgURL, config.RequiredTables(), parserOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +215,7 @@ func (s *StatusChecker) TransformationRulesStatus(ctx context.Context, config *C
 		Transformers:   config.Processor.Transformer.TransformerRules,
 		ValidationMode: config.Processor.Transformer.ValidationMode,
 	}
-	if _, err := validator(ctx, rules); err != nil {
+	if _, err := validator.ParseAndValidate(ctx, rules); err != nil {
 		status.Valid = false
 		switch {
 		case errors.Is(err, syscall.ECONNREFUSED):
@@ -220,6 +224,7 @@ func (s *StatusChecker) TransformationRulesStatus(ctx context.Context, config *C
 			status.Errors = append(status.Errors, err.Error())
 		}
 	}
+	status.Warnings = validator.Warnings()
 
 	return status, nil
 }

--- a/pkg/stream/stream_status_checker_test.go
+++ b/pkg/stream/stream_status_checker_test.go
@@ -21,6 +21,19 @@ import (
 	replicationpg "github.com/xataio/pgstream/pkg/wal/replication/postgres"
 )
 
+type mockRuleValidator struct {
+	parseAndValidateFn func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error)
+	warnings           []string
+}
+
+func (m *mockRuleValidator) ParseAndValidate(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
+	return m.parseAndValidateFn(ctx, rules)
+}
+
+func (m *mockRuleValidator) Warnings() []string {
+	return m.warnings
+}
+
 func TestStatusChecker_Status(t *testing.T) {
 	t.Parallel()
 
@@ -111,9 +124,11 @@ func TestStatusChecker_Status(t *testing.T) {
 		}, nil
 	}
 
-	validRuleValidatorBuilder := func(context.Context, string, []string) (ruleValidator, error) {
-		return func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
-			return nil, nil
+	validRuleValidatorBuilder := func(context.Context, string, []string, ...transformer.ParserOption) (ruleValidator, error) {
+		return &mockRuleValidator{
+			parseAndValidateFn: func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
+				return nil, nil
+			},
 		}, nil
 	}
 
@@ -122,7 +137,7 @@ func TestStatusChecker_Status(t *testing.T) {
 		connBuilder          pglib.QuerierBuilder
 		migratorBuilder      func(*InitConfig) (migrator, error)
 		config               *Config
-		ruleValidatorBuilder func(context.Context, string, []string) (ruleValidator, error)
+		ruleValidatorBuilder func(context.Context, string, []string, ...transformer.ParserOption) (ruleValidator, error)
 
 		wantStatus *Status
 		wantErr    error
@@ -193,7 +208,7 @@ func TestStatusChecker_Status(t *testing.T) {
 			connBuilder:     validConnBuilder,
 			migratorBuilder: validMigratorBuilder,
 			config:          validConfig,
-			ruleValidatorBuilder: func(ctx context.Context, s string, r []string) (ruleValidator, error) {
+			ruleValidatorBuilder: func(ctx context.Context, s string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
 				return nil, errTest
 			},
 
@@ -636,16 +651,18 @@ func TestStatusChecker_transformationRulesStatus(t *testing.T) {
 
 	tests := []struct {
 		name                 string
-		ruleValidatorBuilder func(context.Context, string, []string) (ruleValidator, error)
+		ruleValidatorBuilder func(context.Context, string, []string, ...transformer.ParserOption) (ruleValidator, error)
 		config               *Config
 		wantStatus           *TransformationRulesStatus
 		wantErr              error
 	}{
 		{
 			name: "ok - valid transformation rules",
-			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string) (ruleValidator, error) {
-				return func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
-					return nil, nil
+			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
+				return &mockRuleValidator{
+					parseAndValidateFn: func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
+						return nil, nil
+					},
 				}, nil
 			},
 			config: &Config{
@@ -666,8 +683,36 @@ func TestStatusChecker_transformationRulesStatus(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "ok - valid transformation rules with warnings",
+			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
+				return &mockRuleValidator{
+					parseAndValidateFn: func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
+						return nil, nil
+					},
+					warnings: []string{"a transformer might break a unique index"},
+				}, nil
+			},
+			config: &Config{
+				Processor: ProcessorConfig{
+					Transformer: &transformer.Config{
+						TransformerRules: []transformer.TableRules{},
+					},
+				},
+				Listener: ListenerConfig{
+					Postgres: &PostgresListenerConfig{
+						URL: "postgres://user:password@localhost:5432/db",
+					},
+				},
+			},
+			wantStatus: &TransformationRulesStatus{
+				Valid:    true,
+				Warnings: []string{"a transformer might break a unique index"},
+			},
+			wantErr: nil,
+		},
+		{
 			name: "ok - no transformer configured",
-			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string) (ruleValidator, error) {
+			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
 				return nil, errors.New("unexpected call to ruleValidatorBuilder")
 			},
 			config: &Config{
@@ -685,7 +730,7 @@ func TestStatusChecker_transformationRulesStatus(t *testing.T) {
 		},
 		{
 			name: "error - source postgres URL not provided",
-			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string) (ruleValidator, error) {
+			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
 				return nil, errors.New("unexpected call to ruleValidatorBuilder")
 			},
 			config: &Config{
@@ -708,9 +753,11 @@ func TestStatusChecker_transformationRulesStatus(t *testing.T) {
 		},
 		{
 			name: "error - rule validation failure",
-			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string) (ruleValidator, error) {
-				return func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
-					return nil, errTest
+			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
+				return &mockRuleValidator{
+					parseAndValidateFn: func(ctx context.Context, rules transformer.Rules) (*transformer.TransformerMap, error) {
+						return nil, errTest
+					},
 				}, nil
 			},
 			config: &Config{
@@ -733,7 +780,7 @@ func TestStatusChecker_transformationRulesStatus(t *testing.T) {
 		},
 		{
 			name: "error - ruleValidatorBuilder failure",
-			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string) (ruleValidator, error) {
+			ruleValidatorBuilder: func(ctx context.Context, pgURL string, r []string, _ ...transformer.ParserOption) (ruleValidator, error) {
 				return nil, errTest
 			},
 			config: &Config{

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
@@ -21,36 +21,80 @@ type PostgresTransformerParser struct {
 	builder        transformerBuilder
 	pgtypeMap      *pglib.Mapper
 	requiredTables []string
+
+	warnings []string
+	// only a postgres target actually enforces a unique index; elsewhere the
+	// same findings are reported but must not block the pipeline
+	enforceUniqueness bool
+}
+
+type ParserOption func(*PostgresTransformerParser)
+
+// WithUniquenessEnforcement makes transformation rules that break a unique
+// index a hard error instead of a warning. Enable it when the target enforces
+// unique indexes, which today means a postgres target.
+func WithUniquenessEnforcement() ParserOption {
+	return func(v *PostgresTransformerParser) {
+		v.enforceUniqueness = true
+	}
 }
 
 const (
 	fieldDescriptionsQuery = "SELECT * FROM %s LIMIT 0"
 	schemaTablesQuery      = "SELECT tablename FROM pg_tables WHERE schemaname=$1"
-	publicSchema           = "public"
-	wildcard               = "*"
+	// expression columns have attnum 0 and no pg_attribute row, so the LEFT
+	// JOIN yields a NULL attname rather than dropping the index entirely.
+	// indkey also carries INCLUDE columns, which do not enforce uniqueness;
+	// only the first indnkeyatts entries do
+	uniqueIndexQuery = `SELECT idx.relname, i.indisprimary, a.attname
+	FROM pg_index i
+	JOIN pg_class c ON c.oid = i.indrelid
+	JOIN pg_class idx ON idx.oid = i.indexrelid
+	JOIN pg_namespace n ON n.oid = c.relnamespace
+	JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord) ON true
+	LEFT JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum
+	WHERE i.indisunique AND i.indisvalid AND i.indislive
+	AND k.ord <= i.indnkeyatts
+	AND n.nspname = $1 AND c.relname = $2
+	ORDER BY idx.relname, k.ord`
+	publicSchema = "public"
+	wildcard     = "*"
 )
 
 var errInvalidTableName = errors.New("invalid table name, expected format: schema.table or table")
 
-func NewPostgresTransformerParser(ctx context.Context, pgURL string, builder transformerBuilder, requiredTables []string) (*PostgresTransformerParser, error) {
+func NewPostgresTransformerParser(ctx context.Context, pgURL string, builder transformerBuilder, requiredTables []string, opts ...ParserOption) (*PostgresTransformerParser, error) {
 	pool, err := pglib.NewConnPool(ctx, pgURL)
 	if err != nil {
 		return nil, err
 	}
-	return &PostgresTransformerParser{
+	parser := &PostgresTransformerParser{
 		conn:           pool,
 		connURL:        pgURL,
 		builder:        builder,
 		pgtypeMap:      pglib.NewMapper(pool),
 		requiredTables: requiredTables,
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(parser)
+	}
+	return parser, nil
+}
+
+func (v *PostgresTransformerParser) Warnings() []string {
+	return v.warnings
 }
 
 func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules Rules) (*TransformerMap, error) {
+	// reset before any early return, so a failed call cannot leave the
+	// previous call's warnings visible through Warnings
+	v.warnings = nil
+
 	// validate that all required tables are present in the rules
 	if err := v.validateAllRequiredTables(ctx, rules); err != nil {
 		return nil, err
 	}
+	var uniquenessErrs []string
 	transformerMap := NewTransformerMap()
 	for _, table := range rules.Transformers {
 		fieldDescriptions, err := v.getFieldDescriptions(context.Background(), table.Schema, table.Table)
@@ -109,8 +153,71 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 			// add the transformer to the map
 			transformerMap.AddActiveTransformer(table.Schema, table.Table, colName, transformer)
 		}
+
+		// catch collisions before the load
+		uniqueIndexes, err := v.getUniqueIndexes(ctx, table.Schema, table.Table)
+		if err != nil {
+			return nil, err
+		}
+		columnTransformers, _ := transformerMap.GetActiveColumnTransformers(table.Schema, table.Table)
+		findings := validateUniqueness(table.Schema, table.Table, uniqueIndexes, columnTransformers, allowUniquenessLossColumns(table))
+		if v.enforceUniqueness {
+			uniquenessErrs = append(uniquenessErrs, findings.errors...)
+		} else {
+			v.warnings = append(v.warnings, findings.errors...)
+		}
+		v.warnings = append(v.warnings, findings.warnings...)
 	}
+
+	if len(uniquenessErrs) > 0 {
+		return nil, fmt.Errorf("%w: %s", ErrUniquenessNotPreserved, strings.Join(uniquenessErrs, "; "))
+	}
+
 	return transformerMap, nil
+}
+
+func allowUniquenessLossColumns(table TableRules) map[string]bool {
+	allowed := make(map[string]bool, len(table.ColumnRules))
+	for colName, colRules := range table.ColumnRules {
+		if colRules.AllowUniquenessLoss {
+			allowed[colName] = true
+		}
+	}
+	return allowed
+}
+
+func (v *PostgresTransformerParser) getUniqueIndexes(ctx context.Context, schema, table string) ([]uniqueIndex, error) {
+	rows, err := v.conn.Query(ctx, uniqueIndexQuery, schema, table)
+	if err != nil {
+		return nil, fmt.Errorf("querying unique indexes for table %q.%q: %w", schema, table, err)
+	}
+	defer rows.Close()
+
+	// rows arrive grouped by index
+	var indexes []uniqueIndex
+	for rows.Next() {
+		var indexName string
+		var columnName *string
+		var primary bool
+		if err := rows.Scan(&indexName, &primary, &columnName); err != nil {
+			return nil, fmt.Errorf("scanning unique index for table %q.%q: %w", schema, table, err)
+		}
+		if len(indexes) == 0 || indexes[len(indexes)-1].name != indexName {
+			indexes = append(indexes, uniqueIndex{name: indexName, primary: primary})
+		}
+		current := &indexes[len(indexes)-1]
+		if columnName == nil {
+			current.hasExpressions = true
+			continue
+		}
+		current.columns = append(current.columns, *columnName)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading unique indexes for table %q.%q: %w", schema, table, err)
+	}
+
+	return indexes, nil
 }
 
 func (v *PostgresTransformerParser) validateAllRequiredTables(ctx context.Context, rules Rules) error {

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -59,6 +60,12 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 							return nil
 						},
 						ErrFn: func() error { return nil },
+					}, nil
+				case uniqueIndexQuery:
+					return &pgmocks.Rows{
+						CloseFn: func() {},
+						NextFn:  func(i uint) bool { return false },
+						ErrFn:   func() error { return nil },
 					}, nil
 				case "SELECT nspname FROM pg_catalog.pg_namespace WHERE nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast', 'pgstream') AND nspname NOT LIKE 'pg_temp_%' AND nspname NOT LIKE 'pg_toast_temp_%'":
 					return &pgmocks.Rows{
@@ -432,6 +439,167 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 			for _, col := range tc.wantNoopTransformersFor {
 				require.Contains(t, noopColumnTransformers, col)
 			}
+		})
+	}
+}
+
+func TestPostgresTransformerParser_uniqueIndexValidation(t *testing.T) {
+	t.Parallel()
+
+	// two indexes over the same table, so the row-grouping loop has to start a
+	// new index when the name changes and keep column order within each
+	type indexRow struct {
+		index   string
+		primary bool
+		column  *string
+	}
+	name, email := "name", "email"
+	indexRows := []indexRow{
+		{index: "test_name_email_key", column: &name},
+		{index: "test_name_email_key", column: &email},
+		{index: "test_pkey", primary: true, column: &email},
+	}
+
+	testQuerier := func() *pgmocks.Querier {
+		return &pgmocks.Querier{
+			QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
+				switch query {
+				case "SELECT * FROM \"public\".\"test\" LIMIT 0":
+					return &pgmocks.Rows{
+						FieldDescriptionsFn: func() []pgconn.FieldDescription {
+							return []pgconn.FieldDescription{
+								{Name: "name", DataTypeOID: pgtype.TextOID},
+								{Name: "email", DataTypeOID: pgtype.TextOID},
+							}
+						},
+						CloseFn: func() {},
+						ErrFn:   func() error { return nil },
+					}, nil
+				case uniqueIndexQuery:
+					require.Equal(t, []any{"public", "test"}, args)
+					return &pgmocks.Rows{
+						CloseFn: func() {},
+						NextFn:  func(i uint) bool { return i <= uint(len(indexRows)) },
+						ScanFn: func(i uint, dest ...any) error {
+							require.Len(t, dest, 3)
+							indexName, ok := dest[0].(*string)
+							require.True(t, ok)
+							primary, ok := dest[1].(*bool)
+							require.True(t, ok)
+							columnName, ok := dest[2].(**string)
+							require.True(t, ok)
+							row := indexRows[i-1]
+							*indexName = row.index
+							*primary = row.primary
+							*columnName = row.column
+							return nil
+						},
+						ErrFn: func() error { return nil },
+					}, nil
+				default:
+					return nil, fmt.Errorf("unexpected query: %s", query)
+				}
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		columnRules map[string]TransformerRules
+		enforce     bool
+
+		wantErr      error
+		wantErrMsg   string
+		wantWarnings []string
+	}{
+		{
+			name: "error - masking on a column of the unique index",
+			columnRules: map[string]TransformerRules{
+				"name": {Name: "masking", Parameters: map[string]any{"type": "id"}},
+			},
+			enforce:    true,
+			wantErr:    ErrUniquenessNotPreserved,
+			wantErrMsg: `unique index "test_name_email_key" (name, email) is covered by a transformer that maps distinct values to the same output ("name" uses "masking")`,
+		},
+		{
+			name: "warning - masking is not enforced without a postgres target",
+			columnRules: map[string]TransformerRules{
+				"name": {Name: "masking", Parameters: map[string]any{"type": "id"}},
+			},
+			wantWarnings: []string{
+				`"public"."test": unique index "test_name_email_key" (name, email) is covered by a transformer that maps distinct values to the same output ("name" uses "masking"), ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, or set allow_uniqueness_loss on the column to override`,
+			},
+		},
+		{
+			name: "error - masking on the primary key column",
+			columnRules: map[string]TransformerRules{
+				"email": {Name: "masking", Parameters: map[string]any{"type": "id"}},
+			},
+			enforce:    true,
+			wantErr:    ErrUniquenessNotPreserved,
+			wantErrMsg: `primary key "test_pkey" (email) is covered by a transformer`,
+		},
+		{
+			name: "ok - masking with allow_uniqueness_loss",
+			columnRules: map[string]TransformerRules{
+				"name": {Name: "masking", Parameters: map[string]any{"type": "id"}, AllowUniquenessLoss: true},
+			},
+			enforce: true,
+		},
+		{
+			name: "ok - encrypted_aes_siv preserves uniqueness",
+			columnRules: map[string]TransformerRules{
+				"name": {Name: "encrypted_aes_siv", Parameters: map[string]any{"key_hex": strings.Repeat("ab", 64)}},
+			},
+			enforce: true,
+		},
+		{
+			name: "warning - random string does not guarantee uniqueness",
+			columnRules: map[string]TransformerRules{
+				"name": {Name: "string"},
+			},
+			enforce: true,
+			wantWarnings: []string{
+				`"public"."test": unique index "test_name_email_key" (name, email) is covered by a transformer that does not guarantee unique output ("name" uses "string"), so duplicate key violations are possible`,
+			},
+		},
+		{
+			name: "ok - noop rule on a column of the unique index",
+			columnRules: map[string]TransformerRules{
+				"name": {Name: "noop"},
+			},
+			enforce: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parser := PostgresTransformerParser{
+				conn:              testQuerier(),
+				builder:           builder.NewTransformerBuilder(),
+				pgtypeMap:         pglib.NewMapper(testQuerier()),
+				enforceUniqueness: tc.enforce,
+			}
+
+			_, err := parser.ParseAndValidate(context.Background(), Rules{
+				ValidationMode: validationModeRelaxed,
+				Transformers: []TableRules{
+					{
+						Schema:         "public",
+						Table:          "test",
+						ValidationMode: validationModeRelaxed,
+						ColumnRules:    tc.columnRules,
+					},
+				},
+			})
+			require.ErrorIs(t, err, tc.wantErr)
+			if tc.wantErrMsg != "" {
+				require.Contains(t, err.Error(), tc.wantErrMsg)
+			}
+			require.Equal(t, tc.wantWarnings, parser.Warnings())
 		})
 	}
 }

--- a/pkg/wal/processor/transformer/wal_transformer.go
+++ b/pkg/wal/processor/transformer/wal_transformer.go
@@ -52,6 +52,8 @@ const (
 var (
 	errValidatorRequiredForStrictMode = errors.New("strict validation mode requires a validator function")
 	errDDLNotSupportedInStrictMode    = errors.New("DDL events are not supported in strict validation mode, update the transformation rules to include the new table/column before applying DDL changes")
+
+	ErrUniquenessNotPreserved = errors.New("transformation rules break a unique index")
 )
 
 // New will return a transformer processor wrapper that will transform incoming

--- a/pkg/wal/processor/transformer/wal_transformer_rules.go
+++ b/pkg/wal/processor/transformer/wal_transformer_rules.go
@@ -15,7 +15,8 @@ type TableRules struct {
 }
 
 type TransformerRules struct {
-	Name              string         `yaml:"name"`
-	Parameters        map[string]any `yaml:"parameters"`
-	DynamicParameters map[string]any `yaml:"dynamic_parameters"`
+	Name                string         `yaml:"name"`
+	Parameters          map[string]any `yaml:"parameters"`
+	DynamicParameters   map[string]any `yaml:"dynamic_parameters"`
+	AllowUniquenessLoss bool           `yaml:"allow_uniqueness_loss"`
 }

--- a/pkg/wal/processor/transformer/wal_transformer_uniqueness.go
+++ b/pkg/wal/processor/transformer/wal_transformer_uniqueness.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformer
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/xataio/pgstream/pkg/transformers"
+)
+
+type uniqueIndex struct {
+	name    string
+	primary bool
+	columns []string
+	// an expression element, e.g. lower(email), resolves to no column
+	hasExpressions bool
+}
+
+func (i uniqueIndex) describe() string {
+	kind := "unique index"
+	if i.primary {
+		kind = "primary key"
+	}
+	columns := i.columns
+	if i.hasExpressions {
+		columns = append(append([]string{}, columns...), "<expression>")
+	}
+	return fmt.Sprintf("%s %q (%s)", kind, i.name, strings.Join(columns, ", "))
+}
+
+// errors will collide, warnings might
+type uniquenessFindings struct {
+	errors   []string
+	warnings []string
+}
+
+func validateUniqueness(schema, table string, indexes []uniqueIndex, columnTransformers ColumnTransformers, allowUniquenessLoss map[string]bool) uniquenessFindings {
+	findings := uniquenessFindings{}
+	for _, index := range indexes {
+		var lossy, notGuaranteed []string
+		for _, col := range index.columns {
+			if allowUniquenessLoss[col] {
+				continue
+			}
+			t, found := columnTransformers[col]
+			// untransformed columns cannot collide
+			if !found || t == nil {
+				continue
+			}
+			switch transformers.UniquenessOf(t) {
+			case transformers.UniquenessLossy:
+				lossy = append(lossy, fmt.Sprintf("%q uses %q", col, t.Type()))
+			case transformers.UniquenessNotGuaranteed:
+				notGuaranteed = append(notGuaranteed, fmt.Sprintf("%q uses %q", col, t.Type()))
+			}
+		}
+
+		// the expression could reference any transformed column, so the check
+		// cannot clear this index either way; say so rather than stay silent
+		if index.hasExpressions && len(columnTransformers) > 0 {
+			findings.warnings = append(findings.warnings, fmt.Sprintf(
+				"%s: %s contains expression columns that pgstream cannot analyse, so it is not checked for uniqueness; verify it by hand",
+				schemaTableKey(schema, table), index.describe()))
+		}
+
+		switch {
+		case len(lossy) > 0:
+			findings.errors = append(findings.errors, fmt.Sprintf(
+				"%s: %s is covered by a transformer that maps distinct values to the same output (%s), which will cause duplicate key violations. "+
+					"Use a transformer that preserves uniqueness, such as encrypted_aes_siv, or set allow_uniqueness_loss on the column to override",
+				schemaTableKey(schema, table), index.describe(), strings.Join(lossy, ", ")))
+		case len(notGuaranteed) > 0:
+			findings.warnings = append(findings.warnings, fmt.Sprintf(
+				"%s: %s is covered by a transformer that does not guarantee unique output (%s), so duplicate key violations are possible",
+				schemaTableKey(schema, table), index.describe(), strings.Join(notGuaranteed, ", ")))
+		}
+	}
+
+	sort.Strings(findings.errors)
+	sort.Strings(findings.warnings)
+	return findings
+}

--- a/pkg/wal/processor/transformer/wal_transformer_uniqueness_integration_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_uniqueness_integration_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformer
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/testcontainers"
+	"github.com/xataio/pgstream/pkg/transformers/builder"
+)
+
+// the unique index lookup is a raw catalog query, so the mocked unit tests
+// cannot tell whether it actually selects the right indexes and columns
+func TestPostgresTransformerParser_getUniqueIndexes_Integration(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx := context.Background()
+
+	var pgURL string
+	cleanup, err := testcontainers.SetupPostgresContainer(ctx, &pgURL, testcontainers.Postgres17)
+	require.NoError(t, err)
+	defer cleanup()
+
+	adminConn, err := pglib.NewConn(ctx, pgURL)
+	require.NoError(t, err)
+	defer adminConn.Close(ctx)
+
+	_, err = adminConn.Exec(ctx, `
+		CREATE TABLE public.patients (
+			id bigint PRIMARY KEY,
+			pms_patient_id text,
+			pms_type text,
+			email text,
+			display_name text,
+			nickname text
+		);
+		CREATE UNIQUE INDEX patients_pms_idx ON public.patients (pms_patient_id, pms_type);
+		CREATE UNIQUE INDEX patients_lower_email ON public.patients (lower(email));
+		CREATE UNIQUE INDEX patients_id_incl ON public.patients (id) INCLUDE (display_name);
+		CREATE INDEX patients_nickname_idx ON public.patients (nickname);
+	`)
+	require.NoError(t, err)
+
+	// an invalid index, as left behind by a failed CREATE INDEX CONCURRENTLY:
+	// pg_dump skips it, so the target never enforces it
+	_, err = adminConn.Exec(ctx, `
+		INSERT INTO public.patients (id, nickname) VALUES (1, 'dup'), (2, 'dup');
+		CREATE UNIQUE INDEX CONCURRENTLY patients_nickname_key ON public.patients (nickname);
+	`)
+	require.Error(t, err, "expected the concurrent unique index build to fail on duplicates")
+
+	parser, err := NewPostgresTransformerParser(ctx, pgURL, builder.NewTransformerBuilder(), nil)
+	require.NoError(t, err)
+	defer parser.Close()
+
+	indexes, err := parser.getUniqueIndexes(ctx, "public", "patients")
+	require.NoError(t, err)
+
+	byName := make(map[string]uniqueIndex, len(indexes))
+	for _, index := range indexes {
+		byName[index.name] = index
+	}
+
+	// composite unique index: both key columns, in index order
+	require.Equal(t, uniqueIndex{
+		name:    "patients_pms_idx",
+		columns: []string{"pms_patient_id", "pms_type"},
+	}, byName["patients_pms_idx"])
+
+	// primary key, flagged as such
+	require.Equal(t, uniqueIndex{
+		name:    "patients_pkey",
+		primary: true,
+		columns: []string{"id"},
+	}, byName["patients_pkey"])
+
+	// INCLUDE columns do not enforce uniqueness, so display_name must not appear
+	require.Equal(t, uniqueIndex{
+		name:    "patients_id_incl",
+		columns: []string{"id"},
+	}, byName["patients_id_incl"])
+
+	// an expression index resolves to no column, but must still be reported so
+	// the caller can warn rather than silently pass the table
+	require.Equal(t, uniqueIndex{
+		name:           "patients_lower_email",
+		hasExpressions: true,
+	}, byName["patients_lower_email"])
+
+	// non-unique and invalid indexes are not constraints to preserve
+	require.NotContains(t, byName, "patients_nickname_idx")
+	require.NotContains(t, byName, "patients_nickname_key")
+	require.Len(t, indexes, 4)
+}

--- a/pkg/wal/processor/transformer/wal_transformer_uniqueness_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_uniqueness_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/pkg/transformers"
+	transformermocks "github.com/xataio/pgstream/pkg/transformers/mocks"
+)
+
+func newUniquenessMock(i transformers.Uniqueness) *transformermocks.Transformer {
+	return &transformermocks.Transformer{
+		TransformFn:  func(transformers.Value) (any, error) { return nil, nil },
+		UniquenessFn: func() transformers.Uniqueness { return i },
+	}
+}
+
+func TestValidateUniqueness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		indexes             []uniqueIndex
+		columnTransformers  ColumnTransformers
+		allowUniquenessLoss map[string]bool
+
+		wantErrors   []string
+		wantWarnings []string
+	}{
+		{
+			name:               "ok - no unique indexes",
+			indexes:            nil,
+			columnTransformers: ColumnTransformers{"id": newUniquenessMock(transformers.UniquenessLossy)},
+		},
+		{
+			name:               "ok - unique index on untransformed column",
+			indexes:            []uniqueIndex{{name: "users_email_key", columns: []string{"email"}}},
+			columnTransformers: ColumnTransformers{"name": newUniquenessMock(transformers.UniquenessLossy)},
+		},
+		{
+			name:               "ok - uniqueness preserving transformer on unique index",
+			indexes:            []uniqueIndex{{name: "users_email_key", columns: []string{"email"}}},
+			columnTransformers: ColumnTransformers{"email": newUniquenessMock(transformers.UniquenessPreserved)},
+		},
+		{
+			name:               "ok - noop transformer on unique index",
+			indexes:            []uniqueIndex{{name: "users_email_key", columns: []string{"email"}}},
+			columnTransformers: ColumnTransformers{"email": nil},
+		},
+		{
+			name:               "error - lossy transformer on unique index",
+			indexes:            []uniqueIndex{{name: "users_email_key", columns: []string{"email"}}},
+			columnTransformers: ColumnTransformers{"email": newUniquenessMock(transformers.UniquenessLossy)},
+			wantErrors: []string{
+				`"public"."users": unique index "users_email_key" (email) is covered by a transformer that maps distinct values to the same output ("email" uses "mock"), ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`or set allow_uniqueness_loss on the column to override`,
+			},
+		},
+		{
+			name:               "error - lossy transformer on one column of a composite unique index",
+			indexes:            []uniqueIndex{{name: "patients_pms_idx", columns: []string{"pms_patient_id", "pms_type"}}},
+			columnTransformers: ColumnTransformers{"pms_patient_id": newUniquenessMock(transformers.UniquenessLossy)},
+			wantErrors: []string{
+				`"public"."users": unique index "patients_pms_idx" (pms_patient_id, pms_type) is covered by a transformer that maps distinct values to the same output ` +
+					`("pms_patient_id" uses "mock"), which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`or set allow_uniqueness_loss on the column to override`,
+			},
+		},
+		{
+			name:               "error - primary key described as such",
+			indexes:            []uniqueIndex{{name: "users_pkey", primary: true, columns: []string{"id"}}},
+			columnTransformers: ColumnTransformers{"id": newUniquenessMock(transformers.UniquenessLossy)},
+			wantErrors: []string{
+				`"public"."users": primary key "users_pkey" (id) is covered by a transformer that maps distinct values to the same output ("id" uses "mock"), ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`or set allow_uniqueness_loss on the column to override`,
+			},
+		},
+		{
+			name:               "warning - not guaranteed transformer on unique index",
+			indexes:            []uniqueIndex{{name: "users_email_key", columns: []string{"email"}}},
+			columnTransformers: ColumnTransformers{"email": newUniquenessMock(transformers.UniquenessNotGuaranteed)},
+			wantWarnings: []string{
+				`"public"."users": unique index "users_email_key" (email) is covered by a transformer that does not guarantee unique output ("email" uses "mock"), ` +
+					`so duplicate key violations are possible`,
+			},
+		},
+		{
+			name:    "error - lossy takes precedence over not guaranteed on the same index",
+			indexes: []uniqueIndex{{name: "users_idx", columns: []string{"email", "name"}}},
+			columnTransformers: ColumnTransformers{
+				"email": newUniquenessMock(transformers.UniquenessNotGuaranteed),
+				"name":  newUniquenessMock(transformers.UniquenessLossy),
+			},
+			wantErrors: []string{
+				`"public"."users": unique index "users_idx" (email, name) is covered by a transformer that maps distinct values to the same output ("name" uses "mock"), ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`or set allow_uniqueness_loss on the column to override`,
+			},
+		},
+		{
+			name:                "ok - lossy transformer with allow_uniqueness_loss",
+			indexes:             []uniqueIndex{{name: "users_email_key", columns: []string{"email"}}},
+			columnTransformers:  ColumnTransformers{"email": newUniquenessMock(transformers.UniquenessLossy)},
+			allowUniquenessLoss: map[string]bool{"email": true},
+		},
+		{
+			name: "findings sorted for stable output",
+			indexes: []uniqueIndex{
+				{name: "users_z_key", columns: []string{"z"}},
+				{name: "users_a_key", columns: []string{"a"}},
+			},
+			columnTransformers: ColumnTransformers{
+				"z": newUniquenessMock(transformers.UniquenessLossy),
+				"a": newUniquenessMock(transformers.UniquenessLossy),
+			},
+			wantErrors: []string{
+				`"public"."users": unique index "users_a_key" (a) is covered by a transformer that maps distinct values to the same output ("a" uses "mock"), ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`or set allow_uniqueness_loss on the column to override`,
+				`"public"."users": unique index "users_z_key" (z) is covered by a transformer that maps distinct values to the same output ("z" uses "mock"), ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`or set allow_uniqueness_loss on the column to override`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			findings := validateUniqueness("public", "users", tc.indexes, tc.columnTransformers, tc.allowUniquenessLoss)
+			require.Equal(t, tc.wantErrors, findings.errors)
+			require.Equal(t, tc.wantWarnings, findings.warnings)
+		})
+	}
+}
+
+func TestValidateUniqueness_transformerTypesAreClassified(t *testing.T) {
+	t.Parallel()
+
+	maskingTransformer, err := transformers.NewMaskingTransformer(transformers.ParameterValues{"type": "id"})
+	require.NoError(t, err)
+	require.Equal(t, transformers.UniquenessLossy, maskingTransformer.Uniqueness())
+
+	findings := validateUniqueness("public", "patients",
+		[]uniqueIndex{{name: "patients_pms_idx", columns: []string{"pms_patient_id"}}},
+		ColumnTransformers{"pms_patient_id": maskingTransformer},
+		nil)
+
+	require.Len(t, findings.errors, 1)
+	require.Contains(t, findings.errors[0], `"pms_patient_id" uses "masking"`)
+	require.Empty(t, findings.warnings)
+}


### PR DESCRIPTION
#### Description

The core of the stack. Reads the unique indexes, unique constraints and primary keys of every table in the transformation rules and checks them against the configured transformers, so a rule that will produce duplicate keys fails at parse time rather than part-way through a data load.

#### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Changes Made

- New `pg_index` lookup and `validateUniqueness`. A `lossy` transformer on a covered column errors; `not_guaranteed` warns; columns with no rule or a `noop` rule are never flagged.
- Only the first `indnkeyatts` entries of `indkey` enforce uniqueness, so `INCLUDE` columns are excluded — otherwise a lossy transformer on a non-key column would be rejected for a collision that cannot happen.
- Invalid and non-live indexes are skipped: `pg_dump` does not recreate them, so there is no constraint on the target to violate.
- An index element over an expression (`lower(email)`) has no `pg_attribute` row, so it is surfaced via `LEFT JOIN` and reported as unverifiable instead of silently dropping the whole index.
- Blocking is scoped to targets that actually enforce unique indexes (today, a Postgres target); elsewhere the same finding is a warning.
- `allow_uniqueness_loss` opts a column out.

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

Added a testcontainers test (`PGSTREAM_INTEGRATION_TESTS=true`) covering composite ordering, primary keys, `INCLUDE` columns, expression indexes and invalid indexes — mocks cannot tell whether the SQL itself is right. Mutation-checked: reverting the query makes it fail. Also ran `validate rules` against live PostgreSQL for both target modes.

#### Additional Notes

**Breaking:** a pg→pg pipeline with a lossy transformer on a unique-indexed column now fails at startup instead of failing mid-load. That is the point of the change, but affected configs need either a uniqueness-preserving transformer or `allow_uniqueness_loss` per column, so it wants a release note.

Not covered, by design: target-only indexes, indexes created after startup, expression indexes (warned, not analysed) and equality exclusion constraints.

Targets `pr4-neosync-uniqueness`.