### PR TITLE
Cap the schema observer's connection pool

### DIFF
--- a/cmd/config/test/test_config.yaml
+++ b/cmd/config/test/test_config.yaml
@@ -66,7 +66,7 @@ source:
 target:
   postgres:
     url: "postgresql://user:password@localhost:5432/mytargetdatabase"
-    max_connections: 60 # maximum number of connections per pool to the target database
+    max_connections: 60 # maximum number of connections in the writer pool to the target database
     batch:
       timeout: 1000 # batch timeout in milliseconds
       size: 100 # number of messages in a batch

--- a/config_template.yaml
+++ b/config_template.yaml
@@ -79,7 +79,7 @@ source:
 target:
   postgres:
     url: "postgresql://user:password@localhost:5432/mytargetdatabase"
-    max_connections: 50 # maximum number of connections per pool to the target database. Defaults to 50; overrides pool_max_conns in the URL when set.
+    max_connections: 50 # maximum number of connections in the writer pool to the target database. Defaults to 50; overrides pool_max_conns in the URL when set. The schema observer keeps its own pool, capped at 16 and never larger than this value, so the process opens at most this many plus 16.
     batch:
       timeout: 1000 # batch timeout in milliseconds. Defaults to 30s
       size: 100 # number of messages in a batch. Defaults to 20000

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,7 @@ source:
 target:
   postgres:
     url: "postgresql://user:password@localhost:5432/mytargetdatabase"
-    max_connections: 50 # maximum number of connections per pool to the target database. Defaults to 50; overrides pool_max_conns in the URL when set.
+    max_connections: 50 # maximum number of connections in the writer pool to the target database. Defaults to 50; overrides pool_max_conns in the URL when set. The schema observer keeps its own pool, capped at 16 and never larger than this value, so the process opens at most this many plus 16.
     batch:
       timeout: 1000 # batch timeout in milliseconds. Defaults to 30s
       size: 100 # number of messages in a batch. Defaults to 20000
@@ -375,7 +375,7 @@ One of exponential/constant/disable retries backoff policies can be provided for
 | Environment Variable                                           | Default                         | Required | Description                                                                                                                                                                                                    |
 | -------------------------------------------------------------- | ------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | PGSTREAM_POSTGRES_WRITER_TARGET_URL                            | N/A                             | Yes      | URL for the PostgreSQL store to connect to                                                                                                                                                                     |
-| PGSTREAM_POSTGRES_WRITER_MAX_CONNECTIONS                       | 50                              | No       | Maximum number of connections per pool to the target PostgreSQL database. Overrides `pool_max_conns` in the target URL when set.                                                                               |
+| PGSTREAM_POSTGRES_WRITER_MAX_CONNECTIONS                       | 50                              | No       | Maximum number of connections in the writer pool to the target PostgreSQL database. Overrides `pool_max_conns` in the target URL when set. The schema observer keeps its own pool, capped at 16 and never larger than this value, so the process opens at most this many plus 16.                                                                               |
 | PGSTREAM_POSTGRES_WRITER_BATCH_TIMEOUT                         | 30s                             | No       | Max time interval at which the batch sending to PostgreSQL is triggered.                                                                                                                                       |
 | PGSTREAM_POSTGRES_WRITER_BATCH_SIZE                            | 20000                           | No       | Max number of messages to be sent per batch. When this size is reached, the batch is sent to PostgreSQL.                                                                                                       |
 | PGSTREAM_POSTGRES_WRITER_MAX_QUEUE_BYTES                       | 104857600 (100MiB)              | No       | Max memory used by the postgres batch writer for inflight batches.                                                                                                                                             |

--- a/pkg/wal/processor/postgres/config.go
+++ b/pkg/wal/processor/postgres/config.go
@@ -25,6 +25,9 @@ type Config struct {
 const (
 	defaultInitialInterval = 500 * time.Millisecond
 	defaultMaxInterval     = 30 * time.Second
+
+	// otherwise the observer doubles max_connections
+	maxObserverConnections = 16
 )
 
 func (c *Config) retryPolicy() backoff.Config {
@@ -44,4 +47,8 @@ func (c *Config) poolOptions() []pglib.PoolOption {
 		return nil
 	}
 	return []pglib.PoolOption{pglib.WithMaxConnections(int32(c.MaxConnections))}
+}
+
+func observerConnections(maxConnections int32) int32 {
+	return max(1, min(maxConnections, maxObserverConnections))
 }

--- a/pkg/wal/processor/postgres/config_test.go
+++ b/pkg/wal/processor/postgres/config_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestObserverConnections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		maxConnections int32
+		expected       int32
+	}{
+		{
+			name:           "default writer pool is capped",
+			maxConnections: 50,
+			expected:       maxObserverConnections,
+		},
+		{
+			name:           "large writer pool is capped",
+			maxConnections: 500,
+			expected:       maxObserverConnections,
+		},
+		{
+			name:           "small writer pool bounds the observer",
+			maxConnections: 4,
+			expected:       4,
+		},
+		{
+			name:           "exactly at the cap",
+			maxConnections: maxObserverConnections,
+			expected:       maxObserverConnections,
+		},
+		{
+			name:           "single connection writer pool",
+			maxConnections: 1,
+			expected:       1,
+		},
+		{
+			// pgxpool rejects pools smaller than one
+			name:           "never returns less than one",
+			maxConnections: 0,
+			expected:       1,
+		},
+		{
+			name:           "negative writer pool still floors at one",
+			maxConnections: -7,
+			expected:       1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, observerConnections(tt.maxConnections))
+		})
+	}
+}

--- a/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
+++ b/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
@@ -26,16 +26,14 @@ type BulkIngestWriter struct {
 	batchSenderBuilder func(ctx context.Context, schema, table string) (queryBatchSender, error)
 	// copyBudget caps the total number of concurrent COPYs across all tables
 	// (and all their send drainers) so they never exhaust the target
-	// connection pool. It is sized from the resolved pool max-connections value,
-	// minus a reserve for the writer's own metadata/type queries.
+	// connection pool. It is sized from the resolved pool max-connections
+	// value, minus copyBudgetReserve.
 	copyBudget synclib.WeightedSemaphore
 }
 
 const bulkIngestWriter = "postgres_bulk_ingest_writer"
 
-// copyBudgetReserve is the number of pool connections kept out of the
-// concurrent-COPY budget, leaving headroom for the writer's adapter
-// metadata/type queries against the same pool.
+// batch writer and retrier reset share this pool
 const copyBudgetReserve = 5
 
 var errUnexpectedCopiedRows = errors.New("number of rows copied doesn't match the source rows")

--- a/pkg/wal/processor/postgres/postgres_bulk_ingest_writer_test.go
+++ b/pkg/wal/processor/postgres/postgres_bulk_ingest_writer_test.go
@@ -514,21 +514,38 @@ func TestCopyBudgetSize(t *testing.T) {
 
 func TestNewBulkIngestWriter_maxConnections(t *testing.T) {
 	tests := []struct {
-		name           string
-		url            string
-		maxConnections uint
-		expected       int32
+		name             string
+		url              string
+		maxConnections   uint
+		expected         int32
+		expectedObserver int32
 	}{
 		{
-			name:     "connection URL",
-			url:      "postgresql://user:password@localhost:5432/database?pool_max_conns=12",
-			expected: 12,
+			name:             "connection URL",
+			url:              "postgresql://user:password@localhost:5432/database?pool_max_conns=12",
+			expected:         12,
+			expectedObserver: 12,
 		},
 		{
-			name:           "writer config overrides connection URL",
-			url:            "postgresql://user:password@localhost:5432/database?pool_max_conns=12",
-			maxConnections: 20,
-			expected:       20,
+			name:             "writer config overrides connection URL",
+			url:              "postgresql://user:password@localhost:5432/database?pool_max_conns=12",
+			maxConnections:   20,
+			expected:         20,
+			expectedObserver: maxObserverConnections,
+		},
+		{
+			name:             "observer capped below the writer pool",
+			url:              "postgresql://user:password@localhost:5432/database",
+			maxConnections:   200,
+			expected:         200,
+			expectedObserver: maxObserverConnections,
+		},
+		{
+			name:             "observer never exceeds the writer pool",
+			url:              "postgresql://user:password@localhost:5432/database",
+			maxConnections:   2,
+			expected:         2,
+			expectedObserver: 2,
 		},
 	}
 
@@ -552,7 +569,7 @@ func TestNewBulkIngestWriter_maxConnections(t *testing.T) {
 			require.True(t, ok)
 			observerPool, ok := observer.pgConn.(*pglib.Pool)
 			require.True(t, ok)
-			require.Equal(t, tt.expected, observerPool.Config().MaxConns)
+			require.Equal(t, tt.expectedObserver, observerPool.Config().MaxConns)
 
 			budget := copyBudgetSize(tt.expected)
 			for range budget {

--- a/pkg/wal/processor/postgres/postgres_schema_observer.go
+++ b/pkg/wal/processor/postgres/postgres_schema_observer.go
@@ -54,9 +54,16 @@ type pgSchemaObserver struct {
 // including generated table columns and materialized views. It keeps a cache to
 // reduce the number of calls to postgres, and it updates the state whenever a
 // DDL event is received through the WAL.
-func newPGSchemaObserver(ctx context.Context, cfg *Config, logger loglib.Logger) (*pgSchemaObserver, error) {
+func newPGSchemaObserver(ctx context.Context, cfg *Config, logger loglib.Logger, maxConnections int32) (*pgSchemaObserver, error) {
+	observerMaxConnections := observerConnections(maxConnections)
+	// derived, not configured: nothing else reports it
+	logger.Info("postgres schema observer connection pool sized", loglib.Fields{
+		"observer_max_connections": observerMaxConnections,
+		"writer_max_connections":   maxConnections,
+	})
+
 	newConnPool := func(ctx context.Context) (pglib.Querier, error) {
-		return pglib.NewConnPool(ctx, cfg.URL, cfg.poolOptions()...)
+		return pglib.NewConnPool(ctx, cfg.URL, pglib.WithMaxConnections(observerMaxConnections))
 	}
 
 	// the observer sits on the hot path: an unretried transient failure here

--- a/pkg/wal/processor/postgres/postgres_wal_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_adapter.go
@@ -74,8 +74,8 @@ type (
 	ddlEventAdapter func(*wal.Data) (*wal.DDLEvent, error)
 )
 
-func newAdapter(ctx context.Context, logger loglib.Logger, cfg *Config, forCopy bool) (*adapter, error) {
-	schemaObserver, err := newPGSchemaObserver(ctx, cfg, logger)
+func newAdapter(ctx context.Context, logger loglib.Logger, cfg *Config, forCopy bool, maxConnections int32) (*adapter, error) {
+	schemaObserver, err := newPGSchemaObserver(ctx, cfg, logger, maxConnections)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/wal/processor/postgres/postgres_writer.go
+++ b/pkg/wal/processor/postgres/postgres_writer.go
@@ -101,7 +101,7 @@ func newWriter(ctx context.Context, config *Config, writerType string, opts ...W
 
 	forCopy := writerType == bulkIngestWriter
 
-	w.adapter, err = newAdapter(ctx, w.logger, config, forCopy)
+	w.adapter, err = newAdapter(ctx, w.logger, config, forCopy, w.maxConnections)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Description

`target.postgres.max_connections` sized two pools, not one: the writer's and the schema observer's. The setting therefore permitted twice the connections it named: an operator capping at 90 to stay under a 100-connection target limit could still reach 180.

The observer is now sized separately, at `min(writer pool, 16)`. Its catalog lookups are short and cached, so its demand is a burst at start-up and after DDL rather than the writer's sustained COPY concurrency. Deriving it from the writer's *resolved* size means whichever setting produced that budget — `max_connections`, or `pool_max_conns` in the target URL.

##### Related Issue(s)

- Related to #1048

#### Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

#### Changes Made

- Sized the schema observer's pool at `min(writer pool, 16)` instead of inheriting `max_connections`.
- Threaded the writer's resolved pool size through `newAdapter` into `newPGSchemaObserver`.
- Logged the resolved observer pool size at construction — it is derived rather than configured, so nothing else reports it.

#### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
