### PR TITLE
Fix create role check when database is empty

### DIFF
--- a/internal/postgres/pg_restore.go
+++ b/internal/postgres/pg_restore.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"regexp"
@@ -165,16 +166,63 @@ func tailOutput(out []byte, maxBytes int) string {
 	return "..." + redacted[len(redacted)-maxBytes:]
 }
 
-func RemoveDatabaseFromConnectionString(url string) (string, error) {
-	dbName, err := extractDatabase(url)
+// RemoveDatabaseFromConnectionString returns connString with the database
+// removed, so a connection made with it lands on the server's default database
+// instead of one that may not exist yet. The postgres maintenance database is
+// left in place, since it always exists.
+//
+// Connection strings come in two shapes and both are handled: a URL, whose
+// path is emptied, and a libpq key=value DSN, whose dbname keyword is dropped.
+// A DSN value quoted around a space (dbname='my db') is not recognised; libpq
+// permits it but nothing in pgstream produces one.
+func RemoveDatabaseFromConnectionString(connString string) (string, error) {
+	dbName, err := extractDatabase(connString)
 	if err != nil {
 		return "", err
 	}
 	if dbName == "" || dbName == postgres {
-		return url, nil
+		return connString, nil
 	}
 
-	return strings.ReplaceAll(url, "/"+dbName, "/"), nil
+	if strings.HasPrefix(connString, "postgres://") || strings.HasPrefix(connString, "postgresql://") {
+		return removeDatabaseFromURL(connString)
+	}
+	return removeDatabaseFromDSN(connString), nil
+}
+
+// removeDatabaseFromURL empties the path of a postgres URL. It parses rather
+// than substituting the database name textually, because that name also occurs
+// elsewhere in a connection string — most commonly as the user, since
+// `postgres://app:pw@host/app` is a routine shape — and a textual replacement
+// would strip it from there too.
+func removeDatabaseFromURL(rawURL string) (string, error) {
+	parsed, err := neturl.Parse(rawURL)
+	if err != nil {
+		// pgx tolerates unescaped characters in the password that net/url
+		// rejects; ParseConfig escapes them the same way before parsing.
+		escaped, escapeErr := escapeConnectionURL(rawURL)
+		if escapeErr != nil {
+			return "", fmt.Errorf("removing database from connection string: %w", escapeErr)
+		}
+		if parsed, err = neturl.Parse(escaped); err != nil {
+			return "", fmt.Errorf("removing database from connection string: %w", err)
+		}
+	}
+	parsed.Path = "/"
+	return parsed.String(), nil
+}
+
+// removeDatabaseFromDSN drops the dbname keyword from a libpq key=value DSN.
+func removeDatabaseFromDSN(dsn string) string {
+	fields := strings.Fields(dsn)
+	kept := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if strings.HasPrefix(field, "dbname=") {
+			continue
+		}
+		kept = append(kept, field)
+	}
+	return strings.Join(kept, " ")
 }
 
 func parsePgRestoreOutputErrs(out []byte) error {

--- a/internal/postgres/pg_restore_test.go
+++ b/internal/postgres/pg_restore_test.go
@@ -31,6 +31,26 @@ func TestRemoveDatabaseFromConnectionString(t *testing.T) {
 			connection: "postgres://pgstream:secret@localhost:5432/postgres?sslmode=disable",
 			want:       "postgres://pgstream:secret@localhost:5432/postgres?sslmode=disable",
 		},
+		{
+			name:       "user matching the database name is preserved",
+			connection: "postgres://app:secret@app.internal:5432/app?sslmode=disable",
+			want:       "postgres://app:secret@app.internal:5432/?sslmode=disable",
+		},
+		{
+			name:       "host matching the database name is preserved",
+			connection: "postgres://pgstream:secret@target_db:5432/target_db",
+			want:       "postgres://pgstream:secret@target_db:5432/",
+		},
+		{
+			name:       "no database to remove",
+			connection: "postgres://pgstream:secret@localhost:5432/",
+			want:       "postgres://pgstream:secret@localhost:5432/",
+		},
+		{
+			name:       "dsn database is removed",
+			connection: "host=localhost port=5432 user=app dbname=app sslmode=disable",
+			want:       "host=localhost port=5432 user=app sslmode=disable",
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/stream/preflight/access_test.go
+++ b/pkg/stream/preflight/access_test.go
@@ -948,3 +948,52 @@ func sequencePrivilegeRows(t *testing.T, rows []sourceSequenceSelectPrivilegeRow
 		ErrFn: func() error { return nil },
 	}
 }
+
+func TestTargetPrivilegeCheckURL(t *testing.T) {
+	t.Parallel()
+
+	const targetURL = "postgres://pgstream:secret@localhost:5432/target_db?sslmode=disable"
+
+	tests := []struct {
+		name           string
+		createTargetDB bool
+		want           string
+	}{
+		{
+			name: "existing target database is kept",
+			want: targetURL,
+		},
+		{
+			name:           "target database created by the snapshot is dropped",
+			createTargetDB: true,
+			want:           "postgres://pgstream:secret@localhost:5432/?sslmode=disable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &stream.Config{
+				Listener: stream.ListenerConfig{
+					Postgres: &stream.PostgresListenerConfig{
+						URL: "postgres://source",
+						Snapshot: &snapshotbuilder.SnapshotListenerConfig{
+							Schema: &snapshotbuilder.SchemaSnapshotConfig{
+								DumpRestore: &pgdumprestore.Config{
+									TargetPGURL:    targetURL,
+									CreateTargetDB: tc.createTargetDB,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			got, err := targetPrivilegeCheckURL(cfg)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/stream/preflight/access_test.go
+++ b/pkg/stream/preflight/access_test.go
@@ -949,24 +949,43 @@ func sequencePrivilegeRows(t *testing.T, rows []sourceSequenceSelectPrivilegeRow
 	}
 }
 
-func TestTargetPrivilegeCheckURL(t *testing.T) {
+func TestBuildAccessChecks_TargetPrivilegeChecks(t *testing.T) {
 	t.Parallel()
-
-	const targetURL = "postgres://pgstream:secret@localhost:5432/target_db?sslmode=disable"
 
 	tests := []struct {
 		name           string
+		targetURL      string
 		createTargetDB bool
-		want           string
+		rolesMode      string
+		wantCreateDB   bool
+		wantCreateRole bool
 	}{
 		{
-			name: "existing target database is kept",
-			want: targetURL,
+			name:           "both checks share the resolved target",
+			targetURL:      "postgres://pgstream:secret@localhost:5432/target_db",
+			createTargetDB: true,
+			rolesMode:      "enabled",
+			wantCreateDB:   true,
+			wantCreateRole: true,
 		},
 		{
-			name:           "target database created by the snapshot is dropped",
+			name:           "an unresolvable target still reports both checks",
+			targetURL:      "://not-a-url",
 			createTargetDB: true,
-			want:           "postgres://pgstream:secret@localhost:5432/?sslmode=disable",
+			rolesMode:      "enabled",
+			wantCreateDB:   true,
+			wantCreateRole: true,
+		},
+		{
+			name:           "roles only",
+			targetURL:      "postgres://pgstream:secret@localhost:5432/target_db",
+			rolesMode:      "enabled",
+			wantCreateRole: true,
+		},
+		{
+			name:           "no target url adds neither",
+			createTargetDB: true,
+			rolesMode:      "enabled",
 		},
 	}
 
@@ -981,8 +1000,9 @@ func TestTargetPrivilegeCheckURL(t *testing.T) {
 						Snapshot: &snapshotbuilder.SnapshotListenerConfig{
 							Schema: &snapshotbuilder.SchemaSnapshotConfig{
 								DumpRestore: &pgdumprestore.Config{
-									TargetPGURL:    targetURL,
-									CreateTargetDB: tc.createTargetDB,
+									TargetPGURL:       tc.targetURL,
+									CreateTargetDB:    tc.createTargetDB,
+									RolesSnapshotMode: tc.rolesMode,
 								},
 							},
 						},
@@ -990,8 +1010,72 @@ func TestTargetPrivilegeCheckURL(t *testing.T) {
 				},
 			}
 
-			got, err := targetPrivilegeCheckURL(cfg)
+			checks, cleanup := BuildAccessChecks(cfg)
+			require.NotNil(t, cleanup)
+			defer func() { require.NoError(t, cleanup(context.Background())) }()
 
+			var gotCreateDB, gotCreateRole bool
+			for _, check := range checks {
+				switch check.(type) {
+				case *TargetCreateDBPrivilegeCheck:
+					gotCreateDB = true
+				case *TargetCreateRolePrivilegeCheck:
+					gotCreateRole = true
+				}
+			}
+			require.Equal(t, tc.wantCreateDB, gotCreateDB)
+			require.Equal(t, tc.wantCreateRole, gotCreateRole)
+		})
+	}
+}
+
+func TestTargetPrivilegeCheckURL(t *testing.T) {
+	t.Parallel()
+
+	const targetURL = "postgres://pgstream:secret@localhost:5432/target_db?sslmode=disable"
+
+	tests := []struct {
+		name           string
+		targetURL      string
+		createTargetDB bool
+		want           string
+		wantErr        bool
+	}{
+		{
+			name:      "existing target database is kept",
+			targetURL: targetURL,
+			want:      targetURL,
+		},
+		{
+			name:           "target database created by the snapshot is dropped",
+			targetURL:      targetURL,
+			createTargetDB: true,
+			want:           "postgres://pgstream:secret@localhost:5432/?sslmode=disable",
+		},
+		{
+			name:           "user matching the target database name is kept",
+			targetURL:      "postgres://app:secret@app.internal:5432/app",
+			createTargetDB: true,
+			want:           "postgres://app:secret@app.internal:5432/",
+		},
+		{
+			name:           "unparseable url is reported",
+			targetURL:      "://not-a-url",
+			createTargetDB: true,
+			wantErr:        true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := targetPrivilegeCheckURL(tc.targetURL, tc.createTargetDB)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 			require.Equal(t, tc.want, got)
 		})

--- a/pkg/stream/preflight/builder.go
+++ b/pkg/stream/preflight/builder.go
@@ -136,37 +136,22 @@ func BuildAccessChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 
 	cleanups := []CleanupFunc{src.Close}
 
-	if cfg.SnapshotCreateTargetDB() {
-		if cfg.SnapshotTargetPostgresURL() != "" {
-			targetURL, err := targetPrivilegeCheckURL(cfg)
-			if err != nil {
-				checks = append(checks, &TargetCreateDBPrivilegeCheck{
-					Target: func(context.Context) (postgres.Querier, error) {
-						return nil, err
-					},
-				})
-				return checks, joinCleanups(cleanups)
-			}
-			target := postgres.NewLazyConn(targetURL)
-			checks = append(checks, &TargetCreateDBPrivilegeCheck{Target: target.Acquire})
+	createDB, restoreRoles := cfg.SnapshotCreateTargetDB(), cfg.SnapshotRestoresRoles()
+	if targetURL := cfg.SnapshotTargetPostgresURL(); targetURL != "" && (createDB || restoreRoles) {
+		// both checks ask the same cluster the same kind of question, so they
+		// resolve one connection string and share one connection
+		checkURL, err := targetPrivilegeCheckURL(targetURL, createDB)
+		acquire := func(context.Context) (postgres.Querier, error) { return nil, err }
+		if err == nil {
+			target := postgres.NewLazyConn(checkURL)
+			acquire = target.Acquire
 			cleanups = append(cleanups, target.Close)
 		}
-	}
-
-	if cfg.SnapshotRestoresRoles() {
-		if cfg.SnapshotTargetPostgresURL() != "" {
-			targetURL, err := targetPrivilegeCheckURL(cfg)
-			if err != nil {
-				checks = append(checks, &TargetCreateRolePrivilegeCheck{
-					Target: func(context.Context) (postgres.Querier, error) {
-						return nil, err
-					},
-				})
-				return checks, joinCleanups(cleanups)
-			}
-			target := postgres.NewLazyConn(targetURL)
-			checks = append(checks, &TargetCreateRolePrivilegeCheck{Target: target.Acquire})
-			cleanups = append(cleanups, target.Close)
+		if createDB {
+			checks = append(checks, &TargetCreateDBPrivilegeCheck{Target: acquire})
+		}
+		if restoreRoles {
+			checks = append(checks, &TargetCreateRolePrivilegeCheck{Target: acquire})
 		}
 	}
 
@@ -178,9 +163,8 @@ func BuildAccessChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 // so any database in the target cluster can answer the question. The
 // configured target database is only dropped from the connection string when
 // the snapshot creates it, since it does not exist yet at check time.
-func targetPrivilegeCheckURL(cfg *stream.Config) (string, error) {
-	targetURL := cfg.SnapshotTargetPostgresURL()
-	if !cfg.SnapshotCreateTargetDB() {
+func targetPrivilegeCheckURL(targetURL string, createTargetDB bool) (string, error) {
+	if !createTargetDB {
 		return targetURL, nil
 	}
 	return postgres.RemoveDatabaseFromConnectionString(targetURL)

--- a/pkg/stream/preflight/builder.go
+++ b/pkg/stream/preflight/builder.go
@@ -137,9 +137,8 @@ func BuildAccessChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 	cleanups := []CleanupFunc{src.Close}
 
 	if cfg.SnapshotCreateTargetDB() {
-		if targetURL := cfg.SnapshotTargetPostgresURL(); targetURL != "" {
-			var err error
-			targetURL, err = postgres.RemoveDatabaseFromConnectionString(targetURL)
+		if cfg.SnapshotTargetPostgresURL() != "" {
+			targetURL, err := targetPrivilegeCheckURL(cfg)
 			if err != nil {
 				checks = append(checks, &TargetCreateDBPrivilegeCheck{
 					Target: func(context.Context) (postgres.Querier, error) {
@@ -155,9 +154,8 @@ func BuildAccessChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 	}
 
 	if cfg.SnapshotRestoresRoles() {
-		if targetURL := cfg.SnapshotTargetPostgresURL(); targetURL != "" {
-			var err error
-			targetURL, err = postgres.RemoveDatabaseFromConnectionString(targetURL)
+		if cfg.SnapshotTargetPostgresURL() != "" {
+			targetURL, err := targetPrivilegeCheckURL(cfg)
 			if err != nil {
 				checks = append(checks, &TargetCreateRolePrivilegeCheck{
 					Target: func(context.Context) (postgres.Querier, error) {
@@ -173,6 +171,19 @@ func BuildAccessChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 	}
 
 	return checks, joinCleanups(cleanups)
+}
+
+// targetPrivilegeCheckURL returns the connection string the target privilege
+// checks connect to. CREATEDB and CREATEROLE are cluster wide role attributes,
+// so any database in the target cluster can answer the question. The
+// configured target database is only dropped from the connection string when
+// the snapshot creates it, since it does not exist yet at check time.
+func targetPrivilegeCheckURL(cfg *stream.Config) (string, error) {
+	targetURL := cfg.SnapshotTargetPostgresURL()
+	if !cfg.SnapshotCreateTargetDB() {
+		return targetURL, nil
+	}
+	return postgres.RemoveDatabaseFromConnectionString(targetURL)
 }
 
 // BuildSchemaChecks returns the schema-preflight checks applicable to cfg,


### PR DESCRIPTION
#### Description

`pgstream check` stripped the database from the target connection string before running `target_createrole_privilege`, so the check connected with no database and Postgres fell back to the connecting role name:

```
database "testuser" does not exist
```

Stripping is only needed when the snapshot creates the target database, since only then can the configured database be missing at check time.

The second commit is a follow-up. Dropping the database was done by textual substitution, `strings.ReplaceAll(url, "/"+dbName, "/")`. But the database name also occurs elsewhere in a connection string, most often as the user, so `postgres://app:secret@app.internal/app` became `postgres://:secret@app.internal/`, silently connecting as no user at all. That path is reached by `pg_restore --create` as well as by these checks.

##### Related Issue(s)

- Fixes #1133

#### Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

#### Changes Made

- Keep the configured target database in the connection string for the CREATEDB/CREATEROLE preflight checks unless `create_target_db` is set.
- Replace the textual database substitution in `RemoveDatabaseFromConnectionString` with URL parsing, and drop the `dbname` keyword for key=value DSNs, which were previously not stripped at all.

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed