### PR TITLE
Copy passthrough during snapshot mode if no transformers are configured

### DIFF
--- a/internal/postgres/retrier/pg_querier_retrier.go
+++ b/internal/postgres/retrier/pg_querier_retrier.go
@@ -152,6 +152,13 @@ func (q *Querier) resetConn(ctx context.Context) error {
 }
 
 func (q *Querier) isRetriableError(err error) bool {
+	return IsRetriableError(err)
+}
+
+// IsRetriableError reports whether retrying an operation that failed with err
+// could succeed. Callers retrying at a coarser granularity than a single
+// query use it so their rule cannot drift from this one.
+func IsRetriableError(err error) bool {
 	mappedErr := postgres.MapError(err)
 
 	permissionDenied := &postgres.ErrPermissionDenied{}

--- a/internal/sync/semaphore.go
+++ b/internal/sync/semaphore.go
@@ -17,3 +17,10 @@ type WeightedSemaphore interface {
 func NewWeightedSemaphore(size int64) *semaphore.Weighted {
 	return semaphore.NewWeighted(size)
 }
+
+// CopyBudgetReserve leaves room for non-copy connections
+const CopyBudgetReserve = 5
+
+func CopyBudgetSize(maxConnections int32) int64 {
+	return max(1, int64(maxConnections)-CopyBudgetReserve)
+}

--- a/internal/sync/semaphore_test.go
+++ b/internal/sync/semaphore_test.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyBudgetSize(t *testing.T) {
+	t.Parallel()
+
+	// zero would block every copy forever
+	require.Equal(t, int64(1), CopyBudgetSize(1))
+	require.Equal(t, int64(1), CopyBudgetSize(CopyBudgetReserve))
+	require.Equal(t, int64(45), CopyBudgetSize(50))
+}

--- a/pkg/snapshot/generator/postgres/data/chunk_mover.go
+++ b/pkg/snapshot/generator/postgres/data/chunk_mover.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	loglib "github.com/xataio/pgstream/pkg/log"
+	"github.com/xataio/pgstream/pkg/otel"
+)
+
+// runInTx runs fn against a connection that can read the chunk. A reading
+// strategy supplies its own: the ctid reader imports the exported transaction
+// snapshot, a keyset reader need not open one at all.
+type runInTx func(ctx context.Context, fn func(tx pglib.Tx) error) error
+
+// chunkMover moves the rows a reading strategy has selected. The strategy
+// decides which rows to read and says so as a complete query; the mover decides
+// what becomes of them, so every strategy gets every mover.
+//
+// It takes the query rather than the rows because the copy passthrough must
+// never run it as an ordinary query: it wraps it in COPY. It takes a way to run
+// rather than an open transaction because the passthrough retries a whole chunk
+// on a fresh pipe, which needs a fresh transaction.
+//
+// The query must be complete SQL. COPY accepts no bind parameters, so a
+// strategy that phrases its chunk with placeholders can only ever be decoded.
+type chunkMover interface {
+	// prepareTable resolves whatever the mover needs before the table's chunks
+	// are moved, once its columns are known.
+	prepareTable(ctx context.Context, table *table) error
+	// move reads the chunk the query selects and returns the rows moved.
+	move(ctx context.Context, run runInTx, table *table, query string) (uint, error)
+	close(ctx context.Context) error
+}
+
+// newChunkMover picks how a chunk is moved. Selecting it here, next to the
+// sink and before any reader exists, is what keeps it independent of the
+// reading strategy.
+func newChunkMover(ctx context.Context, cfg *Config, logger loglib.Logger,
+	instrumentation *otel.Instrumentation, progress progressTracker, decoding chunkMover,
+) (chunkMover, error) {
+	if cfg.CopyPassthrough == nil {
+		return decoding, nil
+	}
+	return newCopyPassthroughMover(ctx, cfg.CopyPassthrough, logger, instrumentation, progress, decoding)
+}
+
+// decodingMover reads the rows and hands them to the sink, which adapts them
+// into wal events for the processor.
+type decodingMover struct {
+	sink rowSink
+}
+
+func newDecodingMover(sink rowSink) decodingMover {
+	return decodingMover{sink: sink}
+}
+
+func (m decodingMover) prepareTable(context.Context, *table) error { return nil }
+
+func (m decodingMover) close(context.Context) error { return nil }
+
+func (m decodingMover) move(ctx context.Context, run runInTx, table *table, query string) (uint, error) {
+	var rowCount uint
+	err := run(ctx, func(tx pglib.Tx) error {
+		rows, err := tx.Query(ctx, query)
+		if err != nil {
+			return wrapChunkQueryError(err)
+		}
+		defer rows.Close()
+
+		rowCount, err = m.sink.emit(ctx, table, rows)
+		return err
+	})
+	return rowCount, err
+}
+
+// a vanished relation means schema drift
+func wrapChunkQueryError(err error) error {
+	var relationErr *pglib.ErrRelationDoesNotExist
+	if errors.As(err, &relationErr) {
+		return fmt.Errorf("%w: querying table rows: %w", ErrSchemaChangedDuringSnapshot, err)
+	}
+	return fmt.Errorf("querying table rows: %w", err)
+}

--- a/pkg/snapshot/generator/postgres/data/config.go
+++ b/pkg/snapshot/generator/postgres/data/config.go
@@ -2,6 +2,11 @@
 
 package postgres
 
+import (
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/pkg/backoff"
+)
+
 type Config struct {
 	// Postgres connection URL. Required.
 	URL string
@@ -30,6 +35,8 @@ type Config struct {
 	// expect unmarshalled values. This setting is derived from the stream
 	// configuration for postgres targets, not set by users.
 	RawJSONValues bool
+	// derived from stream config, not users
+	CopyPassthrough *CopyPassthroughConfig
 }
 
 const (
@@ -39,6 +46,26 @@ const (
 	defaultBatchBytes      = 80 * 1024 * 1024 // 80 MiB
 	defaultMaxConnections  = 50
 )
+
+// the generator writes the target
+type CopyPassthroughConfig struct {
+	TargetURL       string
+	DisableTriggers bool
+	// 0 defers to the url
+	MaxConnections uint
+	RetryPolicy    backoff.Config
+}
+
+// array_recv ignores user-defined OID mismatch
+// needs target schema from source
+const copyFormat = " WITH (FORMAT binary)"
+
+func (c *CopyPassthroughConfig) poolOptions() []pglib.PoolOption {
+	if c.MaxConnections == 0 {
+		return nil
+	}
+	return []pglib.PoolOption{pglib.WithMaxConnections(int32(c.MaxConnections))}
+}
 
 func (c *Config) batchBytes() uint64 {
 	if c.BatchBytes > 0 {

--- a/pkg/snapshot/generator/postgres/data/ctid_table_reader.go
+++ b/pkg/snapshot/generator/postgres/data/ctid_table_reader.go
@@ -4,7 +4,6 @@ package postgres
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -23,7 +22,7 @@ import (
 type ctidReader struct {
 	conn         pglib.Querier
 	logger       loglib.Logger
-	sink         rowSink
+	mover        chunkMover
 	tableWorkers uint
 	batchBytes   uint64
 }
@@ -96,6 +95,10 @@ func (s *ctidSession) readTable(ctx context.Context, table *table) error {
 	}
 	table.columns = columns
 
+	if err := s.reader.mover.prepareTable(ctx, table); err != nil {
+		return err
+	}
+
 	// If one page range fails, we abort the entire table snapshot. The
 	// snapshot relies on the transaction snapshot id to ensure all workers
 	// have the same table view, which allows us to use the ctid to
@@ -148,34 +151,20 @@ func buildPageRangeQuery(t *table, r pageRange) string {
 }
 
 func (s *ctidSession) snapshotTableRange(ctx context.Context, table *table, pageRange pageRange) error {
-	return s.execInTx(ctx, func(tx pglib.Tx) error {
-		s.reader.logger.Debug(fmt.Sprintf("querying table page range %d-%d", pageRange.start, pageRange.end), loglib.Fields{
-			"schema": table.schema, "table": table.name, "snapshotID": s.snapshotID,
-		})
-
-		query := buildPageRangeQuery(table, pageRange)
-		rows, err := tx.Query(ctx, query)
-		if err != nil {
-			// something this query names vanished
-			var relationErr *pglib.ErrRelationDoesNotExist
-			if errors.As(err, &relationErr) {
-				return fmt.Errorf("%w: querying table rows: %w", ErrSchemaChangedDuringSnapshot, err)
-			}
-			return fmt.Errorf("querying table rows: %w", err)
-		}
-		defer rows.Close()
-
-		rowCount, err := s.reader.sink.emit(ctx, table, rows)
-		if err != nil {
-			return err
-		}
-
-		s.reader.logger.Debug(fmt.Sprintf("%d rows processed", rowCount), loglib.Fields{
-			"schema": table.schema, "table": table.name, "snapshotID": s.snapshotID,
-		})
-
-		return nil
+	s.reader.logger.Debug(fmt.Sprintf("querying table page range %d-%d", pageRange.start, pageRange.end), loglib.Fields{
+		"schema": table.schema, "table": table.name, "snapshotID": s.snapshotID,
 	})
+
+	rowCount, err := s.reader.mover.move(ctx, s.execInTx, table, buildPageRangeQuery(table, pageRange))
+	if err != nil {
+		return err
+	}
+
+	s.reader.logger.Debug(fmt.Sprintf("%d rows processed", rowCount), loglib.Fields{
+		"schema": table.schema, "table": table.name, "snapshotID": s.snapshotID,
+	})
+
+	return nil
 }
 
 // tableInfoQuery shares the capture rule.

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_copy_passthrough.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_copy_passthrough.go
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	pglibinstrumentation "github.com/xataio/pgstream/internal/postgres/instrumentation"
+	pglibretrier "github.com/xataio/pgstream/internal/postgres/retrier"
+	synclib "github.com/xataio/pgstream/internal/sync"
+	"github.com/xataio/pgstream/pkg/backoff"
+	loglib "github.com/xataio/pgstream/pkg/log"
+	"github.com/xataio/pgstream/pkg/otel"
+	"golang.org/x/sync/errgroup"
+)
+
+var (
+	errMissingCopyPassthroughTarget = errors.New("copy passthrough requires a target postgres url")
+	errUnexpectedCopiedRows         = errors.New("number of rows copied doesn't match the source rows")
+	errChunkAlreadyCommitted        = errors.New("the target committed the page range before the source transaction failed")
+)
+
+// copyPassthroughMover streams a page range from the source's COPY TO
+// STDOUT into the target's COPY FROM STDIN, decoding nothing on the way. It
+// writes to the target itself, so it takes on what the bypassed writer did:
+// the target connection and its retry policy, trigger suppression, and a
+// budget capping concurrent COPYs.
+//
+// It delegates the rows COPY cannot carry.
+type copyPassthroughMover struct {
+	cfg             *CopyPassthroughConfig
+	logger          loglib.Logger
+	progress        progressTracker
+	targetConn      pglib.Querier
+	budget          synclib.WeightedSemaphore
+	fallback        chunkMover
+	backoffProvider backoff.Provider
+}
+
+func newCopyPassthroughMover(ctx context.Context, cfg *CopyPassthroughConfig, logger loglib.Logger,
+	instrumentation *otel.Instrumentation, progress progressTracker, fallback chunkMover,
+) (*copyPassthroughMover, error) {
+	if cfg.TargetURL == "" {
+		return nil, errMissingCopyPassthroughTarget
+	}
+
+	poolOpts := cfg.poolOptions()
+	maxConnections, err := pglib.ConnPoolMaxConnections(cfg.TargetURL, poolOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("resolving copy passthrough target connections: %w", err)
+	}
+
+	// not the retrying querier: it replays the transaction closure, and the
+	// closure reads a pipe the failed attempt already drained. Retrying is
+	// done a page range at a time instead, where the pipe is rebuilt.
+	pool, err := pglib.NewConnPool(ctx, cfg.TargetURL, poolOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to copy passthrough target: %w", err)
+	}
+	targetConn := pglib.Querier(pool)
+
+	if instrumentation.IsEnabled() {
+		// release the pool, not the instrumented querier: NewQuerier returns a
+		// nil Querier when it fails, and the pool is what has to be closed
+		instrumented, err := pglibinstrumentation.NewQuerier(targetConn, instrumentation)
+		if err != nil {
+			return nil, errors.Join(fmt.Errorf("instrumenting copy passthrough target: %w", err), pool.Close(ctx))
+		}
+		targetConn = instrumented
+	}
+
+	if err := targetConn.Ping(ctx); err != nil {
+		return nil, errors.Join(fmt.Errorf("pinging copy passthrough target: %w", err), targetConn.Close(ctx))
+	}
+
+	return &copyPassthroughMover{
+		cfg:             cfg,
+		logger:          logger,
+		progress:        progress,
+		targetConn:      targetConn,
+		budget:          synclib.NewWeightedSemaphore(synclib.CopyBudgetSize(maxConnections)),
+		fallback:        fallback,
+		backoffProvider: backoff.NewProvider(&cfg.RetryPolicy),
+	}, nil
+}
+
+const targetGeneratedColumnsQuery = `SELECT a.attname::text
+FROM pg_catalog.pg_attribute a
+  JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relname = $1 AND n.nspname = $2 AND a.attnum > 0 AND NOT a.attisdropped AND a.attgenerated <> ''
+ORDER BY a.attnum`
+
+// the target rejects these, so the target decides
+func (s *copyPassthroughMover) prepareTable(ctx context.Context, table *table) error {
+	if err := s.fallback.prepareTable(ctx, table); err != nil {
+		return err
+	}
+
+	rows, err := s.targetConn.Query(ctx, targetGeneratedColumnsQuery,
+		pglib.UnquoteIdentifier(table.name), pglib.UnquoteIdentifier(table.schema))
+	if err != nil {
+		return fmt.Errorf("getting target generated columns for %s.%s: %w", table.schema, table.name, err)
+	}
+	defer rows.Close()
+
+	var generated []string
+	for rows.Next() {
+		var column string
+		if err := rows.Scan(&column); err != nil {
+			return fmt.Errorf("scanning target generated column: %w", err)
+		}
+		generated = append(generated, column)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	copyable := withoutColumns(table.columns, generated)
+	if len(generated) > 0 && len(copyable) == 0 {
+		// every column is generated, so no COPY can carry the table's rows and
+		// the decoding path moves them. The reader's own column list is left
+		// alone: emptying it widens its query to every column, the generated
+		// ones included, which the target then rejects on insert.
+		table.decodeOnly = true
+		return nil
+	}
+
+	// prune what the strategy will select, so its query and the target COPY
+	// name the same columns: the mover no longer builds both statements
+	table.columns = copyable
+	return nil
+}
+
+func withoutColumns(columns, remove []string) []string {
+	if len(remove) == 0 {
+		return columns
+	}
+
+	removed := make(map[string]struct{}, len(remove))
+	for _, column := range remove {
+		removed[column] = struct{}{}
+	}
+
+	kept := make([]string, 0, len(columns))
+	for _, column := range columns {
+		if _, drop := removed[column]; !drop {
+			kept = append(kept, column)
+		}
+	}
+	return kept
+}
+
+func (s *copyPassthroughMover) close(ctx context.Context) error {
+	return errors.Join(s.targetConn.Close(ctx), s.fallback.close(ctx))
+}
+
+func (s *copyPassthroughMover) move(ctx context.Context, run runInTx, table *table, query string) (uint, error) {
+	// prepareTable found rows COPY cannot carry: the decoding path moves them,
+	// and reports its own progress through the sink
+	if table.decodeOnly {
+		return s.fallback.move(ctx, run, table, query)
+	}
+
+	// held outside the source tx, not inside it
+	if err := s.budget.Acquire(ctx, 1); err != nil {
+		return 0, fmt.Errorf("acquiring copy budget: %w", err)
+	}
+	defer s.budget.Release(1)
+
+	rowCount, err := s.copyChunkWithRetry(ctx, run, table, query)
+	if err != nil {
+		return rowCount, err
+	}
+
+	// the sink reports the bytes the decoding path moves; nothing reports this
+	// path's, so the mover does it here
+	s.progress.advance(table.schema, int64(rowCount)*table.rowSize)
+	return rowCount, nil
+}
+
+func (s *copyPassthroughMover) copyChunkWithRetry(ctx context.Context, run runInTx, table *table, query string) (uint, error) {
+	rowCount, err := s.copyChunk(ctx, run, table, query)
+	if err == nil || s.cfg.RetryPolicy.DisableRetries || !retriableCopyError(err) {
+		return rowCount, err
+	}
+
+	// a page range is re-runnable while the target transaction rolled back, and
+	// the source is read from the same exported snapshot. copyChunk marks the
+	// failures that land after the target commit permanent, so they never reach
+	// this loop.
+	err = s.backoffProvider(ctx).RetryNotify(func() error {
+		var retryErr error
+		rowCount, retryErr = s.copyChunk(ctx, run, table, query)
+		if retryErr != nil && !retriableCopyError(retryErr) {
+			return fmt.Errorf("%w: %w", retryErr, backoff.ErrPermanent)
+		}
+		return retryErr
+	}, func(err error, d time.Duration) {
+		s.logger.Warn(err, "retrying copy passthrough chunk", loglib.Fields{
+			"schema": table.schema, "table": table.name, "retry_delay": d.String(),
+		})
+	})
+	return rowCount, err
+}
+
+// an integrity assertion is not a transient failure
+func retriableCopyError(err error) bool {
+	return !errors.Is(err, backoff.ErrPermanent) && pglibretrier.IsRetriableError(err)
+}
+
+func (s *copyPassthroughMover) copyChunk(ctx context.Context, run runInTx, table *table, query string) (uint, error) {
+	var (
+		rowCount  uint
+		committed bool
+	)
+	err := run(ctx, func(tx pglib.Tx) error {
+		var err error
+		rowCount, err = s.copyChunkInTx(ctx, tx, table, query)
+		// the target transaction is nested in this one and commits before it,
+		// so a nil here means the rows are already durable on the target
+		committed = err == nil
+		return err
+	})
+	if err != nil && committed {
+		// the source transaction failed after the target had committed the
+		// range. Copying it again would write the same rows twice, which no
+		// row count assertion can see, so fail the table instead.
+		return rowCount, fmt.Errorf("%w: %w: %w", errChunkAlreadyCommitted, err, backoff.ErrPermanent)
+	}
+	return rowCount, err
+}
+
+// the pipe bounds memory
+func (s *copyPassthroughMover) copyChunkInTx(ctx context.Context, tx pglib.Tx, table *table, query string) (uint, error) {
+	sourceSQL := buildCopyToSQL(query)
+	targetSQL := buildCopyFromSQL(table)
+
+	s.logger.Trace("copy passthrough", loglib.Fields{
+		"schema": table.schema, "table": table.name,
+		"source_sql": sourceSQL, "target_sql": targetSQL,
+	})
+
+	pr, pw := io.Pipe()
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	var rowsOut atomic.Int64
+	eg.Go(func() error {
+		n, err := tx.CopyToWriter(egCtx, pw, sourceSQL)
+		if err != nil {
+			err = wrapChunkQueryError(err)
+		} else {
+			rowsOut.Store(n)
+		}
+		// unblocks a target awaiting rows
+		pw.CloseWithError(err)
+		return err
+	})
+
+	eg.Go(func() error {
+		err := s.targetConn.ExecInTx(egCtx, func(targetTx pglib.Tx) error {
+			if err := s.prepareTargetTx(egCtx, targetTx); err != nil {
+				return err
+			}
+			rowsIn, err := targetTx.CopyFromReader(egCtx, pr, targetSQL)
+			if err != nil {
+				return fmt.Errorf("copying rows into %s.%s: %w", table.schema, table.name, err)
+			}
+			if out := rowsOut.Load(); rowsIn != out {
+				return fmt.Errorf("%w: copied (%d), expected (%d): %w",
+					errUnexpectedCopiedRows, rowsIn, out, backoff.ErrPermanent)
+			}
+			return nil
+		})
+		// unblocks a source mid-write
+		pr.CloseWithError(err)
+		return err
+	})
+
+	if err := eg.Wait(); err != nil {
+		return 0, err
+	}
+
+	return uint(rowsOut.Load()), nil
+}
+
+// the strategy's own query, which must carry no bind parameters
+func buildCopyToSQL(query string) string {
+	return fmt.Sprintf("COPY (%s) TO STDOUT%s", query, copyFormat)
+}
+
+// survives target column reordering
+func buildCopyFromSQL(t *table) string {
+	target := pglib.QuoteQualifiedIdentifier(t.schema, t.name)
+	if len(t.columns) == 0 {
+		return fmt.Sprintf("COPY %s FROM STDIN%s", target, copyFormat)
+	}
+
+	quotedColumns := make([]string, len(t.columns))
+	for i, column := range t.columns {
+		quotedColumns[i] = pglib.QuoteRawIdentifier(column)
+	}
+	return fmt.Sprintf("COPY %s (%s) FROM STDIN%s", target, strings.Join(quotedColumns, ", "), copyFormat)
+}
+
+// bounds the wait, does not cap the copy
+const targetLockTimeout = "SET LOCAL lock_timeout = '30s'"
+
+// the bypassed writer did this
+func (s *copyPassthroughMover) prepareTargetTx(ctx context.Context, tx pglib.Tx) error {
+	if _, err := tx.Exec(ctx, targetLockTimeout); err != nil {
+		return fmt.Errorf("setting lock timeout on postgres target: %w", err)
+	}
+
+	if !s.cfg.DisableTriggers {
+		return nil
+	}
+
+	if _, err := tx.Exec(ctx, "SET LOCAL session_replication_role = replica"); err != nil {
+		return fmt.Errorf("disabling triggers on postgres target: %w", err)
+	}
+	return nil
+}

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_copy_passthrough_integration_test.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_copy_passthrough_integration_test.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/testcontainers"
+	"github.com/xataio/pgstream/pkg/snapshot"
+	"github.com/xataio/pgstream/pkg/wal"
+)
+
+func Test_PostgresSnapshotGenerator_copyPassthrough(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var sourceURL, targetURL string
+	sourceCleanup, err := testcontainers.SetupPostgresContainer(ctx, &sourceURL, testcontainers.Postgres17)
+	require.NoError(t, err)
+	defer sourceCleanup()
+	targetCleanup, err := testcontainers.SetupPostgresContainer(ctx, &targetURL, testcontainers.Postgres17)
+	require.NoError(t, err)
+	defer targetCleanup()
+
+	const testTable = "copy_passthrough_test"
+	schema := fmt.Sprintf(`CREATE TABLE %s (
+		id      int primary key,
+		label   text,
+		amount  numeric,
+		ts      timestamptz,
+		flags   bool[],
+		payload bytea
+	)`, testTable)
+	execQuery(t, ctx, sourceURL, schema)
+	// stands in for the schema snapshot
+	execQuery(t, ctx, targetURL, schema)
+
+	execQuery(t, ctx, sourceURL, fmt.Sprintf(`INSERT INTO %s VALUES
+		(1, 'plain',                 '10.25',  '2024-01-02 03:04:05+00', '{t,f}', '\x00ff'),
+		(2, E'tab\there',            '-0.001', '1999-12-31 23:59:59+00', '{}',    '\x'),
+		(3, E'newline\nand\rreturn', '0',      'infinity',               NULL,    NULL),
+		(4, E'back\\slash',          NULL,     '-infinity',              '{t}',   '\xdeadbeef'),
+		(5, '',                      '1e10',   '2024-06-01 12:00:00+00', '{f,f}', '\x0a0d09')`,
+		testTable))
+
+	// any event means it decoded instead
+	generator, err := NewSnapshotGenerator(ctx, &Config{
+		URL:             sourceURL,
+		CopyPassthrough: &CopyPassthroughConfig{TargetURL: targetURL},
+	}, &failingProcessor{t: t})
+	require.NoError(t, err)
+	defer generator.Close()
+
+	require.NoError(t, generator.CreateSnapshot(ctx, &snapshot.Snapshot{
+		SchemaTables: map[string][]string{"public": {testTable}},
+	}))
+
+	require.Equal(t,
+		readRowsAsText(t, ctx, sourceURL, testTable),
+		readRowsAsText(t, ctx, targetURL, testTable))
+}
+
+// pins what binary format relies on
+func Test_PostgresSnapshotGenerator_copyPassthrough_userDefinedTypes(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var sourceURL, targetURL string
+	sourceCleanup, err := testcontainers.SetupPostgresContainer(ctx, &sourceURL, testcontainers.Postgres17)
+	require.NoError(t, err)
+	defer sourceCleanup()
+	targetCleanup, err := testcontainers.SetupPostgresContainer(ctx, &targetURL, testcontainers.Postgres17)
+	require.NoError(t, err)
+	defer targetCleanup()
+
+	const testTable = "copy_passthrough_udt_test"
+	schema := fmt.Sprintf(`
+		CREATE TYPE mood AS ENUM ('sad','ok','happy');
+		CREATE TYPE addr AS (street text, num int);
+		CREATE DOMAIN pos AS int;
+		CREATE DOMAIN moodd AS mood;
+		CREATE TYPE numrng AS RANGE (subtype = numeric);
+		CREATE TABLE %s (
+			id        int primary key,
+			c_enum    mood,
+			c_enumarr mood[],
+			c_comp    addr,
+			c_comparr addr[],
+			c_domint  pos,
+			c_domenum moodd,
+			c_rng     numrng,
+			c_bltrng  numrange,
+			c_bltmrng nummultirange
+		)`, testTable)
+
+	execQuery(t, ctx, sourceURL, schema)
+	// the decoys shift every user-defined OID on the target
+	execQuery(t, ctx, targetURL, `CREATE TYPE decoy_enum AS ENUM ('a');
+		CREATE TYPE decoy_comp AS (x int);
+		CREATE DOMAIN decoy_dom AS text;
+		CREATE TYPE decoy_rng AS RANGE (subtype = int4);`)
+	execQuery(t, ctx, targetURL, schema)
+
+	require.NotEqual(t,
+		readTypeOID(t, ctx, sourceURL, "mood"),
+		readTypeOID(t, ctx, targetURL, "mood"),
+		"decoy types did not shift the target OIDs, so this test proves nothing")
+
+	execQuery(t, ctx, sourceURL, fmt.Sprintf(`INSERT INTO %s VALUES
+		(1, 'happy', '{sad,ok}',  ROW('main st', 2), ARRAY[ROW('main st', 2)::addr], 5, 'ok', '[1,2]', '[1,2]', '{[1,2]}'),
+		(2, 'sad',   '{}',        ROW(NULL, NULL),   '{}',                           0, NULL, 'empty', 'empty', '{}'),
+		(3, NULL,    NULL,        NULL,              NULL,                           NULL, NULL, NULL, NULL, NULL)`,
+		testTable))
+
+	generator, err := NewSnapshotGenerator(ctx, &Config{
+		URL: sourceURL,
+		// no explicit format: this must exercise the binary default
+		CopyPassthrough: &CopyPassthroughConfig{TargetURL: targetURL},
+	}, &failingProcessor{t: t})
+	require.NoError(t, err)
+	defer generator.Close()
+
+	require.NoError(t, generator.CreateSnapshot(ctx, &snapshot.Snapshot{
+		SchemaTables: map[string][]string{"public": {testTable}},
+	}))
+
+	require.Equal(t,
+		readRowsAsText(t, ctx, sourceURL, testTable),
+		readRowsAsText(t, ctx, targetURL, testTable))
+}
+
+// no COPY carries all-generated rows
+func Test_PostgresSnapshotGenerator_copyPassthrough_allGeneratedColumns(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var sourceURL, targetURL string
+	sourceCleanup, err := testcontainers.SetupPostgresContainer(ctx, &sourceURL, testcontainers.Postgres17)
+	require.NoError(t, err)
+	defer sourceCleanup()
+	targetCleanup, err := testcontainers.SetupPostgresContainer(ctx, &targetURL, testcontainers.Postgres17)
+	require.NoError(t, err)
+	defer targetCleanup()
+
+	const testTable = "copy_passthrough_all_generated_test"
+	schema := fmt.Sprintf("CREATE TABLE %s (only_generated int GENERATED ALWAYS AS (1) STORED)", testTable)
+	execQuery(t, ctx, sourceURL, schema)
+	execQuery(t, ctx, targetURL, schema)
+	execQuery(t, ctx, sourceURL, fmt.Sprintf("INSERT INTO %s DEFAULT VALUES", testTable))
+	execQuery(t, ctx, sourceURL, fmt.Sprintf("INSERT INTO %s DEFAULT VALUES", testTable))
+
+	rows := &countingProcessor{}
+	generator, err := NewSnapshotGenerator(ctx, &Config{
+		URL:             sourceURL,
+		CopyPassthrough: &CopyPassthroughConfig{TargetURL: targetURL},
+	}, rows)
+	require.NoError(t, err)
+	defer generator.Close()
+
+	require.NoError(t, generator.CreateSnapshot(ctx, &snapshot.Snapshot{
+		SchemaTables: map[string][]string{"public": {testTable}},
+	}))
+
+	// events prove it decoded instead
+	require.Equal(t, 2, rows.count())
+}
+
+type countingProcessor struct {
+	events atomic.Int64
+}
+
+func (p *countingProcessor) ProcessWALEvent(context.Context, *wal.Event) error {
+	p.events.Add(1)
+	return nil
+}
+
+func (p *countingProcessor) Close() error { return nil }
+func (p *countingProcessor) Name() string { return "countingProcessor" }
+func (p *countingProcessor) count() int   { return int(p.events.Load()) }
+
+func readTypeOID(t *testing.T, ctx context.Context, pgurl, typeName string) int {
+	t.Helper()
+
+	conn, err := pglib.NewConn(ctx, pgurl)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	var oid int
+	require.NoError(t, conn.QueryRow(ctx, []any{&oid}, "SELECT $1::regtype::oid::int", typeName))
+	return oid
+}
+
+type failingProcessor struct {
+	t *testing.T
+}
+
+func (p *failingProcessor) ProcessWALEvent(_ context.Context, event *wal.Event) error {
+	p.t.Errorf("copy passthrough emitted a wal event, so rows were decoded: %v", event)
+	return nil
+}
+
+func (p *failingProcessor) Close() error { return nil }
+func (p *failingProcessor) Name() string { return "failingProcessor" }
+
+// compares rows across two instances
+func readRowsAsText(t *testing.T, ctx context.Context, pgurl, tableName string) []string {
+	t.Helper()
+
+	conn, err := pglib.NewConn(ctx, pgurl)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	rows, err := conn.Query(ctx, fmt.Sprintf("SELECT (t.*)::text FROM %s t ORDER BY id", tableName))
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var row string
+		require.NoError(t, rows.Scan(&row))
+		out = append(out, row)
+	}
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, out, "no rows read from %s", tableName)
+	return out
+}

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_copy_passthrough_test.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_copy_passthrough_test.go
@@ -1,0 +1,570 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/postgres/mocks"
+	"github.com/xataio/pgstream/internal/progress"
+	progressmocks "github.com/xataio/pgstream/internal/progress/mocks"
+	synclib "github.com/xataio/pgstream/internal/sync"
+	"github.com/xataio/pgstream/pkg/backoff"
+	loglib "github.com/xataio/pgstream/pkg/log"
+)
+
+func TestBuildCopyToSQL(t *testing.T) {
+	t.Parallel()
+
+	// the strategy's query is wrapped verbatim, whatever selected the chunk
+	require.Equal(t,
+		`COPY (SELECT "id" FROM ONLY "public"."users" WHERE ctid BETWEEN '(0,0)' AND '(10,0)') TO STDOUT WITH (FORMAT binary)`,
+		buildCopyToSQL(`SELECT "id" FROM ONLY "public"."users" WHERE ctid BETWEEN '(0,0)' AND '(10,0)'`))
+	require.Equal(t,
+		`COPY (SELECT "id" FROM ONLY "public"."users" WHERE "id" > 42 ORDER BY "id" LIMIT 1000) TO STDOUT WITH (FORMAT binary)`,
+		buildCopyToSQL(`SELECT "id" FROM ONLY "public"."users" WHERE "id" > 42 ORDER BY "id" LIMIT 1000`))
+}
+
+func TestBuildCopyFromSQL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		table *table
+
+		want string
+	}{
+		{
+			name:  "columns are named so target column order is irrelevant",
+			table: &table{schema: "public", name: "users", columns: []string{"id", "name"}},
+			want:  `COPY "public"."users" ("id", "name") FROM STDIN WITH (FORMAT binary)`,
+		},
+		{
+			name:  "no columns omits the column list",
+			table: &table{schema: "public", name: "users"},
+			want:  `COPY "public"."users" FROM STDIN WITH (FORMAT binary)`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, buildCopyFromSQL(tc.table))
+		})
+	}
+}
+
+func TestCopyPassthroughMover_copyRange(t *testing.T) {
+	t.Parallel()
+
+	errSource := errors.New("source copy failed")
+	errTarget := errors.New("target copy failed")
+	testTable := &table{schema: "public", name: "users", columns: []string{"id"}}
+
+	newSourceTx := func(payload string, rows int64, sourceErr error) *mocks.Tx {
+		return &mocks.Tx{
+			CopyToWriterFn: func(_ context.Context, w io.Writer, _ string) (int64, error) {
+				if sourceErr != nil {
+					return -1, sourceErr
+				}
+				if _, err := io.WriteString(w, payload); err != nil {
+					return -1, err
+				}
+				return rows, nil
+			},
+		}
+	}
+
+	newTargetConn := func(rows int64, targetErr error, got *string) *mocks.Querier {
+		return &mocks.Querier{
+			ExecInTxFn: func(ctx context.Context, fn func(tx pglib.Tx) error) error {
+				return fn(&mocks.Tx{
+					ExecFn: func(context.Context, uint, string, ...any) (pglib.CommandTag, error) {
+						return pglib.CommandTag{}, nil
+					},
+					CopyFromReaderFn: func(_ context.Context, r io.Reader, _ string) (int64, error) {
+						if targetErr != nil {
+							return -1, targetErr
+						}
+						b, err := io.ReadAll(r)
+						if err != nil {
+							return -1, err
+						}
+						*got = string(b)
+						return rows, nil
+					},
+				})
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		sourceTx  *mocks.Tx
+		targetRow int64
+		targetErr error
+
+		wantRows    uint
+		wantPayload string
+		wantErr     error
+	}{
+		{
+			name:        "rows stream through unchanged",
+			sourceTx:    newSourceTx("1\n2\n3\n", 3, nil),
+			targetRow:   3,
+			wantRows:    3,
+			wantPayload: "1\n2\n3\n",
+		},
+		{
+			name:      "row count mismatch is reported",
+			sourceTx:  newSourceTx("1\n2\n3\n", 3, nil),
+			targetRow: 2,
+			wantErr:   errUnexpectedCopiedRows,
+		},
+		{
+			name:      "source failure surfaces",
+			sourceTx:  newSourceTx("", 0, errSource),
+			targetRow: 0,
+			wantErr:   errSource,
+		},
+		{
+			name:      "target failure surfaces and does not block the source",
+			sourceTx:  newSourceTx("1\n2\n3\n", 3, nil),
+			targetErr: errTarget,
+			wantErr:   errTarget,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got string
+			s := newTestCopyPassthrough(newTargetConn(tc.targetRow, tc.targetErr, &got), nil)
+
+			rows, err := s.copyChunkInTx(t.Context(), tc.sourceTx, testTable, "SELECT id FROM t")
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantRows, rows)
+			require.Equal(t, tc.wantPayload, got)
+		})
+	}
+}
+
+func TestCopyPassthroughMover_prepareTargetTx(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		disableTriggers bool
+
+		wantQueries []string
+	}{
+		{
+			name:            "triggers left alone by default",
+			disableTriggers: false,
+			wantQueries:     []string{targetLockTimeout},
+		},
+		{
+			name:            "triggers suppressed for the copy",
+			disableTriggers: true,
+			wantQueries: []string{
+				targetLockTimeout,
+				"SET LOCAL session_replication_role = replica",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var queries []string
+			tx := &mocks.Tx{
+				ExecFn: func(_ context.Context, _ uint, query string, _ ...any) (pglib.CommandTag, error) {
+					queries = append(queries, query)
+					return pglib.CommandTag{}, nil
+				},
+			}
+
+			s := &copyPassthroughMover{cfg: &CopyPassthroughConfig{DisableTriggers: tc.disableTriggers}}
+			require.NoError(t, s.prepareTargetTx(t.Context(), tx))
+			require.Equal(t, tc.wantQueries, queries)
+		})
+	}
+}
+
+func TestWithoutColumns(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{"id", "name"},
+		withoutColumns([]string{"id", "name"}, nil))
+	require.Equal(t, []string{"id", "name"},
+		withoutColumns([]string{"id", "name", "username", "slug"}, []string{"username", "slug"}))
+	require.Equal(t, []string{"id"},
+		withoutColumns([]string{"id"}, []string{"username"}))
+	// every column generated: nothing left for COPY to carry
+	require.Empty(t, withoutColumns([]string{"slug"}, []string{"slug"}))
+}
+
+func TestCopyPassthroughMover_snapshotRange_fallback(t *testing.T) {
+	t.Parallel()
+
+	copyable := &table{schema: "public", name: "users", columns: []string{"id"}}
+	// prepareTable marks the table; its columns stay, so the decoding path
+	// still selects them instead of widening to SELECT *
+	allGenerated := &table{schema: "public", name: "users", columns: []string{"slug"}, decodeOnly: true}
+
+	tests := []struct {
+		name  string
+		table *table
+
+		wantCopied   bool
+		wantFellBack bool
+	}{
+		{
+			name:       "copies the rows COPY can carry",
+			table:      copyable,
+			wantCopied: true,
+		},
+		{
+			name:         "delegates a table COPY cannot carry",
+			table:        allGenerated,
+			wantFellBack: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var copied bool
+			sourceTx := &mocks.Tx{
+				CopyToWriterFn: func(_ context.Context, w io.Writer, _ string) (int64, error) {
+					copied = true
+					_, err := io.WriteString(w, "1\n")
+					return 1, err
+				},
+			}
+			targetConn := &mocks.Querier{
+				ExecInTxFn: func(ctx context.Context, fn func(tx pglib.Tx) error) error {
+					return fn(&mocks.Tx{
+						ExecFn: func(context.Context, uint, string, ...any) (pglib.CommandTag, error) {
+							return pglib.CommandTag{}, nil
+						},
+						CopyFromReaderFn: func(_ context.Context, r io.Reader, _ string) (int64, error) {
+							if _, err := io.ReadAll(r); err != nil {
+								return -1, err
+							}
+							return 1, nil
+						},
+					})
+				},
+			}
+
+			fallback := &stubSnapshotter{}
+			s := newTestCopyPassthrough(targetConn, fallback)
+
+			run := func(ctx context.Context, fn func(tx pglib.Tx) error) error { return fn(sourceTx) }
+			_, err := s.move(t.Context(), run, tc.table, "SELECT id FROM t")
+			require.NoError(t, err)
+
+			require.Equal(t, tc.wantCopied, copied)
+			require.Equal(t, tc.wantFellBack, fallback.called)
+		})
+	}
+}
+
+func newTestCopyPassthrough(targetConn pglib.Querier, fallback chunkMover) *copyPassthroughMover {
+	return &copyPassthroughMover{
+		cfg:        &CopyPassthroughConfig{},
+		logger:     loglib.NewNoopLogger(),
+		targetConn: targetConn,
+		budget:     synclib.NewWeightedSemaphore(1),
+		fallback:   fallback,
+	}
+}
+
+type stubSnapshotter struct{ called bool }
+
+func (s *stubSnapshotter) prepareTable(context.Context, *table) error { return nil }
+func (s *stubSnapshotter) close(context.Context) error                { return nil }
+
+func (s *stubSnapshotter) move(context.Context, runInTx, *table, string) (uint, error) {
+	s.called = true
+	return 0, nil
+}
+
+// a retry must re-read the source, not resume a drained pipe
+func TestCopyPassthroughMover_snapshotRange_retries(t *testing.T) {
+	t.Parallel()
+
+	testTable := &table{schema: "public", name: "users", columns: []string{"id"}}
+	errRetriable := errors.New("connection reset by peer")
+
+	tests := []struct {
+		name      string
+		targetErr func(attempt int) error
+		targetRow func(attempt int) int64
+
+		wantAttempts int
+		wantErr      error
+	}{
+		{
+			name:         "a retriable failure copies the range again",
+			targetErr:    func(attempt int) error { return map[bool]error{true: errRetriable, false: nil}[attempt == 1] },
+			targetRow:    func(int) int64 { return 3 },
+			wantAttempts: 2,
+		},
+		{
+			name:         "a row count mismatch is not retried",
+			targetErr:    func(int) error { return nil },
+			targetRow:    func(int) int64 { return 2 },
+			wantAttempts: 1,
+			wantErr:      errUnexpectedCopiedRows,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var attempts int
+			var payloads []string
+			run := func(ctx context.Context, fn func(tx pglib.Tx) error) error {
+				attempts++
+				return fn(&mocks.Tx{
+					CopyToWriterFn: func(_ context.Context, w io.Writer, _ string) (int64, error) {
+						_, err := io.WriteString(w, "1\n2\n3\n")
+						return 3, err
+					},
+				})
+			}
+
+			s := newTestCopyPassthrough(&mocks.Querier{
+				ExecInTxFn: func(ctx context.Context, fn func(tx pglib.Tx) error) error {
+					return fn(&mocks.Tx{
+						ExecFn: func(context.Context, uint, string, ...any) (pglib.CommandTag, error) {
+							return pglib.CommandTag{}, nil
+						},
+						CopyFromReaderFn: func(_ context.Context, r io.Reader, _ string) (int64, error) {
+							b, readErr := io.ReadAll(r)
+							if readErr != nil {
+								return -1, readErr
+							}
+							payloads = append(payloads, string(b))
+							if err := tc.targetErr(attempts); err != nil {
+								return -1, err
+							}
+							return tc.targetRow(attempts), nil
+						},
+					})
+				},
+			}, nil)
+			s.backoffProvider = backoff.NewProvider(&backoff.Config{
+				Constant: &backoff.ConstantConfig{Interval: time.Millisecond, MaxRetries: 3},
+			})
+
+			_, err := s.move(t.Context(), run, testTable, "SELECT id FROM t")
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.wantAttempts, attempts)
+			// every attempt read the whole range, never a partial pipe
+			for _, payload := range payloads {
+				require.Equal(t, "1\n2\n3\n", payload)
+			}
+		})
+	}
+}
+
+func TestCopyPassthroughMover_prepareTable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		columns   []string
+		generated []string
+
+		wantColumns    []string
+		wantDecodeOnly bool
+	}{
+		{
+			name:        "nothing generated leaves the column list alone",
+			columns:     []string{"id", "name"},
+			wantColumns: []string{"id", "name"},
+		},
+		{
+			name:        "a generated column is pruned from what the strategy selects",
+			columns:     []string{"id", "name", "slug"},
+			generated:   []string{"slug"},
+			wantColumns: []string{"id", "name"},
+		},
+		{
+			// emptying the list would widen the reader's query to SELECT *, and
+			// the decoding path would then hand the writer the generated
+			// columns the target rejects
+			name:           "an all generated table keeps its columns and is decoded",
+			columns:        []string{"slug"},
+			generated:      []string{"slug"},
+			wantColumns:    []string{"slug"},
+			wantDecodeOnly: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := newTestCopyPassthrough(&mocks.Querier{
+				QueryFn: func(context.Context, uint, string, ...any) (pglib.Rows, error) {
+					return generatedColumnRows(t, tc.generated), nil
+				},
+			}, &stubSnapshotter{})
+
+			tbl := &table{schema: "public", name: "users", columns: append([]string(nil), tc.columns...)}
+			require.NoError(t, s.prepareTable(t.Context(), tbl))
+
+			require.Equal(t, tc.wantColumns, tbl.columns)
+			require.Equal(t, tc.wantDecodeOnly, tbl.decodeOnly)
+		})
+	}
+}
+
+// the target transaction is nested in the source one and commits first, so a
+// source failure landing after it must fail the range instead of copying it
+// again: nothing downstream can tell the duplicate rows apart
+func TestCopyPassthroughMover_move_sourceFailsAfterTargetCommit(t *testing.T) {
+	t.Parallel()
+
+	// retriable on its own, so only the commit ordering keeps it from retrying
+	errSourceCommit := errors.New("connection reset by peer")
+	testTable := &table{schema: "public", name: "users", columns: []string{"id"}}
+
+	attempts := 0
+	run := func(ctx context.Context, fn func(tx pglib.Tx) error) error {
+		attempts++
+		if err := fn(&mocks.Tx{
+			CopyToWriterFn: func(_ context.Context, w io.Writer, _ string) (int64, error) {
+				_, err := io.WriteString(w, "1\n")
+				return 1, err
+			},
+		}); err != nil {
+			return err
+		}
+		// the source transaction commits once the target's already has
+		return errSourceCommit
+	}
+
+	s := newTestCopyPassthrough(newStubTargetConn(1), nil)
+	s.backoffProvider = backoff.NewProvider(&backoff.Config{
+		Constant: &backoff.ConstantConfig{Interval: time.Millisecond, MaxRetries: 3},
+	})
+
+	_, err := s.move(t.Context(), run, testTable, "SELECT id FROM t")
+	require.ErrorIs(t, err, errChunkAlreadyCommitted)
+	require.ErrorIs(t, err, errSourceCommit)
+	require.Equal(t, 1, attempts)
+}
+
+// the sink reports the bytes the decoding path moves; the passthrough has no
+// sink, so without its own report the schema's bar never leaves zero
+func TestCopyPassthroughMover_move_progress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		table *table
+
+		wantAdvanced []int64
+	}{
+		{
+			name:         "the copied bytes advance the schema bar",
+			table:        &table{schema: "public", name: "users", columns: []string{"id"}, rowSize: 10},
+			wantAdvanced: []int64{30},
+		},
+		{
+			name:  "a delegated table is reported by the sink, not here",
+			table: &table{schema: "public", name: "users", columns: []string{"slug"}, rowSize: 10, decodeOnly: true},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var advanced []int64
+			tracker := progressTracker{enabled: true, bars: synclib.NewMap[string, progress.Bar]()}
+			tracker.set(tc.table.schema, &progressmocks.Bar{
+				Add64Fn: func(n int64) error {
+					advanced = append(advanced, n)
+					return nil
+				},
+			})
+
+			s := newTestCopyPassthrough(newStubTargetConn(3), &stubSnapshotter{})
+			s.progress = tracker
+
+			run := func(ctx context.Context, fn func(tx pglib.Tx) error) error {
+				return fn(&mocks.Tx{
+					CopyToWriterFn: func(_ context.Context, w io.Writer, _ string) (int64, error) {
+						_, err := io.WriteString(w, "1\n2\n3\n")
+						return 3, err
+					},
+				})
+			}
+
+			_, err := s.move(t.Context(), run, tc.table, "SELECT id FROM t")
+			require.NoError(t, err)
+			require.Equal(t, tc.wantAdvanced, advanced)
+		})
+	}
+}
+
+func newStubTargetConn(rows int64) *mocks.Querier {
+	return &mocks.Querier{
+		ExecInTxFn: func(ctx context.Context, fn func(tx pglib.Tx) error) error {
+			return fn(&mocks.Tx{
+				ExecFn: func(context.Context, uint, string, ...any) (pglib.CommandTag, error) {
+					return pglib.CommandTag{}, nil
+				},
+				CopyFromReaderFn: func(_ context.Context, r io.Reader, _ string) (int64, error) {
+					if _, err := io.ReadAll(r); err != nil {
+						return -1, err
+					}
+					return rows, nil
+				},
+			})
+		},
+	}
+}
+
+func generatedColumnRows(t *testing.T, columns []string) *mocks.Rows {
+	t.Helper()
+	return &mocks.Rows{
+		NextFn: func(i uint) bool { return i <= uint(len(columns)) },
+		ScanFn: func(i uint, dest ...any) error {
+			require.Len(t, dest, 1)
+			column, ok := dest[0].(*string)
+			require.True(t, ok, fmt.Sprintf("column, expected *string, got %T", dest[0]))
+			*column = columns[i-1]
+			return nil
+		},
+		ErrFn:   func() error { return nil },
+		CloseFn: func() {},
+	}
+}

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator.go
@@ -31,6 +31,8 @@ type SnapshotGenerator struct {
 	// reader encapsulates the strategy used to read a schema's tables (ctid
 	// range scan by default).
 	reader tableReader
+	// mover decides what becomes of the rows a reader selects
+	mover chunkMover
 	// instrumentation is captured while applying options and used to decorate
 	// the reader once it has been built.
 	instrumentation *otel.Instrumentation
@@ -74,6 +76,8 @@ type table struct {
 	rowSize int64
 	// one list per page range
 	columns []string
+	// set by the chunk mover: no COPY can carry this table's rows verbatim
+	decodeOnly bool
 }
 
 type Option func(sg *SnapshotGenerator)
@@ -101,7 +105,12 @@ func NewSnapshotGenerator(ctx context.Context, cfg *Config, processor processor.
 	}
 
 	sink := newRowSink(pglib.NewMapper(conn), sg.processor, sg.logger, sg.progress)
-	sg.reader = newTableReader(sg.conn, sg.logger, sink, cfg, sg.instrumentation)
+	mover, err := newChunkMover(ctx, cfg, sg.logger, sg.instrumentation, sg.progress, newDecodingMover(sink))
+	if err != nil {
+		return nil, errors.Join(err, conn.Close(ctx))
+	}
+	sg.mover = mover
+	sg.reader = newTableReader(sg.conn, sg.logger, mover, cfg, sg.instrumentation)
 
 	return sg, nil
 }
@@ -185,7 +194,8 @@ func (sg *SnapshotGenerator) CreateSnapshot(ctx context.Context, ss *snapshot.Sn
 }
 
 func (sg *SnapshotGenerator) Close() error {
-	return sg.conn.Close(context.Background())
+	ctx := context.Background()
+	return errors.Join(sg.conn.Close(ctx), sg.mover.close(ctx))
 }
 
 func (sg *SnapshotGenerator) createSchemaSnapshot(ctx context.Context, schemaTables *schemaTables) error {

--- a/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_test.go
+++ b/pkg/snapshot/generator/postgres/data/pg_snapshot_generator_test.go
@@ -1412,7 +1412,7 @@ func TestSnapshotGenerator_CreateSnapshot(t *testing.T) {
 				reader: &ctidReader{
 					conn:         tc.querier,
 					logger:       logger,
-					sink:         newRowSink(pglib.NewMapper(tc.querier), processor, loglib.NewNoopLogger(), pt),
+					mover:        newDecodingMover(newRowSink(pglib.NewMapper(tc.querier), processor, loglib.NewNoopLogger(), pt)),
 					tableWorkers: 1,
 					batchBytes:   1024 * 1024, // 1MB
 				},
@@ -2040,7 +2040,7 @@ func TestSnapshotGenerator_snapshotTableRange(t *testing.T) {
 					LogLevel: "debug",
 				})),
 				conn: tc.querier,
-				sink: newRowSink(pglib.NewMapper(tc.querier), &processormocks.Processor{
+				mover: newDecodingMover(newRowSink(pglib.NewMapper(tc.querier), &processormocks.Processor{
 					ProcessWALEventFn: func(ctx context.Context, walEvent *wal.Event) error {
 						if tc.processor != nil {
 							if err := tc.processor.ProcessWALEvent(ctx, walEvent); err != nil {
@@ -2050,7 +2050,7 @@ func TestSnapshotGenerator_snapshotTableRange(t *testing.T) {
 						eventChan <- walEvent
 						return nil
 					},
-				}, loglib.NewNoopLogger(), pt),
+				}, loglib.NewNoopLogger(), pt)),
 			}
 			session := &ctidSession{
 				reader:       reader,

--- a/pkg/snapshot/generator/postgres/data/table_reader.go
+++ b/pkg/snapshot/generator/postgres/data/table_reader.go
@@ -41,11 +41,11 @@ type readSession interface {
 // newTableReader builds the strategy used to read the snapshot tables and wraps
 // it with any active decorator. Picking between strategies belongs here, so
 // that the snapshot generator only ever sees a tableReader.
-func newTableReader(conn pglib.Querier, logger loglib.Logger, sink rowSink, cfg *Config, instrumentation *otel.Instrumentation) tableReader {
+func newTableReader(conn pglib.Querier, logger loglib.Logger, mover chunkMover, cfg *Config, instrumentation *otel.Instrumentation) tableReader {
 	var reader tableReader = &ctidReader{
 		conn:         conn,
 		logger:       logger,
-		sink:         sink,
+		mover:        mover,
 		tableWorkers: cfg.tableWorkers(),
 		batchBytes:   cfg.batchBytes(),
 	}

--- a/pkg/stream/config.go
+++ b/pkg/stream/config.go
@@ -12,6 +12,7 @@ import (
 	pglib "github.com/xataio/pgstream/internal/postgres"
 	"github.com/xataio/pgstream/pkg/backoff"
 	"github.com/xataio/pgstream/pkg/kafka"
+	pgsnapshotgenerator "github.com/xataio/pgstream/pkg/snapshot/generator/postgres/data"
 	kafkacheckpoint "github.com/xataio/pgstream/pkg/wal/checkpointer/kafka"
 	snapshotbuilder "github.com/xataio/pgstream/pkg/wal/listener/snapshot/builder"
 	"github.com/xataio/pgstream/pkg/wal/processor/filter"
@@ -246,6 +247,33 @@ func (c *Config) restoreConflictTargetsBeforeData() bool {
 	}
 	bw := c.Processor.Postgres.BatchWriter
 	return !bw.BulkIngestEnabled && strings.EqualFold(bw.OnConflictAction, "update")
+}
+
+// the chain is the authority on what reads rows
+func (c *Config) snapshotCopyPassthroughEligible(chain *processorChain) bool {
+	if c.Processor.Postgres == nil || !c.Processor.Postgres.BatchWriter.BulkIngestEnabled {
+		return false
+	}
+	if c.Listener.Postgres == nil || c.Listener.Postgres.Snapshot == nil || c.Listener.Postgres.Snapshot.Data == nil {
+		return false
+	}
+	return !chain.hasRowVisibleLayers()
+}
+
+// takes the bypassed writer's settings
+func (c *Config) applySnapshotCopyPassthrough(chain *processorChain) bool {
+	if !c.snapshotCopyPassthroughEligible(chain) {
+		return false
+	}
+
+	target := c.Processor.Postgres.BatchWriter
+	c.Listener.Postgres.Snapshot.Data.CopyPassthrough = &pgsnapshotgenerator.CopyPassthroughConfig{
+		TargetURL:       target.URL,
+		DisableTriggers: target.DisableTriggers,
+		MaxConnections:  target.MaxConnections,
+		RetryPolicy:     target.EffectiveRetryPolicy(),
+	}
+	return true
 }
 
 // applySnapshotRawJSONValues enables raw (text) decoding of json/jsonb values

--- a/pkg/stream/snapshot_copy_passthrough_test.go
+++ b/pkg/stream/snapshot_copy_passthrough_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package stream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	loglib "github.com/xataio/pgstream/pkg/log"
+	pgsnapshotgenerator "github.com/xataio/pgstream/pkg/snapshot/generator/postgres/data"
+	"github.com/xataio/pgstream/pkg/wal/listener/snapshot/builder"
+	"github.com/xataio/pgstream/pkg/wal/processor/filter"
+	"github.com/xataio/pgstream/pkg/wal/processor/mocks"
+	pgwriter "github.com/xataio/pgstream/pkg/wal/processor/postgres"
+	"github.com/xataio/pgstream/pkg/wal/processor/transformer"
+)
+
+// every row visible layer must block it
+func TestConfig_snapshotCopyPassthroughEligible_blockedByEveryModifier(t *testing.T) {
+	t.Parallel()
+
+	// injector is left out: injector.New dials the source
+	modifiers := map[string]func(*ProcessorConfig){
+		"transformer": func(c *ProcessorConfig) { c.Transformer = &transformer.Config{} },
+		"filter":      func(c *ProcessorConfig) { c.Filter = &filter.Config{IncludeTables: []string{"*"}} },
+		"sanitizer":   func(c *ProcessorConfig) { c.Sanitize = &SanitizeConfig{StripNullCharBytes: true} },
+	}
+
+	for name, enable := range modifiers {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			config := newPassthroughEligibleConfig()
+			enable(&config.Processor)
+
+			require.False(t, config.snapshotCopyPassthroughEligible(newTestChain(t, config)),
+				"%s must block the copy passthrough", name)
+		})
+	}
+}
+
+func TestConfig_snapshotCopyPassthroughEligible(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		build func(*Config)
+
+		want bool
+	}{
+		{
+			name:  "postgres target with bulk ingest and no modifiers",
+			build: func(*Config) {},
+			want:  true,
+		},
+		{
+			name:  "non postgres target",
+			build: func(c *Config) { c.Processor.Postgres = nil },
+		},
+		{
+			name:  "bulk ingest disabled",
+			build: func(c *Config) { c.Processor.Postgres.BatchWriter.BulkIngestEnabled = false },
+		},
+		{
+			name:  "no data snapshot configured",
+			build: func(c *Config) { c.Listener.Postgres.Snapshot.Data = nil },
+		},
+		{
+			name:  "a sanitizer that strips nothing is never wrapped",
+			build: func(c *Config) { c.Processor.Sanitize = &SanitizeConfig{} },
+			want:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			config := newPassthroughEligibleConfig()
+			tc.build(config)
+
+			require.Equal(t, tc.want, config.snapshotCopyPassthroughEligible(newTestChain(t, config)))
+		})
+	}
+}
+
+func TestConfig_applySnapshotCopyPassthrough(t *testing.T) {
+	t.Parallel()
+
+	t.Run("carries the target settings the writer would have applied", func(t *testing.T) {
+		t.Parallel()
+
+		config := newPassthroughEligibleConfig()
+		config.Processor.Postgres.BatchWriter.DisableTriggers = true
+		config.Processor.Postgres.BatchWriter.MaxConnections = 25
+
+		require.True(t, config.applySnapshotCopyPassthrough(newTestChain(t, config)))
+
+		require.Equal(t, &pgsnapshotgenerator.CopyPassthroughConfig{
+			TargetURL:       "postgresql://target",
+			DisableTriggers: true,
+			MaxConnections:  25,
+			RetryPolicy:     config.Processor.Postgres.BatchWriter.EffectiveRetryPolicy(),
+		}, config.Listener.Postgres.Snapshot.Data.CopyPassthrough)
+	})
+
+	t.Run("leaves the data snapshot alone when not eligible", func(t *testing.T) {
+		t.Parallel()
+
+		config := newPassthroughEligibleConfig()
+		config.Processor.Transformer = &transformer.Config{}
+
+		require.False(t, config.applySnapshotCopyPassthrough(newTestChain(t, config)))
+		require.Nil(t, config.Listener.Postgres.Snapshot.Data.CopyPassthrough)
+	})
+}
+
+// assembled the way the pipeline assembles it
+func newTestChain(t *testing.T, config *Config) *processorChain {
+	t.Helper()
+
+	chain, closer, err := addProcessorModifiers(t.Context(), config, loglib.NewNoopLogger(),
+		&mocks.Processor{}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, closer()) })
+	return chain
+}
+
+func newPassthroughEligibleConfig() *Config {
+	return &Config{
+		Listener: ListenerConfig{
+			Postgres: &PostgresListenerConfig{
+				// empty: a source url makes the transformer layer dial it
+				Snapshot: &builder.SnapshotListenerConfig{
+					Data: &pgsnapshotgenerator.Config{URL: "postgresql://source"},
+				},
+			},
+		},
+		Processor: ProcessorConfig{
+			Postgres: &PostgresProcessorConfig{
+				BatchWriter: pgwriter.Config{
+					URL:               "postgresql://target",
+					BulkIngestEnabled: true,
+				},
+			},
+		},
+	}
+}

--- a/pkg/stream/stream_run.go
+++ b/pkg/stream/stream_run.go
@@ -146,6 +146,7 @@ func Run(ctx context.Context, logger loglib.Logger, config *Config, init bool, i
 			}
 
 			config.applySnapshotRawJSONValues()
+			config.applySnapshotCopyPassthrough(snapshotChain)
 			snapshotGenerator, err := snapshotbuilder.NewSnapshotGenerator(
 				ctx,
 				config.Listener.Postgres.Snapshot,

--- a/pkg/stream/stream_snapshot.go
+++ b/pkg/stream/stream_snapshot.go
@@ -44,6 +44,7 @@ func Snapshot(ctx context.Context, logger loglib.Logger, config *Config, instrum
 	// Listener
 
 	config.applySnapshotRawJSONValues()
+	config.applySnapshotCopyPassthrough(chain)
 	snapshotGenerator, err := snapshotbuilder.NewSnapshotGenerator(
 		ctx,
 		config.Listener.Postgres.Snapshot,

--- a/pkg/wal/processor/postgres/config.go
+++ b/pkg/wal/processor/postgres/config.go
@@ -50,6 +50,9 @@ func (c *Config) retryPolicy() backoff.Config {
 	}
 }
 
+// EffectiveRetryPolicy returns the retry policy once the default is applied.
+func (c *Config) EffectiveRetryPolicy() backoff.Config { return c.retryPolicy() }
+
 func (c *Config) poolOptions() []pglib.PoolOption {
 	if c.MaxConnections == 0 {
 		return nil

--- a/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
+++ b/pkg/wal/processor/postgres/postgres_bulk_ingest_writer.go
@@ -27,14 +27,11 @@ type BulkIngestWriter struct {
 	// copyBudget caps the total number of concurrent COPYs across all tables
 	// (and all their send drainers) so they never exhaust the target
 	// connection pool. It is sized from the resolved pool max-connections
-	// value, minus copyBudgetReserve.
+	// value, minus synclib.CopyBudgetReserve.
 	copyBudget synclib.WeightedSemaphore
 }
 
 const bulkIngestWriter = "postgres_bulk_ingest_writer"
-
-// batch writer and retrier reset share this pool
-const copyBudgetReserve = 5
 
 var errUnexpectedCopiedRows = errors.New("number of rows copied doesn't match the source rows")
 
@@ -54,7 +51,7 @@ func NewBulkIngestWriter(ctx context.Context, config *Config, opts ...WriterOpti
 	biw := &BulkIngestWriter{
 		Writer:         w,
 		batchSenderMap: synclib.NewMap[string, queryBatchSender](),
-		copyBudget:     synclib.NewWeightedSemaphore(copyBudgetSize(w.maxConnections)),
+		copyBudget:     synclib.NewWeightedSemaphore(synclib.CopyBudgetSize(w.maxConnections)),
 	}
 
 	biw.batchSenderBuilder = func(ctx context.Context, schema, table string) (queryBatchSender, error) {
@@ -66,10 +63,6 @@ func NewBulkIngestWriter(ctx context.Context, config *Config, opts ...WriterOpti
 	}
 
 	return biw, nil
-}
-
-func copyBudgetSize(maxConnections int32) int64 {
-	return max(1, int64(maxConnections)-copyBudgetReserve)
 }
 
 // ProcessWALEvent is called on every new message from the wal. It can be called

--- a/pkg/wal/processor/postgres/postgres_bulk_ingest_writer_test.go
+++ b/pkg/wal/processor/postgres/postgres_bulk_ingest_writer_test.go
@@ -424,7 +424,7 @@ func TestBulkIngestWriter_sendBatch(t *testing.T) {
 					pgConn:          tc.pgConn,
 					disableTriggers: tc.disableTriggers,
 				},
-				copyBudget: synclib.NewWeightedSemaphore(pglib.MaxConns - copyBudgetReserve),
+				copyBudget: synclib.NewWeightedSemaphore(pglib.MaxConns - synclib.CopyBudgetReserve),
 			}
 
 			err := writer.sendBatch(context.Background(), tc.batch)
@@ -508,14 +508,14 @@ func TestCopyBudgetSize(t *testing.T) {
 	}{
 		{name: "default pool", maxConnections: pglib.MaxConns, expected: 45},
 		{name: "configured pool", maxConnections: 12, expected: 7},
-		{name: "reserve matches pool", maxConnections: copyBudgetReserve, expected: 1},
+		{name: "reserve matches pool", maxConnections: synclib.CopyBudgetReserve, expected: 1},
 		{name: "pool smaller than reserve", maxConnections: 2, expected: 1},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tt.expected, copyBudgetSize(tt.maxConnections))
+			require.Equal(t, tt.expected, synclib.CopyBudgetSize(tt.maxConnections))
 		})
 	}
 }
@@ -579,7 +579,7 @@ func TestNewBulkIngestWriter_maxConnections(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, tt.expectedObserver, observerPool.Config().MaxConns)
 
-			budget := copyBudgetSize(tt.expected)
+			budget := synclib.CopyBudgetSize(tt.expected)
 			for range budget {
 				require.True(t, writer.copyBudget.TryAcquire(1))
 			}


### PR DESCRIPTION
#### Description

This PR adds support for snapshotting a table by piping the source's `COPY ... TO STDOUT` straight into the target's `COPY ... FROM STDIN` when the rows do not need to be parsed. When a transformer, filter, injector or sanitizer is configured, we fall back to the previous behaviour.

Previously, we read read rows, decoded every value into Go values via pgx, wrapped them in `wal.Event` structs, passed them through the processor chain to the bulk ingest writer, which re-encoded them into a `COPY`. Both ends were already `COPY`; only the round trip through Go in the middle is removed. I measured improvement on ~17% on a text heavy table. It is a workload-specific improvement, since the saving is largest where decoding allocates most. So it can be higher for some cases.

<img width="1331" height="803" alt="Screenshot 2026-08-31 at 20-43-23 pgstream benchmarks" src="https://github.com/user-attachments/assets/cdd72e18-b45f-4ab0-a375-ccf5174cefa9" />

Furthermore, #801 (cube) and #1035 (enum) exist because pgx cannot produce those types' binary encodings, which is why `textOnlyCopyTypes` and `needsTextCopy` exist. Server-to-server COPY never touches a pgx codec, so that family of bugs cannot occur on this path.

Builds on the raw COPY stream primitives from #1126.

**Please review commit by commit.**

- **`feat: stream snapshot rows without decoding them`**: the new logic
- **`refactor: make the page range reader a strategy`**: `pg_snapshot_range_snapshotter.go` looks like a new file but is `processTableRange` relocated: three receiver renames and one inlined variable

#### Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

**Commit 1: the passthrough**

- The two COPYs run either side of an `io.Pipe`, so memory is bounded by the pipe rather than the page range, and each side closes its end with its error so neither can block on the other
- Binary format throughout
- Generated columns are named by neither end, taken from the **target's** catalog since the target is what rejects them. A table whose columns are all generated has nothing COPY can carry and falls back to decoding.

**Commit 2: the strategy extraction**

- Reading a page range becomes an interface with two implementations
- The reader is handed the transaction *runner* rather than a transaction, so one that must wait waits before the source transaction opens rather than holding a source connection idle in transaction
- Construction goes through `newSnapshotGenerator`, which takes the reader as an argument, so no path can leave it unset.

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary (no user-facing config surface)
