### PR TITLE
Processors chain reports if a layer needs to see rows

### DIFF
--- a/pkg/stream/processor_chain_test.go
+++ b/pkg/stream/processor_chain_test.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package stream
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	loglib "github.com/xataio/pgstream/pkg/log"
+	"github.com/xataio/pgstream/pkg/otel"
+	"github.com/xataio/pgstream/pkg/wal/processor"
+	"github.com/xataio/pgstream/pkg/wal/processor/filter"
+	"github.com/xataio/pgstream/pkg/wal/processor/mocks"
+	"github.com/xataio/pgstream/pkg/wal/processor/transformer"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+var errTestWrap = errors.New("wrap failed")
+
+// select a writer, not a layer
+var targetFields = map[string]struct{}{
+	"Kafka":    {},
+	"Search":   {},
+	"Webhook":  {},
+	"Postgres": {},
+	"Stdout":   {},
+}
+
+// wrap a layer around the writer
+var modifierFields = map[string]struct{}{
+	"Transformer": {},
+	"Injector":    {},
+	"Filter":      {},
+	"Sanitize":    {},
+}
+
+// unclassified layers get bypassed
+func TestProcessorConfig_allFieldsClassified(t *testing.T) {
+	t.Parallel()
+
+	cfgType := reflect.TypeOf(ProcessorConfig{})
+	for i := range cfgType.NumField() {
+		name := cfgType.Field(i).Name
+		_, isTarget := targetFields[name]
+		_, isModifier := modifierFields[name]
+		switch {
+		case isTarget && isModifier:
+			t.Errorf("ProcessorConfig field %q is classified as both a target and a modifier", name)
+		case !isTarget && !isModifier:
+			t.Errorf("unclassified ProcessorConfig field %q: add it to targetFields if it selects a target "+
+				"writer, or to modifierFields and have addProcessorModifiers apply a modifier for it, after "+
+				"deciding whether the layer needs to see every row", name)
+		}
+	}
+}
+
+func TestAddProcessorModifiers_hasRowVisibleLayers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  ProcessorConfig
+
+		want bool
+	}{
+		{
+			name: "no modifiers leaves the chain bypassable",
+			cfg:  ProcessorConfig{},
+			want: false,
+		},
+		{
+			name: "sanitizer",
+			cfg:  ProcessorConfig{Sanitize: &SanitizeConfig{StripNullCharBytes: true}},
+			want: true,
+		},
+		{
+			name: "sanitizer without null byte stripping is never applied",
+			cfg:  ProcessorConfig{Sanitize: &SanitizeConfig{}},
+			want: false,
+		},
+		{
+			name: "transformer",
+			cfg:  ProcessorConfig{Transformer: &transformer.Config{}},
+			want: true,
+		},
+		{
+			name: "filter",
+			cfg:  ProcessorConfig{Filter: &filter.Config{IncludeTables: []string{"*"}}},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			chain, closer, err := addProcessorModifiers(t.Context(), &Config{Processor: tc.cfg},
+				loglib.NewNoopLogger(), &mocks.Processor{}, nil)
+			require.NoError(t, err)
+			defer closer()
+
+			require.Equal(t, tc.want, chain.hasRowVisibleLayers())
+		})
+	}
+}
+
+// instrumentation wraps without a config field
+func TestAddProcessorModifiers_instrumentationIsRecordedButNotRowVisible(t *testing.T) {
+	t.Parallel()
+
+	instrumentation := &otel.Instrumentation{Meter: noop.NewMeterProvider().Meter("test")}
+	require.True(t, instrumentation.IsEnabled())
+
+	chain, closer, err := addProcessorModifiers(t.Context(), &Config{}, loglib.NewNoopLogger(),
+		&mocks.Processor{}, instrumentation)
+	require.NoError(t, err)
+	defer closer()
+
+	require.Equal(t, []modifier{modifierInstrumentation}, chain.applied)
+	require.False(t, chain.hasRowVisibleLayers())
+}
+
+func TestProcessorChain_apply(t *testing.T) {
+	t.Parallel()
+
+	t.Run("records only what it wraps", func(t *testing.T) {
+		t.Parallel()
+
+		target := &mocks.Processor{}
+		wrapped := &mocks.Processor{}
+		chain := &processorChain{processor: target}
+
+		require.NoError(t, chain.apply(modifierFilter, func(processor.Processor) (processor.Processor, error) {
+			return wrapped, nil
+		}))
+
+		require.Same(t, wrapped, chain.processor)
+		require.Equal(t, []modifier{modifierFilter}, chain.applied)
+	})
+
+	t.Run("a failed wrap leaves the chain untouched", func(t *testing.T) {
+		t.Parallel()
+
+		target := &mocks.Processor{}
+		chain := &processorChain{processor: target}
+
+		require.Error(t, chain.apply(modifierFilter, func(processor.Processor) (processor.Processor, error) {
+			return nil, errTestWrap
+		}))
+
+		require.Same(t, target, chain.processor)
+		require.Empty(t, chain.applied)
+	})
+}

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -186,13 +186,66 @@ func buildProcessor(ctx context.Context, logger loglib.Logger, config *Processor
 	return processor, nil
 }
 
-func addProcessorModifiers(ctx context.Context, config *Config, logger loglib.Logger, processor processor.Processor, instrumentation *otel.Instrumentation) (processor.Processor, closerFn, error) {
+// modifier is a layer wrapped around the target writer. rowVisible reports
+// whether it observes or changes row data: such a layer must see every row, so
+// a fast path that bypasses the chain is only correct without one.
+type modifier struct {
+	rowVisible bool
+}
+
+var (
+	modifierSanitizer       = modifier{rowVisible: true}
+	modifierTransformer     = modifier{rowVisible: true}
+	modifierInjector        = modifier{rowVisible: true}
+	modifierFilter          = modifier{rowVisible: true}
+	modifierInstrumentation = modifier{}
+)
+
+// processorChain is a target writer with the modifier layers wrapped around
+// it. It records which layers were applied, so a fast path that bypasses the
+// chain can tell whether bypassing it is safe.
+type processorChain struct {
+	processor processor.Processor
+	applied   []modifier
+}
+
+// apply wraps the current processor in a new layer and records it. It is the
+// only way to extend the chain: a layer cannot be added without naming a
+// modifier, which forces whoever adds one to decide whether it is row
+// visible. Recording happens where the wrapping happens, so a layer that is
+// configured but not actually applied is not recorded either.
+func (c *processorChain) apply(m modifier, wrap func(processor.Processor) (processor.Processor, error)) error {
+	p, err := wrap(c.processor)
+	if err != nil {
+		return err
+	}
+	c.processor = p
+	c.applied = append(c.applied, m)
+	return nil
+}
+
+// hasRowVisibleLayers reports whether any applied layer must see every row.
+// When false, rows may be written straight to the target, bypassing the chain.
+func (c *processorChain) hasRowVisibleLayers() bool {
+	for _, m := range c.applied {
+		if m.rowVisible {
+			return true
+		}
+	}
+	return false
+}
+
+func addProcessorModifiers(ctx context.Context, config *Config, logger loglib.Logger, target processor.Processor, instrumentation *otel.Instrumentation) (*processorChain, closerFn, error) {
 	closerAgg := &closerAggregator{}
-	var err error
+	chain := &processorChain{processor: target}
 
 	if config.Processor.Sanitize != nil && config.Processor.Sanitize.StripNullCharBytes {
 		logger.Info("adding null byte sanitizer to processor...")
-		processor = sanitizer.New(processor, sanitizer.WithLogger(logger))
+		if err := chain.apply(modifierSanitizer, func(p processor.Processor) (processor.Processor, error) {
+			return sanitizer.New(p, sanitizer.WithLogger(logger)), nil
+		}); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	if config.Processor.Transformer != nil {
@@ -243,8 +296,9 @@ func addProcessorModifiers(ctx context.Context, config *Config, logger loglib.Lo
 
 			opts = append(opts, transformer.WithParser(parser))
 		}
-		processor, err = transformer.New(ctx, config.Processor.Transformer, processor, transformerBuilder, opts...)
-		if err != nil {
+		if err := chain.apply(modifierTransformer, func(p processor.Processor) (processor.Processor, error) {
+			return transformer.New(ctx, config.Processor.Transformer, p, transformerBuilder, opts...)
+		}); err != nil {
 			logger.Error(err, "creating transformer layer")
 			return nil, nil, err
 		}
@@ -258,31 +312,31 @@ func addProcessorModifiers(ctx context.Context, config *Config, logger loglib.Lo
 		if instrumentation.IsEnabled() {
 			opts = append(opts, injector.WithInstrumentation(instrumentation))
 		}
-		processor, err = injector.New(ctx, config.Processor.Injector, processor, opts...)
-		if err != nil {
+		if err := chain.apply(modifierInjector, func(p processor.Processor) (processor.Processor, error) {
+			return injector.New(ctx, config.Processor.Injector, p, opts...)
+		}); err != nil {
 			return nil, nil, fmt.Errorf("error creating processor injection layer: %w", err)
 		}
 	}
 
 	if config.Processor.Filter != nil {
 		logger.Info("adding filtering to processor...")
-		var err error
-		processor, err = filter.New(processor, config.Processor.Filter,
-			filter.WithLogger(logger))
-		if err != nil {
+		if err := chain.apply(modifierFilter, func(p processor.Processor) (processor.Processor, error) {
+			return filter.New(p, config.Processor.Filter, filter.WithLogger(logger))
+		}); err != nil {
 			return nil, nil, err
 		}
 	}
 
-	if processor != nil && instrumentation.IsEnabled() {
-		var err error
-		processor, err = processinstrumentation.NewProcessor(processor, instrumentation)
-		if err != nil {
+	if chain.processor != nil && instrumentation.IsEnabled() {
+		if err := chain.apply(modifierInstrumentation, func(p processor.Processor) (processor.Processor, error) {
+			return processinstrumentation.NewProcessor(p, instrumentation)
+		}); err != nil {
 			return nil, nil, err
 		}
 	}
 
-	return processor, closerAgg.close, nil
+	return chain, closerAgg.close, nil
 }
 
 type closerAggregator struct {

--- a/pkg/stream/stream_run.go
+++ b/pkg/stream/stream_run.go
@@ -18,7 +18,6 @@ import (
 	kafkalistener "github.com/xataio/pgstream/pkg/wal/listener/kafka"
 	pglistener "github.com/xataio/pgstream/pkg/wal/listener/postgres"
 	snapshotbuilder "github.com/xataio/pgstream/pkg/wal/listener/snapshot/builder"
-	"github.com/xataio/pgstream/pkg/wal/processor"
 	"github.com/xataio/pgstream/pkg/wal/replication"
 	replicationinstrumentation "github.com/xataio/pgstream/pkg/wal/replication/instrumentation"
 	pgreplication "github.com/xataio/pgstream/pkg/wal/replication/postgres"
@@ -119,7 +118,7 @@ func Run(ctx context.Context, logger loglib.Logger, config *Config, init bool, i
 
 	// Processor
 
-	processor, closer, err := newProcessor(ctx, logger, config, checkpoint, processorTypeReplication, instrumentation)
+	replicationChain, closer, err := newProcessor(ctx, logger, config, checkpoint, processorTypeReplication, instrumentation)
 	defer closer()
 	if err != nil {
 		return err
@@ -140,7 +139,7 @@ func Run(ctx context.Context, logger loglib.Logger, config *Config, init bool, i
 			// use a dedicated processor for the snapshot phase, to be able to
 			// close it and make sure the snapshot is complete before starting
 			// to process the WAL replication events.
-			snapshotProcessor, snapshotCloser, err := newProcessor(ctx, logger, config, checkpoint, processorTypeSnapshot, instrumentation)
+			snapshotChain, snapshotCloser, err := newProcessor(ctx, logger, config, checkpoint, processorTypeSnapshot, instrumentation)
 			defer snapshotCloser()
 			if err != nil {
 				return fmt.Errorf("error creating snapshot processor: %w", err)
@@ -150,7 +149,7 @@ func Run(ctx context.Context, logger loglib.Logger, config *Config, init bool, i
 			snapshotGenerator, err := snapshotbuilder.NewSnapshotGenerator(
 				ctx,
 				config.Listener.Postgres.Snapshot,
-				snapshotProcessor,
+				snapshotChain.processor,
 				logger,
 				instrumentation,
 				config.restoreConflictTargetsBeforeData())
@@ -163,13 +162,13 @@ func Run(ctx context.Context, logger loglib.Logger, config *Config, init bool, i
 
 		listener = pglistener.New(
 			replicationHandler,
-			processor.ProcessWALEvent,
+			replicationChain.processor.ProcessWALEvent,
 			opts...)
 	case config.Listener.Kafka != nil:
 		logger.Info("kafka listener configured")
 		listener, err = kafkalistener.NewWALReader(
 			kafkaReader,
-			processor.ProcessWALEvent,
+			replicationChain.processor.ProcessWALEvent,
 			kafkalistener.WithLogger(logger),
 			kafkalistener.WithPhaseTracker(phaseTracker))
 		if err != nil {
@@ -199,20 +198,23 @@ var noopCloser func() error = func() error {
 	return nil
 }
 
-func newProcessor(ctx context.Context, logger loglib.Logger, config *Config, checkpoint checkpointer.Checkpoint, processorType processorType, instrumentation *otel.Instrumentation) (processor.Processor, closerFn, error) {
-	processor, err := buildProcessor(ctx, logger, &config.Processor, checkpoint, processorType, instrumentation)
+func newProcessor(ctx context.Context, logger loglib.Logger, config *Config, checkpoint checkpointer.Checkpoint, processorType processorType, instrumentation *otel.Instrumentation) (*processorChain, closerFn, error) {
+	target, err := buildProcessor(ctx, logger, &config.Processor, checkpoint, processorType, instrumentation)
 	if err != nil {
 		return nil, noopCloser, err
 	}
+	chain, closer, err := addProcessorModifiers(ctx, config, logger, target, instrumentation)
+	if err != nil {
+		// the target writer already holds a pool
+		if closeErr := target.Close(); closeErr != nil {
+			logger.Error(closeErr, "closing target writer after processor modifier setup failed")
+		}
+		return nil, noopCloser, err
+	}
+
 	var closerAgg closerAggregator
-	var closer closerFn
-	processor, closer, err = addProcessorModifiers(ctx, config, logger, processor, instrumentation)
-	if err != nil {
-		return nil, noopCloser, err
-	}
-
 	closerAgg.addCloserFn(closer)
-	closerAgg.addCloserFn(processor.Close)
+	closerAgg.addCloserFn(chain.processor.Close)
 
-	return processor, closerAgg.close, nil
+	return chain, closerAgg.close, nil
 }

--- a/pkg/stream/stream_snapshot.go
+++ b/pkg/stream/stream_snapshot.go
@@ -35,18 +35,11 @@ func Snapshot(ctx context.Context, logger loglib.Logger, config *Config, instrum
 
 	// Processor
 
-	processor, err := buildProcessor(ctx, logger, &config.Processor, nil, processorTypeSnapshot, instrumentation)
-	if err != nil {
-		return err
-	}
-	defer processor.Close()
-
-	var closer closerFn
-	processor, closer, err = addProcessorModifiers(ctx, config, logger, processor, instrumentation)
-	if err != nil {
-		return err
-	}
+	chain, closer, err := newProcessor(ctx, logger, config, nil, processorTypeSnapshot, instrumentation)
 	defer closer()
+	if err != nil {
+		return err
+	}
 
 	// Listener
 
@@ -54,7 +47,7 @@ func Snapshot(ctx context.Context, logger loglib.Logger, config *Config, instrum
 	snapshotGenerator, err := snapshotbuilder.NewSnapshotGenerator(
 		ctx,
 		config.Listener.Postgres.Snapshot,
-		processor,
+		chain.processor,
 		logger,
 		instrumentation,
 		config.restoreConflictTargetsBeforeData())


### PR DESCRIPTION
#### Description

Records the modifier layers `addProcessorModifiers` wraps around the target writer, so the pipeline can answer "does any layer read rows?" from what was actually composed, rather than by inspecting config a second time.

Preparation for the snapshot COPY passthrough, which may only bypass the processor chain when nothing in it needs to see the rows. `hasRowVisibleLayers()` has no production caller on this branch.

#### Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- `addProcessorModifiers` returns a `processorChain` that records each layer as it wraps it. `apply` is its only mutator, so a layer cannot be added without deciding whether it is row visible, and a layer that is configured but not
applied is not recorded — the sanitizer, which only wraps when it has null bytes to strip, is the case config inspection gets wrong.
- Covers the instrumentation layer, which no config field selects and which a guard keyed on `ProcessorConfig` is structurally unable to see.
- The snapshot path shares `newProcessor` with the run path instead of open-coding the same two calls.
- Adds a reflection guard that fails when a field is added to `ProcessorConfig` without classifying it as a target or a modifier.

#### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
