### PR TITLE
Add support for `timetz`

### DIFF
--- a/internal/postgres/pg_utils.go
+++ b/internal/postgres/pg_utils.go
@@ -205,6 +205,11 @@ var extensionTypes = []extensionType{
 	}},
 	{name: "cube", register: registerWithCodec("cube", pgtype.TextCodec{})},
 	{name: "ltree", register: registerWithCodec("ltree", pgtype.TextCodec{})},
+
+	// timetz is a core type rather than an extension one, but pgx ships no
+	// codec for it, so it needs the same treatment: without an entry here pgx
+	// cannot encode it and the preflight schema check reports it as unknown.
+	{name: "timetz", register: registerWithCodec("timetz", pgtype.TextCodec{})},
 }
 
 // ExtensionTypeNames returns the names of every postgres extension type

--- a/internal/postgres/pg_utils.go
+++ b/internal/postgres/pg_utils.go
@@ -205,10 +205,6 @@ var extensionTypes = []extensionType{
 	}},
 	{name: "cube", register: registerWithCodec("cube", pgtype.TextCodec{})},
 	{name: "ltree", register: registerWithCodec("ltree", pgtype.TextCodec{})},
-
-	// timetz is a core type rather than an extension one, but pgx ships no
-	// codec for it, so it needs the same treatment: without an entry here pgx
-	// cannot encode it and the preflight schema check reports it as unknown.
 	{name: "timetz", register: registerWithCodec("timetz", pgtype.TextCodec{})},
 }
 

--- a/pkg/stream/integration/snapshot_pg_integration_test.go
+++ b/pkg/stream/integration/snapshot_pg_integration_test.go
@@ -818,6 +818,116 @@ func Test_SnapshotToPostgres_CircularDependencyView(t *testing.T) {
 	require.Equal(t, []idNameRow{{id: 1, name: "a"}, {id: 2, name: "b"}}, rows)
 }
 
+// Test_SnapshotToPostgres_TimetzColumns verifies that snapshot/restore
+// preserves timetz column values end-to-end. timetz shares the root cause of
+// cube (#801) and ltree (#834): pgx registers no codec for it, so the
+// preflight schema check reports it as an unknown type and binary COPY writes
+// the text representation into a binary field, which the server reads as an
+// int64 microsecond count and rejects with "time out of range".
+func Test_SnapshotToPostgres_TimetzColumns(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	var snapshotPGURL string
+	pgcleanup, err := testcontainers.SetupPostgresContainer(context.Background(), &snapshotPGURL, testcontainers.Postgres14, "config/postgresql.conf")
+	require.NoError(t, err)
+	defer pgcleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	run := func(suffix string, opts ...option) {
+		testTable := fmt.Sprintf("timetz_columns_%s", suffix)
+
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+			`CREATE TABLE %s(
+				id       INTEGER PRIMARY KEY,
+				start_at timetz NOT NULL,
+				end_at   timetz
+			)`, testTable))
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+			`INSERT INTO %s(id, start_at, end_at) VALUES
+				(1, '12:34:56.789+02', '23:59:59.999999-07:30'),
+				(2, '00:00:00+00', NULL),
+				(3, '24:00:00+14', '08:15:00-05')`,
+			testTable))
+
+		cfg := &stream.Config{
+			Listener:  testPostgresListenerCfgWithSnapshot(snapshotPGURL, targetPGURL, []string{"*.*"}),
+			Processor: testPostgresProcessorCfg(opts...),
+		}
+		initStream(t, ctx, snapshotPGURL)
+		runSnapshot(t, ctx, cfg)
+
+		targetConn, err := pglib.NewConn(ctx, targetPGURL)
+		require.NoError(t, err)
+		sourceConn, err := pglib.NewConn(ctx, snapshotPGURL)
+		require.NoError(t, err)
+
+		timer := time.NewTimer(20 * time.Second)
+		defer timer.Stop()
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		type row struct {
+			id      int
+			startAt string
+			endAt   *string
+		}
+		query := fmt.Sprintf("SELECT id, start_at::text, end_at::text FROM %s ORDER BY id", testTable)
+		fetch := func(conn pglib.Querier) ([]row, error) {
+			rows, err := conn.Query(ctx, query)
+			if err != nil {
+				return nil, err
+			}
+			defer rows.Close()
+			out := []row{}
+			for rows.Next() {
+				var r row
+				if err := rows.Scan(&r.id, &r.startAt, &r.endAt); err != nil {
+					return nil, err
+				}
+				out = append(out, r)
+			}
+			return out, rows.Err()
+		}
+
+		want, err := fetch(sourceConn)
+		require.NoError(t, err)
+		require.Len(t, want, 3)
+
+		validation := func() bool {
+			got, err := fetch(targetConn)
+			if err != nil || len(got) != len(want) {
+				return false
+			}
+			require.Equal(t, want, got)
+			return true
+		}
+
+		for {
+			select {
+			case <-timer.C:
+				cancel()
+				t.Error("timeout waiting for postgres snapshot sync of timetz columns")
+				return
+			case <-ticker.C:
+				if validation() {
+					return
+				}
+			}
+		}
+	}
+
+	t.Run("bulk ingest", func(t *testing.T) {
+		run("bulk", withBulkIngestionEnabled())
+	})
+	t.Run("batch writer", func(t *testing.T) {
+		run("batch")
+	})
+}
+
 // Test_SnapshotToPostgres_IdentityAndGeneratedColumns verifies that identity
 // columns have their values preserved while generated (stored) columns are
 // correctly excluded from inserts and recomputed by the target database.

--- a/pkg/stream/integration/snapshot_pg_integration_test.go
+++ b/pkg/stream/integration/snapshot_pg_integration_test.go
@@ -854,7 +854,7 @@ func Test_SnapshotToPostgres_TimetzColumns(t *testing.T) {
 			testTable))
 
 		cfg := &stream.Config{
-			Listener:  testPostgresListenerCfgWithSnapshot(snapshotPGURL, targetPGURL, []string{"*.*"}),
+			Listener:  testPostgresListenerCfgWithSnapshot(snapshotPGURL, targetPGURL, []string{testTable}),
 			Processor: testPostgresProcessorCfg(opts...),
 		}
 		initStream(t, ctx, snapshotPGURL)

--- a/pkg/stream/preflight/schema_test.go
+++ b/pkg/stream/preflight/schema_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
 	"github.com/xataio/pgstream/internal/postgres"
@@ -102,6 +103,27 @@ func TestSchemaTypeCompatibilityCheck_Run_PgstreamExtraTypesPass(t *testing.T) {
 	require.Len(t, findings, 1)
 	require.Contains(t, findings[0].Message, `"public"."t"."g"`)
 	require.Contains(t, findings[0].Message, `type "geometry"`)
+}
+
+func TestSchemaTypeCompatibilityCheck_Run_TimetzPasses(t *testing.T) {
+	t.Parallel()
+
+	// timetz is a core postgres type, but pgx's static type map has no codec
+	// for it, so the check has to recognise the codec pgstream registers for
+	// it instead. Its array variant is still unsupported.
+	check := &SchemaTypeCompatibilityCheck{
+		Source: sourceWithColumns(t, []schemaColumnRow{
+			{Schema: "public", Table: "t", Column: "start_at", BaseOID: int64(pgtype.TimetzOID), TypeName: "timetz", TypeKind: "b"},
+			{Schema: "public", Table: "t", Column: "windows", BaseOID: int64(pgtype.TimetzArrayOID), TypeName: "_timetz", TypeKind: "b"},
+		}),
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	require.Contains(t, findings[0].Message, `"public"."t"."windows"`)
+	require.Contains(t, findings[0].Message, `type "_timetz"`)
 }
 
 func TestPgstreamSupportedTypesMatchesRegistry(t *testing.T) {

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
@@ -486,8 +486,9 @@ func getTypedInt8Range(value any) any {
 // can't produce correctly, so bulk ingest must fall back to text-format
 // COPY for any batch that touches one of these columns.
 var textOnlyCopyTypes = map[string]struct{}{
-	"cube":  {}, // binary header: int32 dim+flags + N×float8 — pgx writes the text rep, server misreads it as a dimension count
-	"ltree": {}, // binary format: 1-byte version + path string — pgx writes the text rep, server reads byte 0 as the version number
+	"cube":   {}, // binary header: int32 dim+flags + N×float8 — pgx writes the text rep, server misreads it as a dimension count
+	"ltree":  {}, // binary format: 1-byte version + path string — pgx writes the text rep, server reads byte 0 as the version number
+	"timetz": {}, // binary format: int64 microseconds + int32 UTC offset — pgx writes the text rep, server reads its first 8 bytes as the microsecond count and errors with "time out of range"
 }
 
 func needsTextCopy(columnTypes []string) bool {

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
@@ -486,9 +486,10 @@ func getTypedInt8Range(value any) any {
 // can't produce correctly, so bulk ingest must fall back to text-format
 // COPY for any batch that touches one of these columns.
 var textOnlyCopyTypes = map[string]struct{}{
-	"cube":   {}, // binary header: int32 dim+flags + N×float8 — pgx writes the text rep, server misreads it as a dimension count
-	"ltree":  {}, // binary format: 1-byte version + path string — pgx writes the text rep, server reads byte 0 as the version number
-	"timetz": {}, // binary format: int64 microseconds + int32 UTC offset — pgx writes the text rep, server reads its first 8 bytes as the microsecond count and errors with "time out of range"
+	"cube":                {}, // binary header: int32 dim+flags + N×float8 — pgx writes the text rep, server misreads it as a dimension count
+	"ltree":               {}, // binary format: 1-byte version + path string — pgx writes the text rep, server reads byte 0 as the version number
+	"timetz":              {}, // binary format: int64 microseconds + int32 UTC offset — pgx writes the text rep, server reads its first 8 bytes as the microsecond count and errors with "time out of range"
+	"time with time zone": {}, // format_type spelling of the timetz. Only the "timetz" key is reachable
 }
 
 func needsTextCopy(columnTypes []string) bool {

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter_test.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter_test.go
@@ -940,6 +940,13 @@ func Test_needsTextCopyForColumns(t *testing.T) {
 			want:        true,
 		},
 		{
+			name:        "timetz column",
+			columnNames: []string{`"id"`, `"start_at"`},
+			columnTypes: []string{"integer", "timetz"},
+			enumColumns: nil,
+			want:        true,
+		},
+		{
 			name:        "enum column",
 			columnNames: []string{`"id"`, `"mood"`},
 			columnTypes: []string{"integer", "mood"},

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter_test.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter_test.go
@@ -947,6 +947,13 @@ func Test_needsTextCopyForColumns(t *testing.T) {
 			want:        true,
 		},
 		{
+			name:        "timetz column, format_type spelling",
+			columnNames: []string{`"id"`, `"start_at"`},
+			columnTypes: []string{"integer", "time with time zone"},
+			enumColumns: nil,
+			want:        true,
+		},
+		{
 			name:        "enum column",
 			columnNames: []string{`"id"`, `"mood"`},
 			columnTypes: []string{"integer", "mood"},


### PR DESCRIPTION
#### Description

Tables with a `timetz` (`time with time zone`) column were rejected up front by the `schema_type_compatibility` preflight check with `type "timetz" unknown type`.

The allowlist was only half the problem. pgx defines `TimetzOID` but registers no codec for it, so bypassing the check would have failed the snapshot anyway: binary COPY writes the value's text representation into a binary `timetz` field, and the server rejects it with `copy from: data exception: time out of range`. Both halves are fixed here.

#### Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

##### Related Issue(s)

- Fixes #1132

#### Changes Made

- Register `pgtype.TextCodec` for `timetz` on every connection
- Add `timetz` to `textOnlyCopyTypes` so batches touching such a column route through text-format COPY instead of binary, under both the `typname` spelling and the `format_type` spelling `time with time zone`.

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
