### PR TITLE
Retry index restore on transient errors

### DIFF
--- a/internal/postgres/errors.go
+++ b/internal/postgres/errors.go
@@ -65,6 +65,17 @@ func (e *ErrDataException) Error() string {
 	return fmt.Sprintf("data exception: %s", e.Details)
 }
 
+// ErrTransientFailure reports a failure that is not caused by the statement
+// being restored, such as a dropped connection or a lock that could not be
+// acquired in time. The same statement can succeed if it is run again.
+type ErrTransientFailure struct {
+	Details string
+}
+
+func (e *ErrTransientFailure) Error() string {
+	return fmt.Sprintf("transient failure: %s", e.Details)
+}
+
 type ErrRelationAlreadyExists struct {
 	Details string
 }

--- a/internal/postgres/pg_restore.go
+++ b/internal/postgres/pg_restore.go
@@ -352,14 +352,70 @@ func parseErrorLine(line string) error {
 		return &ErrPermissionDenied{Details: line}
 	case strings.Contains(line, "does not exist"):
 		return &ErrRelationDoesNotExist{Details: line}
+	case isTransientErrorLine(line):
+		return &ErrTransientFailure{Details: line}
 	default:
 		return errors.New(line)
 	}
 }
 
+// transientErrorFragments are lowercased fragments of the messages postgres and
+// its client tools emit for failures that are unrelated to the statement being
+// restored: a connection that dropped, a server that is not accepting queries
+// yet, or a lock that could not be taken. Rerunning the statement is the only
+// way to tell whether the condition has cleared.
+//
+// Fragments that a permanent failure can also produce are deliberately absent.
+// A statement timeout, for instance, reads like a transient cancellation but
+// recurs on every attempt when the statement is simply too slow, and
+// "out of shared memory" recurs until the server is reconfigured.
+var transientErrorFragments = []string{
+	"broken pipe",
+	"canceling statement due to conflict with recovery",
+	"canceling statement due to lock timeout",
+	"connection reset by peer",
+	"connection timed out",
+	"connection to server at",
+	"connection to server was lost",
+	"could not connect to server",
+	"could not obtain lock on",
+	"could not receive data from server",
+	"could not send data to server",
+	"could not serialize access",
+	"deadlock detected",
+	"eof detected",
+	"is not yet accepting connections",
+	"no connection to the server",
+	"remaining connection slots are reserved",
+	"server closed the connection unexpectedly",
+	"sorry, too many clients already",
+	"ssl connection has been closed unexpectedly",
+	"ssl syscall error",
+	"terminating connection due to administrator command",
+	"terminating connection due to unexpected postmaster exit",
+	"the database system is in recovery mode",
+	"the database system is shutting down",
+	"the database system is starting up",
+	"timeout expired",
+}
+
+// isTransientErrorLine is checked only after the permanent classifications
+// above, so that a connection failure reporting a permanent cause — a missing
+// database, say — keeps the classification of that cause.
+func isTransientErrorLine(line string) bool {
+	lowered := strings.ToLower(line)
+	for _, fragment := range transientErrorFragments {
+		if strings.Contains(lowered, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
 type PGRestoreErrors struct {
-	ignoredErrs  []error
-	criticalErrs []error
+	ignoredErrs   []error
+	criticalErrs  []error
+	retryableErrs []error
 }
 
 func NewPGRestoreErrors(errs ...error) *PGRestoreErrors {
@@ -371,23 +427,41 @@ func NewPGRestoreErrors(errs ...error) *PGRestoreErrors {
 }
 
 func (e PGRestoreErrors) Error() string {
-	if len(e.criticalErrs) == 0 && len(e.ignoredErrs) == 0 {
+	if !e.HasErrors() {
 		return ""
 	}
 
-	return errors.Join(append(e.criticalErrs, e.ignoredErrs...)...).Error()
+	all := make([]error, 0, len(e.criticalErrs)+len(e.retryableErrs)+len(e.ignoredErrs))
+	all = append(all, e.criticalErrs...)
+	all = append(all, e.retryableErrs...)
+	all = append(all, e.ignoredErrs...)
+	return errors.Join(all...).Error()
 }
 
 func (e PGRestoreErrors) HasErrors() bool {
-	return len(e.criticalErrs) > 0 || len(e.ignoredErrs) > 0
+	return len(e.criticalErrs) > 0 || len(e.retryableErrs) > 0 || len(e.ignoredErrs) > 0
 }
 
+// HasCriticalErrors reports whether the restore hit an error that must not be
+// swallowed. Transient errors count as critical: a caller that does not retry
+// has to surface them rather than treat the restore as complete.
 func (e *PGRestoreErrors) HasCriticalErrors() bool {
-	return len(e.criticalErrs) > 0
+	return len(e.criticalErrs) > 0 || len(e.retryableErrs) > 0
+}
+
+// IsRetryable reports whether every error that failed the restore is transient,
+// which is the only case where rerunning the same dump can produce a different
+// outcome.
+func (e *PGRestoreErrors) IsRetryable() bool {
+	return len(e.criticalErrs) == 0 && len(e.retryableErrs) > 0
 }
 
 func (e *PGRestoreErrors) GetIgnoredErrors() []error {
 	return e.ignoredErrs
+}
+
+func (e *PGRestoreErrors) GetRetryableErrors() []error {
+	return e.retryableErrs
 }
 
 func (e *PGRestoreErrors) addError(err error) {
@@ -400,6 +474,7 @@ func (e *PGRestoreErrors) addError(err error) {
 	var errPermissionDenied *ErrPermissionDenied
 	var errDoesNotExist *ErrRelationDoesNotExist
 	var errCommentOwnership *ErrCommentOwnership
+	var errTransient *ErrTransientFailure
 	switch {
 	case errors.As(err, &errAlreadyExists),
 		errors.As(err, &errConstraintViolation),
@@ -407,6 +482,8 @@ func (e *PGRestoreErrors) addError(err error) {
 		errors.As(err, &errDoesNotExist),
 		errors.As(err, &errCommentOwnership):
 		e.ignoredErrs = append(e.ignoredErrs, err)
+	case errors.As(err, &errTransient):
+		e.retryableErrs = append(e.retryableErrs, err)
 	default:
 		e.criticalErrs = append(e.criticalErrs, err)
 	}

--- a/internal/postgres/pg_restore_test.go
+++ b/internal/postgres/pg_restore_test.go
@@ -613,9 +613,47 @@ func TestParseErrorLine(t *testing.T) {
 			wantErr: &ErrRelationAlreadyExists{Details: `ERROR:  "linking_queue_000" is already a partition`},
 		},
 		{
+			name:    "connection lost",
+			line:    `psql: error: connection to server was lost`,
+			wantErr: &ErrTransientFailure{Details: `psql: error: connection to server was lost`},
+		},
+		{
+			name:    "server closed the connection",
+			line:    "pg_restore: error: could not execute query: server closed the connection unexpectedly",
+			wantErr: &ErrTransientFailure{Details: "pg_restore: error: could not execute query: server closed the connection unexpectedly"},
+		},
+		{
+			name:    "lock timeout",
+			line:    `ERROR:  canceling statement due to lock timeout`,
+			wantErr: &ErrTransientFailure{Details: `ERROR:  canceling statement due to lock timeout`},
+		},
+		{
+			name:    "deadlock",
+			line:    `ERROR:  deadlock detected`,
+			wantErr: &ErrTransientFailure{Details: `ERROR:  deadlock detected`},
+		},
+		{
+			name:    "connection refused",
+			line:    `psql: error: connection to server at "localhost" (::1), port 5432 failed: Connection refused`,
+			wantErr: &ErrTransientFailure{Details: `psql: error: connection to server at "localhost" (::1), port 5432 failed: Connection refused`},
+		},
+		{
+			// a connection failure that reports a permanent cause keeps the
+			// classification of that cause, so it is not retried
+			name:    "connection failure with a permanent cause",
+			line:    `psql: error: connection to server at "localhost" (::1), port 5432 failed: FATAL:  database "test" does not exist`,
+			wantErr: &ErrRelationDoesNotExist{Details: `psql: error: connection to server at "localhost" (::1), port 5432 failed: FATAL:  database "test" does not exist`},
+		},
+		{
+			// retrying a statement that is simply too slow times out again
+			name:    "statement timeout",
+			line:    `ERROR:  canceling statement due to statement timeout`,
+			wantErr: errors.New(`ERROR:  canceling statement due to statement timeout`),
+		},
+		{
 			name:    "generic error",
-			line:    "pg_restore: error: connection failed",
-			wantErr: errors.New("pg_restore: error: connection failed"),
+			line:    "pg_restore: error: unrecognized data block type",
+			wantErr: errors.New("pg_restore: error: unrecognized data block type"),
 		},
 	}
 
@@ -623,7 +661,70 @@ func TestParseErrorLine(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := parseErrorLine(tt.line)
 			require.NotNil(t, err)
-			require.ErrorAs(t, err, &tt.wantErr)
+			require.IsType(t, tt.wantErr, err)
+			require.Equal(t, tt.wantErr.Error(), err.Error())
+		})
+	}
+}
+
+func TestPGRestoreErrors_classification(t *testing.T) {
+	t.Parallel()
+
+	errCritical := errors.New("oh noes")
+	errIgnored := &ErrRelationAlreadyExists{Details: "relation exists"}
+	errTransient := &ErrTransientFailure{Details: "connection to server was lost"}
+
+	tests := []struct {
+		name string
+		errs []error
+
+		wantCritical  bool
+		wantRetryable bool
+		wantIgnored   int
+	}{
+		{
+			name: "no errors",
+			errs: nil,
+		},
+		{
+			name:        "ignored only",
+			errs:        []error{errIgnored},
+			wantIgnored: 1,
+		},
+		{
+			name:          "transient only",
+			errs:          []error{errTransient},
+			wantCritical:  true,
+			wantRetryable: true,
+		},
+		{
+			name:          "transient alongside ignored",
+			errs:          []error{errTransient, errIgnored},
+			wantCritical:  true,
+			wantRetryable: true,
+			wantIgnored:   1,
+		},
+		{
+			name:         "transient alongside critical",
+			errs:         []error{errTransient, errCritical},
+			wantCritical: true,
+		},
+		{
+			name:         "critical only",
+			errs:         []error{errCritical},
+			wantCritical: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			errs := NewPGRestoreErrors(tt.errs...)
+			require.Equal(t, len(tt.errs) > 0, errs.HasErrors())
+			require.Equal(t, tt.wantCritical, errs.HasCriticalErrors())
+			require.Equal(t, tt.wantRetryable, errs.IsRetryable())
+			require.Len(t, errs.GetIgnoredErrors(), tt.wantIgnored)
 		})
 	}
 }

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator.go
@@ -14,9 +14,11 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	pglib "github.com/xataio/pgstream/internal/postgres"
 	pglibinstrumentation "github.com/xataio/pgstream/internal/postgres/instrumentation"
+	"github.com/xataio/pgstream/pkg/backoff"
 	loglib "github.com/xataio/pgstream/pkg/log"
 	"github.com/xataio/pgstream/pkg/otel"
 	"github.com/xataio/pgstream/pkg/snapshot"
@@ -56,6 +58,12 @@ type SnapshotGenerator struct {
 	// events instead of running a psql/pg_restore session.
 	indexConstraintSessionSettings []string
 	objectTypeFilter               *objectTypeFilter
+	// indexRestoreBackoff provides the retry policy for index and constraint
+	// restores that fail with transient errors, such as a connection dropped by
+	// an intermittent network fault. Rerunning the dump is safe because objects
+	// created by an earlier attempt fail with "already exists", which the
+	// restore ignores.
+	indexRestoreBackoff backoff.Provider
 }
 
 type snapshotProgressTracker interface {
@@ -91,6 +99,11 @@ type Config struct {
 	// Session settings in name=value format applied only while restoring indexes
 	// and constraints. An empty list preserves the existing behavior.
 	IndexConstraintSessionSettings []string
+	// IndexRestoreRetries is the retry policy applied when restoring indexes
+	// and constraints fails with a transient error. If not set, it defaults to
+	// exponential backoff with an initial interval of 1s, a max interval of
+	// 1min and 3 retries.
+	IndexRestoreRetries backoff.Config
 	// IncludeObjectTypes is a list of object type categories to include in the
 	// schema snapshot. Only one of IncludeObjectTypes or ExcludeObjectTypes
 	// can be set.
@@ -110,6 +123,28 @@ type Config struct {
 var sessionSettingRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_.]*=\S+$`)
 
 var errInvalidSessionSetting = errors.New("invalid index constraint session setting, must be a whitespace-free name=value pair")
+
+const (
+	defaultIndexRestoreRetryInitialInterval = time.Second
+	defaultIndexRestoreRetryMaxInterval     = time.Minute
+	defaultIndexRestoreMaxRetries           = 3
+)
+
+func (c *Config) indexRestoreBackoffConfig() *backoff.Config {
+	if c.IndexRestoreRetries.DisableRetries {
+		return &backoff.Config{}
+	}
+	if c.IndexRestoreRetries.IsSet() {
+		return &c.IndexRestoreRetries
+	}
+	return &backoff.Config{
+		Exponential: &backoff.ExponentialConfig{
+			InitialInterval: defaultIndexRestoreRetryInitialInterval,
+			MaxInterval:     defaultIndexRestoreRetryMaxInterval,
+			MaxRetries:      defaultIndexRestoreMaxRetries,
+		},
+	}
+}
 
 func validateSessionSettings(settings []string) error {
 	for _, setting := range settings {
@@ -175,6 +210,7 @@ func NewSnapshotGenerator(ctx context.Context, c *Config, opts ...Option) (*Snap
 		refreshMaterializedViews:       c.RefreshMaterializedViews,
 		indexConstraintSessionSettings: c.IndexConstraintSessionSettings,
 		objectTypeFilter:               objTypeFilter,
+		indexRestoreBackoff:            backoff.NewProvider(c.indexRestoreBackoffConfig()),
 	}
 
 	for _, opt := range opts {
@@ -433,10 +469,65 @@ func (s *SnapshotGenerator) restoreIndicesAndConstraints(ctx context.Context, du
 	s.logger.Info("restoring schema indices and constraints", loglib.Fields{"schemaTables": ss.SchemaTables})
 	opts := s.optionGenerator.pgrestoreOptions()
 	opts.SessionSettings = s.indexConstraintSessionSettings
+
+	retries := 0
+	var restoreErr error
+	bo := s.indexRestoreBackoffProvider()(ctx)
+	err := bo.RetryNotify(
+		func() error {
+			restoreErr = s.restoreIndices(ctx, opts, dump)
+			return asRetryError(restoreErr)
+		},
+		func(err error, d time.Duration) {
+			retries++
+			s.logger.Warn(err, "restoring schema indices and constraints failed with a transient error, retrying", loglib.Fields{
+				"retries": retries,
+				"backoff": d,
+			})
+		})
+	if err == nil {
+		return nil
+	}
+	// the backoff wraps the failure in its own retry bookkeeping, so report the
+	// restore failure itself, unless the retries were cut short by the context
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if restoreErr != nil {
+		return restoreErr
+	}
+	return err
+}
+
+// indexRestoreBackoffProvider falls back to a provider that does not retry, so
+// that a generator built without going through NewSnapshotGenerator keeps the
+// single-attempt behaviour instead of panicking on a nil provider.
+func (s *SnapshotGenerator) indexRestoreBackoffProvider() backoff.Provider {
+	if s.indexRestoreBackoff != nil {
+		return s.indexRestoreBackoff
+	}
+	return func(context.Context) backoff.Backoff { return backoff.NewStopBackoff() }
+}
+
+func (s *SnapshotGenerator) restoreIndices(ctx context.Context, opts pglib.PGRestoreOptions, dump []byte) error {
 	if s.snapshotTracker != nil {
 		return s.restoreIndicesWithTracking(ctx, opts, dump)
 	}
 	return s.restoreDumpWithOptions(ctx, opts, dump)
+}
+
+// asRetryError marks any error that rerunning the dump cannot resolve as
+// permanent, so that the backoff gives up immediately instead of repeating a
+// restore that is guaranteed to fail the same way.
+func asRetryError(err error) error {
+	if err == nil {
+		return nil
+	}
+	pgrestoreErr := &pglib.PGRestoreErrors{}
+	if errors.As(err, &pgrestoreErr) && pgrestoreErr.IsRetryable() {
+		return err
+	}
+	return fmt.Errorf("%w: %w", err, backoff.ErrPermanent)
 }
 
 func (s *SnapshotGenerator) Close() error {

--- a/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
+++ b/pkg/snapshot/generator/postgres/schema/pgdumprestore/snapshot_pg_dump_restore_generator_test.go
@@ -9,10 +9,12 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	pglib "github.com/xataio/pgstream/internal/postgres"
 	"github.com/xataio/pgstream/internal/postgres/mocks"
+	"github.com/xataio/pgstream/pkg/backoff"
 	"github.com/xataio/pgstream/pkg/log"
 	"github.com/xataio/pgstream/pkg/snapshot"
 	"github.com/xataio/pgstream/pkg/snapshot/generator"
@@ -2478,4 +2480,122 @@ func TestWarnOnCaptureDrift(t *testing.T) {
 			require.Equal(t, tc.wantWarn, len(logger.warnings) > 0, "warnings: %v", logger.warnings)
 		})
 	}
+}
+
+func TestSnapshotGenerator_restoreIndicesAndConstraints(t *testing.T) {
+	t.Parallel()
+
+	errTest := errors.New("oh noes")
+	indexDump := []byte("CREATE INDEX a;\n\n")
+	transientErr := func() error {
+		return pglib.NewPGRestoreErrors(&pglib.ErrTransientFailure{
+			Details: "psql: error: connection to server was lost",
+		})
+	}
+
+	tests := []struct {
+		name string
+		// restoreErrs holds the error returned by each restore attempt. Once
+		// the list is exhausted, the last entry is returned again.
+		restoreErrs []error
+
+		wantAttempts int
+		wantErr      error
+	}{
+		{
+			name:         "ok",
+			restoreErrs:  []error{nil},
+			wantAttempts: 1,
+			wantErr:      nil,
+		},
+		{
+			name:         "ok - transient error cleared on retry",
+			restoreErrs:  []error{transientErr(), nil},
+			wantAttempts: 2,
+			wantErr:      nil,
+		},
+		{
+			name:         "ok - ignored errors are not retried",
+			restoreErrs:  []error{pglib.NewPGRestoreErrors(&pglib.ErrRelationAlreadyExists{})},
+			wantAttempts: 1,
+			wantErr:      nil,
+		},
+		{
+			name:         "error - transient error outlasts the retries",
+			restoreErrs:  []error{transientErr()},
+			wantAttempts: 3,
+			wantErr:      transientErr(),
+		},
+		{
+			name:         "error - critical error is not retried",
+			restoreErrs:  []error{pglib.NewPGRestoreErrors(errTest)},
+			wantAttempts: 1,
+			wantErr:      pglib.NewPGRestoreErrors(errTest),
+		},
+		{
+			name:         "error - critical error alongside a transient one is not retried",
+			restoreErrs:  []error{pglib.NewPGRestoreErrors(errTest, &pglib.ErrTransientFailure{})},
+			wantAttempts: 1,
+			wantErr:      pglib.NewPGRestoreErrors(errTest, &pglib.ErrTransientFailure{}),
+		},
+		{
+			name:         "error - unparsed restore error is not retried",
+			restoreErrs:  []error{errTest},
+			wantAttempts: 1,
+			wantErr:      errTest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			attempts := 0
+			sg := SnapshotGenerator{
+				targetURL:       "target-url",
+				logger:          log.NewNoopLogger(),
+				optionGenerator: &optionGenerator{targetURL: "target-url"},
+				pgRestoreFn: func(_ context.Context, _ pglib.PGRestoreOptions, dump []byte) (string, error) {
+					require.Equal(t, string(indexDump), string(dump))
+					attempts++
+					if attempts > len(tc.restoreErrs) {
+						return "", tc.restoreErrs[len(tc.restoreErrs)-1]
+					}
+					return "", tc.restoreErrs[attempts-1]
+				},
+				indexRestoreBackoff: backoff.NewProvider(&backoff.Config{
+					Constant: &backoff.ConstantConfig{
+						Interval:   time.Millisecond,
+						MaxRetries: 2,
+					},
+				}),
+			}
+
+			err := sg.restoreIndicesAndConstraints(context.Background(), indexDump, &snapshot.Snapshot{})
+			if !errors.Is(err, tc.wantErr) {
+				require.Equal(t, tc.wantErr, err)
+			}
+			require.Equal(t, tc.wantAttempts, attempts)
+		})
+	}
+}
+
+func TestSnapshotGenerator_restoreIndicesAndConstraints_noBackoffProvider(t *testing.T) {
+	t.Parallel()
+
+	indexDump := []byte("CREATE INDEX a;\n\n")
+	attempts := 0
+	sg := SnapshotGenerator{
+		targetURL:       "target-url",
+		logger:          log.NewNoopLogger(),
+		optionGenerator: &optionGenerator{targetURL: "target-url"},
+		pgRestoreFn: func(_ context.Context, _ pglib.PGRestoreOptions, _ []byte) (string, error) {
+			attempts++
+			return "", pglib.NewPGRestoreErrors(&pglib.ErrTransientFailure{})
+		},
+	}
+
+	err := sg.restoreIndicesAndConstraints(context.Background(), indexDump, &snapshot.Snapshot{})
+	require.Error(t, err)
+	require.Equal(t, 1, attempts)
 }


### PR DESCRIPTION
#### Description

Index and constraint restore during a schema snapshot treated every `pg_restore` failure the same way: anything not recognised as already-exists, does-not-exist, permission or constraint became a critical error and aborted the whole snapshot. A dropped connection, a server still coming up, or a lock that could not be taken in time therefore lost a snapshot that a second attempt would have completed.

This PR distinguishes transient failures from permanent ones and retries the index and constraint restore when retrying can change the outcome.

I added `pglib.ErrTransientFailure` and classified restore output against a fragment list covering dropped/refused connections, SSL/EOF/broken pipe, a server starting up or in recovery, connection-slot exhaustion, lock timeout, `could not obtain lock`, deadlock and serialization failure. The check runs after the existing permanent classifications, so `connection to server ... failed: FATAL: database "x" does not exist` keeps its does-not-exist classification instead of being retried forever. Fragments a permanent failure can also produce (statement timeout, out of shared memory) are excluded.

The policy defaults to exponential backoff: 1s initial, 1min max, 3 retries. It is not exposed in the YAML or environment configuration.

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Gave `PGRestoreErrors` a third bucket alongside ignored and critical, plus `IsRetryable()` and `GetRetryableErrors()`. `HasCriticalErrors()` still reports true for transient-only failures, so the restore phases that do not retry (schema, roles, sequences, views) keep surfacing them.
- `restoreIndicesAndConstraints` now runs under a backoff, repeating only when every error that failed the restore is transient.

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
