### PR TITLE
Document transformer uniqueness and the unique index check

### DIFF
--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -6,6 +6,82 @@ pgstream supports column value transformations to anonymize or mask sensitive da
 
 pgstream integrates with existing transformer open source libraries, such as [greenmask](https://github.com/GreenmaskIO/greenmask), [neosync](https://github.com/nucleuscloud/neosync) and [go-masker](https://github.com/ggwhite/go-masker), to leverage a large amount of transformation capabilities, as well as having support for custom transformations.
 
+⚠️ Most transformers do **not** preserve uniqueness. Applying one to a column covered by a unique index or primary key produces duplicate key violations. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
+
+## Uniqueness and unique indexes
+
+Anonymization is lossy by design, and that conflicts directly with unique constraints. Masking `609898123456` with `masking` type `id` yields `609898****`: the transformer keeps a 6 character prefix, so **every** source value sharing that prefix becomes the same masked value. On a column covered by a unique index the load then fails with `duplicate key value violates unique constraint`, part way through the data, long after the run started.
+
+Each transformer declares how it behaves with respect to uniqueness:
+
+| Uniqueness       | Meaning                                                                                                                                                              | Validation |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `preserved`      | Distinct inputs always produce distinct outputs. Safe on unique columns.                                                                                             | passes     |
+| `not_guaranteed` | Output is random, hashed, or driven by user supplied logic. Duplicates are possible, at the birthday bound of the output space (which usually depends on parameters). | warns      |
+| `lossy`          | Distinct inputs are mapped to the same output by construction: partial masks, fixed literals, small value sets, name dictionaries.                                    | errors     |
+
+| Transformer                | Uniqueness       |
+| -------------------------- | ---------------- |
+| `encrypted_aes_siv`        | `preserved`      |
+| `email`                    | `not_guaranteed` |
+| `greenmask_date`           | `not_guaranteed` |
+| `greenmask_float`          | `not_guaranteed` |
+| `greenmask_integer`        | `not_guaranteed` |
+| `greenmask_string`         | `not_guaranteed` |
+| `greenmask_unix_timestamp` | `not_guaranteed` |
+| `greenmask_utc_timestamp`  | `not_guaranteed` |
+| `greenmask_uuid`           | `not_guaranteed` |
+| `hstore`                   | `not_guaranteed` |
+| `json`                     | `not_guaranteed` |
+| `neosync_email`            | `not_guaranteed` |
+| `neosync_string`           | `not_guaranteed` |
+| `pg_anonymizer`            | `not_guaranteed` |
+| `phone_number`             | `not_guaranteed` |
+| `string`                   | `not_guaranteed` |
+| `template`                 | `not_guaranteed` |
+| `greenmask_boolean`        | `lossy`          |
+| `greenmask_choice`         | `lossy`          |
+| `greenmask_firstname`      | `lossy`          |
+| `literal_string`           | `lossy`          |
+| `masking`                  | `lossy`          |
+| `neosync_firstname`        | `lossy`          |
+| `neosync_fullname`         | `lossy`          |
+| `neosync_lastname`         | `lossy`          |
+
+When a source Postgres URL is configured, pgstream reads the unique indexes, unique constraints and primary keys of every table in the transformation rules and checks them against the configured transformers. Columns with no rule, or with a `noop` rule, keep their original value and are never flagged. Run the check on its own with:
+
+```sh
+pgstream validate rules -c pg2pg.yaml
+```
+
+With a **Postgres target**, a `lossy` transformer on a covered column fails the rules with `transformation rules break a unique index`, because the target recreates the source's indexes and the load would hit a duplicate key. With any **other target** (Kafka, Elasticsearch/OpenSearch, webhooks) there is no unique index to violate, so the same finding is reported as a warning and does not block the pipeline. A `not_guaranteed` transformer is always a warning.
+
+To keep a `lossy` transformer on a covered column anyway — because the target does not enforce that index, or because the values are known not to collide — set `allow_uniqueness_loss` on that column rule:
+
+```yaml
+column_transformers:
+  pms_patient_id:
+    name: masking
+    parameters:
+      type: id
+    allow_uniqueness_loss: true
+```
+
+### Keeping a column unique
+
+If you need an anonymized column to stay unique, use `encrypted_aes_siv`: it is deterministic, so equality relationships survive across rows, tables and runs, and no two distinct inputs share a token. Its output is a base64 token rather than a value in the original format.
+
+⚠️ `encrypted_aes_siv` is **pseudonymization, not anonymization**. The output is reversible by anyone holding `key_hex`, so it remains personal data, and because tokens are stable they can be correlated across tables and across successive dumps. Treat `key_hex` as a secret: inject it from a secret store rather than committing it in the rules file, use a different key per environment, and set `associated_data` (for example `schema.table.column`) so tokens cannot be correlated between columns.
+
+### What the check does not cover
+
+- **Expression indexes.** A unique index over an expression, such as `lower(email)`, cannot be resolved to a column, so pgstream reports a warning naming the index and leaves it to you to verify.
+- **Target-only indexes.** The check reads the *source* catalog. A unique index that exists only on the target is not seen.
+- **Indexes created after startup.** Rules are validated once when the pipeline starts. A unique index added to the source later is not re-checked.
+- **Exclusion constraints** with equality semantics (`EXCLUDE (email WITH =)`) are not treated as unique indexes.
+
+If a load fails with `duplicate key value violates unique constraint` on a transformed column, run `pgstream validate rules` against the source to see which rules the check flags.
+
 ## Supported transformers
 
 ### PostgreSQL Anonymizer
@@ -142,6 +218,8 @@ transformations:
 
 **Description:** Generates random or deterministic boolean values (`true` or `false`).
 
+**Uniqueness:** `lossy`. The output space has two values. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
+
 | Supported PostgreSQL types |
 | -------------------------- |
 | `boolean`                  |
@@ -178,6 +256,8 @@ transformations:
   <summary>greenmask_choice</summary>
 
 **Description:** Randomly selects a value from a predefined list of choices.
+
+**Uniqueness:** `lossy`. Any table with more rows than choices produces duplicates. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
 
 | Supported PostgreSQL types          |
 | ----------------------------------- |
@@ -257,6 +337,8 @@ transformations:
   <summary>greenmask_firstname</summary>
 
 **Description:** Generates random or deterministic first names, optionally filtered by gender.
+
+**Uniqueness:** `lossy`. Names come from a fixed dictionary and repeat well before a table of any size is exhausted. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
 
 | Supported PostgreSQL types          |
 | ----------------------------------- |
@@ -488,6 +570,8 @@ transformations:
 
 **Description:** Generates anonymized first names while optionally preserving length.
 
+**Uniqueness:** `lossy`. Names come from a fixed dictionary and repeat well before a table of any size is exhausted. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
+
 | Supported PostgreSQL types          |
 | ----------------------------------- |
 | `text`, `varchar`, `char`, `bpchar` |
@@ -518,6 +602,8 @@ transformations:
 
 **Description:** Generates anonymized last names while optionally preserving length.
 
+**Uniqueness:** `lossy`. Names come from a fixed dictionary and repeat well before a table of any size is exhausted. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
+
 | Supported PostgreSQL types          |
 | ----------------------------------- |
 | `text`, `varchar`, `char`, `bpchar` |
@@ -547,6 +633,8 @@ transformations:
   <summary>neosync_fullname</summary>
 
 **Description:** Generates anonymized full names while optionally preserving length.
+
+**Uniqueness:** `lossy`. Names come from fixed dictionaries, so even first/last combinations repeat well before a large table is exhausted. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
 
 | Supported PostgreSQL types          |
 | ----------------------------------- |
@@ -660,6 +748,10 @@ transformations:
   <summary>masking</summary>
 
 **Description:** Masks string values using the provided masking function.
+
+**Uniqueness:** `lossy`. Every type replaces part of the value with `*`, so all values sharing the untouched part collapse to the same output — `type: id` keeps only a 6 character prefix. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
+
+A `custom` mask that would cover zero characters (for example `mask_begin: 3` with `mask_end: 3`, or `unmask_begin: 0`) is rejected at startup: it leaves values completely unmasked, which silently defeats anonymization. Use the `noop` transformer if passing a column through untouched is what you want.
 
 | Supported PostgreSQL types          |
 | ----------------------------------- |
@@ -1001,6 +1093,8 @@ the hstore transformer with above config produces output:
 
 **Description:** Transforms all values into the given constant value.
 
+**Uniqueness:** `lossy`. Every value becomes the same literal. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
+
 | Supported PostgreSQL types             |
 | -------------------------------------- |
 | All types with a string representation |
@@ -1114,6 +1208,8 @@ transformations:
 
 **Description:** Encrypts values with AES-SIV (RFC 5297), a deterministic authenticated encryption scheme. The same input, key and associated data always produce the same token, so equality relationships between column values are preserved across rows, tables and runs — while remaining reversible by holders of the key, unlike hashing. Tokens are authenticated: tampered or forged values fail decryption. The output is the ciphertext encoded as unpadded base64url, safe for URLs and file names.
 
+**Uniqueness:** `preserved`. Encryption is reversible with the key, so two distinct plaintexts cannot share a token. This is the only transformer that never collides on a column covered by a unique index. Note that being reversible makes it pseudonymization rather than anonymization — see [Keeping a column unique](#keeping-a-column-unique).
+
 | Supported PostgreSQL types                   |
 | -------------------------------------------- |
 | `text`, `varchar`, `char`, `bpchar`, `bytea` |
@@ -1176,6 +1272,7 @@ transformations:
       column_transformers: # List of column transformations
         <column_name>: # Name of the column to which the transformation will be applied
           name: <transformer_name> # Name of the transformer to be applied to the column. If no transformer needs to be applied on strict validation mode, it can be left empty or use `noop`
+          allow_uniqueness_loss: false # Whether to allow a transformer that can produce duplicates on a column covered by a unique index. Defaults to false. See "Uniqueness and unique indexes"
           parameters: # Transformer parameters as defined in the supported transformers documentation
             <transformer_parameter>: <transformer_parameter_value>
 ```


### PR DESCRIPTION
#### Description

Docs for the stack.

#### Type of Change

- [x] 📚 Documentation update

#### Changes Made

- New "Uniqueness and unique indexes" section: what the three levels mean, a per-transformer table, and what the check does and does not cover.
- Per-transformer **Uniqueness** notes on the nine most collision-prone entries.
- Documented that `encrypted_aes_siv` is pseudonymization rather than anonymization — reversible with the key, correlatable across tables and runs — with key-handling guidance, since it is what the error message steers people toward.

#### Testing

- [x] All existing tests pass

#### Additional Notes

Docs only. Targets `pr6-surface-uniqueness-findings`.