### PR TITLE
Support numeric columns in transformers

### DIFF
--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -384,9 +384,14 @@ transformations:
 
 **Description:** Generates random or deterministic floating-point numbers within a specified range.
 
-| Supported PostgreSQL types |
-| -------------------------- |
-| `real`, `double precision` |
+| Supported PostgreSQL types            |
+| ------------------------------------- |
+| `real`, `double precision`, `numeric` |
+⚠️ On a `numeric` column `min_value` and `max_value` are **required**. Their defaults span the whole `float32` range, which produces the same out-of-range constant for every row .
+
+A `numeric` value is converted to a `float64` before it seeds the generator, and the generated value is a `float64` too, so a `numeric` column is anonymized within float64's range: values beyond it are clamped, and values beyond float64's significand are rounded. Only the seed is affected, since the original is discarded.
+
+On a `numeric(p,s)` column the configured range is checked against the column when the rules are validated, so a range that cannot fit fails the run. An unconstrained `numeric` accepts any value, so nothing is checked there beyond the bounds being set.
 
 | Parameter | Type   | Default                                       | Required | Values               |
 | --------- | ------ | --------------------------------------------- | -------- | -------------------- |
@@ -401,9 +406,9 @@ transformations:
 
 **Description:** Generates random or deterministic integers within a specified range.
 
-| Supported PostgreSQL types     |
-| ------------------------------ |
-| `smallint`,`integer`, `bigint` |
+| Supported PostgreSQL types                                             |
+| ---------------------------------------------------------------------- |
+| `smallint`, `integer`, `bigint`, `real`, `double precision`, `numeric` |
 
 | Parameter | Type   | Default     | Required | Values               |
 | --------- | ------ | ----------- | -------- | -------------------- |
@@ -470,9 +475,9 @@ transformations:
 
 **Description:** Generates random or deterministic unix timestamps.
 
-| Supported PostgreSQL types    |
-| ----------------------------- |
-| `smallint`,`integer`,`bigint` |
+| Supported PostgreSQL types                                             |
+| ---------------------------------------------------------------------- |
+| `smallint`, `integer`, `bigint`, `real`, `double precision`, `numeric` |
 
 | Parameter | Type   | Default | Required | Values               |
 | --------- | ------ | ------- | -------- | -------------------- |

--- a/pkg/stream/integration/helper_test.go
+++ b/pkg/stream/integration/helper_test.go
@@ -292,6 +292,12 @@ func withBulkIngestionEnabled() option {
 	}
 }
 
+func withTransformerRules(rules []transformer.TableRules) option {
+	return func(cfg *stream.ProcessorConfig) {
+		cfg.Transformer = &transformer.Config{TransformerRules: rules}
+	}
+}
+
 func testPostgresListenerCfgWithSnapshotAndFilter(sourceURL, targetURL string, tables []string, includeObjectTypes []string) stream.ListenerConfig {
 	cfg := testPostgresListenerCfgWithSnapshot(sourceURL, targetURL, tables)
 	cfg.Postgres.Snapshot.Schema.DumpRestore.IncludeObjectTypes = includeObjectTypes

--- a/pkg/stream/integration/pg_pg_integration_transformer_test.go
+++ b/pkg/stream/integration/pg_pg_integration_transformer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	pglib "github.com/xataio/pgstream/internal/postgres"
 	"github.com/xataio/pgstream/pkg/stream"
+	"github.com/xataio/pgstream/pkg/wal/processor/transformer"
 )
 
 type transformerTestTableRow struct {
@@ -238,4 +239,123 @@ func validateRows(t *testing.T, ctx context.Context, conn *pglib.Conn, expectedR
 		require.NotEmpty(t, row.address, "text column")
 	}
 	return true
+}
+
+// Test_PostgresToPostgres_NumericTransformer covers the replication half of
+// numeric support. wal2json renders a whole numeric as a JSON integer and the
+// listener decodes those as int64, so a numeric column reaches the transformer
+// as an int64 here and as a pgtype.Numeric during a snapshot. A transformer
+// that only accepts the snapshot shape rejects the value, and the default
+// on_error policy then nulls the column rather than failing the run, so
+// nothing but an assertion on the target catches it.
+func Test_PostgresToPostgres_NumericTransformer(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	testTable := "pg2pg_integration_numeric_transformer_test"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	createTable := fmt.Sprintf(
+		`CREATE TABLE %s(
+			id      serial PRIMARY KEY,
+			amount  numeric,
+			lat     numeric(9,6),
+			dbl     double precision
+		)`, testTable)
+	execQuery(t, ctx, createTable)
+	// this pipeline has no injector, so DDL is not replicated; the target
+	// table has to exist before the first row arrives
+	execQueryWithURL(t, ctx, targetPGURL, createTable)
+
+	rules := []transformer.TableRules{{
+		Schema: "public",
+		Table:  testTable,
+		ColumnRules: map[string]transformer.TransformerRules{
+			"amount": {Name: "greenmask_float", Parameters: map[string]any{
+				"generator": "deterministic", "min_value": 0.0, "max_value": 1000.0,
+			}},
+			"lat": {Name: "greenmask_float", Parameters: map[string]any{
+				"generator": "deterministic", "min_value": -90.0, "max_value": 90.0, "precision": 6,
+			}},
+			"dbl": {Name: "greenmask_float", Parameters: map[string]any{
+				"generator": "deterministic", "min_value": 0.0, "max_value": 1000.0,
+			}},
+		},
+	}}
+
+	cfg := &stream.Config{
+		Listener:  testPostgresListenerCfg(t),
+		Processor: testPostgresProcessorCfg(withTransformerRules(rules)),
+	}
+	runStream(t, ctx, cfg)
+
+	// whole numbers on purpose: wal2json emits those unquoted, which is the
+	// shape that used to be rejected. Row 2 mixes in fractional values.
+	execQuery(t, ctx, fmt.Sprintf(
+		`INSERT INTO %s(id, amount, lat, dbl) VALUES
+			(1, 1234, 51, 1000),
+			(2, 1234.5678, 51.507351, 1000.5)`, testTable))
+
+	targetConn, err := pglib.NewConn(ctx, targetPGURL)
+	require.NoError(t, err)
+	defer targetConn.Close(ctx)
+
+	type row struct {
+		id     int
+		amount *float64
+		lat    *float64
+		dbl    *float64
+	}
+	query := fmt.Sprintf("SELECT id, amount, lat, dbl FROM %s ORDER BY id", testTable)
+
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	var got []row
+	for got == nil {
+		select {
+		case <-timer.C:
+			t.Fatal("timeout waiting for replicated numeric columns")
+		case <-ticker.C:
+			rows, err := targetConn.Query(ctx, query)
+			if err != nil {
+				continue
+			}
+			out := []row{}
+			for rows.Next() {
+				var r row
+				if err := rows.Scan(&r.id, &r.amount, &r.lat, &r.dbl); err != nil {
+					break
+				}
+				out = append(out, r)
+			}
+			rows.Close()
+			if len(out) == 2 {
+				got = out
+			}
+		}
+	}
+
+	for _, r := range got {
+		// a rejected value is nulled by the default on_error policy, so a nil
+		// here is the exact regression this test exists for
+		require.NotNil(t, r.amount, "row %d: amount was nulled, the transformer rejected the replicated value", r.id)
+		require.NotNil(t, r.lat, "row %d: lat was nulled, the transformer rejected the replicated value", r.id)
+		require.NotNil(t, r.dbl, "row %d: dbl was nulled, the transformer rejected the replicated value", r.id)
+
+		require.GreaterOrEqual(t, *r.amount, 0.0)
+		require.LessOrEqual(t, *r.amount, 1000.0)
+		require.GreaterOrEqual(t, *r.lat, -90.0)
+		require.LessOrEqual(t, *r.lat, 90.0)
+		require.GreaterOrEqual(t, *r.dbl, 0.0)
+		require.LessOrEqual(t, *r.dbl, 1000.0)
+	}
+	// the source values must not survive untransformed
+	require.NotEqual(t, 1234.0, *got[0].amount)
+	require.NotEqual(t, 51.0, *got[0].lat)
 }

--- a/pkg/stream/integration/snapshot_pg_integration_test.go
+++ b/pkg/stream/integration/snapshot_pg_integration_test.go
@@ -13,6 +13,7 @@ import (
 	pglib "github.com/xataio/pgstream/internal/postgres"
 	"github.com/xataio/pgstream/internal/testcontainers"
 	"github.com/xataio/pgstream/pkg/stream"
+	"github.com/xataio/pgstream/pkg/wal/processor/transformer"
 )
 
 func Test_SnapshotToPostgres(t *testing.T) {
@@ -925,6 +926,147 @@ func Test_SnapshotToPostgres_TimetzColumns(t *testing.T) {
 	})
 	t.Run("batch writer", func(t *testing.T) {
 		run("batch")
+	})
+}
+
+// Test_SnapshotToPostgres_NumericColumnTransformer verifies that a numeric
+// column can be transformed end to end. numeric has no entry in the
+// transformer type compatibility map, so any rule on such a column used to be
+// rejected up front with "does not support pg data type: numeric with OID:
+// 1700", and pgx decodes a numeric into a pgtype.Numeric, which the greenmask
+// numeric transformers did not accept either.
+func Test_SnapshotToPostgres_NumericColumnTransformer(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	var snapshotPGURL string
+	pgcleanup, err := testcontainers.SetupPostgresContainer(context.Background(), &snapshotPGURL, testcontainers.Postgres14, "config/postgresql.conf")
+	require.NoError(t, err)
+	defer pgcleanup()
+
+	// each subtest gets its own context, so a timeout in one cannot cancel
+	// the context the next one still needs
+	run := func(t *testing.T, suffix string, opts ...option) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		testTable := fmt.Sprintf("numeric_transformer_%s", suffix)
+
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+			`CREATE TABLE %s(
+				id       INTEGER PRIMARY KEY,
+				latitude numeric(9,6) NOT NULL,
+				amount   numeric
+			)`, testTable))
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+			`INSERT INTO %s(id, latitude, amount) VALUES
+				(1, 51.507351, 1234.5678),
+				(2, -33.868820, 0),
+				(3, 0.000001, 987654321.123456789)`,
+			testTable))
+
+		rules := []transformer.TableRules{
+			{
+				Schema: "public",
+				Table:  testTable,
+				ColumnRules: map[string]transformer.TransformerRules{
+					"latitude": {
+						Name: "greenmask_float",
+						Parameters: map[string]any{
+							"generator": "deterministic",
+							"min_value": -90.0,
+							"max_value": 90.0,
+							"precision": 6,
+						},
+					},
+					"amount": {
+						Name: "greenmask_float",
+						Parameters: map[string]any{
+							"generator": "deterministic",
+							"min_value": 0.0,
+							"max_value": 1000.0,
+						},
+					},
+				},
+			},
+		}
+
+		cfg := &stream.Config{
+			Listener:  testPostgresListenerCfgWithSnapshot(snapshotPGURL, targetPGURL, []string{testTable}),
+			Processor: testPostgresProcessorCfg(append(opts, withTransformerRules(rules))...),
+		}
+		initStream(t, ctx, snapshotPGURL)
+		runSnapshot(t, ctx, cfg)
+
+		targetConn, err := pglib.NewConn(ctx, targetPGURL)
+		require.NoError(t, err)
+		defer targetConn.Close(ctx)
+
+		timer := time.NewTimer(20 * time.Second)
+		defer timer.Stop()
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		type row struct {
+			id       int
+			latitude float64
+			amount   *float64
+		}
+		query := fmt.Sprintf("SELECT id, latitude, amount FROM %s ORDER BY id", testTable)
+		fetch := func(conn pglib.Querier) ([]row, error) {
+			rows, err := conn.Query(ctx, query)
+			if err != nil {
+				return nil, err
+			}
+			defer rows.Close()
+			out := []row{}
+			for rows.Next() {
+				var r row
+				if err := rows.Scan(&r.id, &r.latitude, &r.amount); err != nil {
+					return nil, err
+				}
+				out = append(out, r)
+			}
+			return out, rows.Err()
+		}
+
+		// poll only for arrival, then assert once on the test's own goroutine:
+		// a require inside the poll predicate would fail the whole run on a
+		// transient intermediate state
+		var got []row
+		for got == nil {
+			select {
+			case <-timer.C:
+				t.Fatal("timeout waiting for postgres snapshot sync of transformed numeric columns")
+			case <-ticker.C:
+				rows, err := fetch(targetConn)
+				if err == nil && len(rows) == 3 {
+					got = rows
+				}
+			}
+		}
+
+		for _, r := range got {
+			require.GreaterOrEqual(t, r.latitude, -90.0)
+			require.LessOrEqual(t, r.latitude, 90.0)
+			require.NotNil(t, r.amount)
+			require.GreaterOrEqual(t, *r.amount, 0.0)
+			require.LessOrEqual(t, *r.amount, 1000.0)
+		}
+		// row 1 is the only one whose source values both sit outside the
+		// configured ranges, so it is what would expose a transformer that
+		// passed the original through untouched
+		require.NotEqual(t, 51.507351, got[0].latitude)
+		require.NotNil(t, got[0].amount)
+		require.NotEqual(t, 1234.5678, *got[0].amount)
+	}
+
+	t.Run("bulk ingest", func(t *testing.T) {
+		run(t, "bulk", withBulkIngestionEnabled())
+	})
+	t.Run("batch writer", func(t *testing.T) {
+		run(t, "batch")
 	})
 }
 

--- a/pkg/transformers/greenmask/greenmask_float_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_float_transformer.go
@@ -9,6 +9,7 @@ import (
 	"math"
 
 	greenmasktransformers "github.com/eminano/greenmask/pkg/generators/transformers"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/xataio/pgstream/pkg/transformers"
 )
 
@@ -96,6 +97,16 @@ func (ft *FloatTransformer) Transform(_ context.Context, value transformers.Valu
 		toTransform = getBytesForFloat(float64(val))
 	case float64:
 		toTransform = getBytesForFloat(val)
+	case pgtype.Numeric:
+		toTransform = getBytesForFloat(float64FromNumeric(val))
+	// wal2json renders a whole numeric or float as a JSON integer, and the
+	// replication listener decodes those as int64, so the same column reaches
+	// this transformer as an integer on the CDC path and as a float on the
+	// snapshot one
+	case int64:
+		toTransform = getBytesForFloat(float64(val))
+	case int:
+		toTransform = getBytesForFloat(float64(val))
 	case []byte:
 		toTransform = val
 	default:

--- a/pkg/transformers/greenmask/greenmask_float_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_float_transformer_test.go
@@ -4,9 +4,12 @@ package greenmask
 
 import (
 	"context"
+	"math"
+	"math/big"
 	"testing"
 
 	greenmasktransformers "github.com/eminano/greenmask/pkg/generators/transformers"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/stretchr/testify/require"
 	"github.com/xataio/pgstream/pkg/transformers"
@@ -156,6 +159,93 @@ func TestFloatTransformer_Transform(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name:  "ok - deterministic with numeric",
+			value: pgtype.Numeric{Int: big.NewInt(51507351), Exp: -6, Valid: true},
+			params: map[string]any{
+				"generator": deterministic,
+				"min_value": -90.0,
+				"max_value": 90.0,
+				"precision": 6,
+			},
+			wantErr: nil,
+		},
+		{
+			name:  "ok - random with a numeric beyond float64 precision",
+			value: pgtype.Numeric{Int: mustParseBigInt(t, "987654321123456789123456789"), Exp: -9, Valid: true},
+			params: map[string]any{
+				"generator": random,
+				"min_value": 0.0,
+				"max_value": 1000.0,
+			},
+			wantErr: nil,
+		},
+		{
+			// clamped rather than failing: pgtype reports this as a strconv
+			// range error, and erroring here would null the column
+			name:  "ok - random with a numeric beyond float64 range",
+			value: pgtype.Numeric{Int: big.NewInt(1), Exp: 400, Valid: true},
+			params: map[string]any{
+				"generator": random,
+				"min_value": 1.0,
+				"max_value": 10.0,
+			},
+			wantErr: nil,
+		},
+		{
+			name:  "ok - random with a negative numeric beyond float64 range",
+			value: pgtype.Numeric{Int: big.NewInt(-1), Exp: 400, Valid: true},
+			params: map[string]any{
+				"generator": random,
+				"min_value": 1.0,
+				"max_value": 10.0,
+			},
+			wantErr: nil,
+		},
+		{
+			// pgx yields a zero float for an invalid numeric; the pipeline
+			// skips nulls before this point, so it only has to not blow up
+			name:  "ok - random with an invalid numeric",
+			value: pgtype.Numeric{Valid: false},
+			params: map[string]any{
+				"generator": random,
+				"min_value": 1.0,
+				"max_value": 10.0,
+			},
+			wantErr: nil,
+		},
+		{
+			// wal2json renders a whole numeric as a JSON integer and the
+			// replication listener decodes it as int64
+			name:  "ok - deterministic with int64 from the CDC path",
+			value: int64(1234),
+			params: map[string]any{
+				"generator": deterministic,
+				"min_value": 0.0,
+				"max_value": 1000.0,
+			},
+			wantErr: nil,
+		},
+		{
+			name:  "ok - deterministic with int from the CDC path",
+			value: 1234,
+			params: map[string]any{
+				"generator": deterministic,
+				"min_value": 0.0,
+				"max_value": 1000.0,
+			},
+			wantErr: nil,
+		},
+		{
+			name:  "ok - deterministic with a NaN numeric",
+			value: pgtype.Numeric{NaN: true, Valid: true},
+			params: map[string]any{
+				"generator": deterministic,
+				"min_value": 1.0,
+				"max_value": 10.0,
+			},
+			wantErr: nil,
+		},
+		{
 			name:  "error - invalid value type",
 			value: "invalid",
 			params: map[string]any{
@@ -192,6 +282,7 @@ func TestFloatTransformer_Transform(t *testing.T) {
 			}
 			result, ok := got.(float64)
 			require.True(t, ok, "expected got to be of type float64")
+			require.False(t, math.IsNaN(result), "a transformed value must never be NaN")
 
 			// check if the result is within the specified range
 			minVal, found, err := transformers.FindParameter[float64](tc.params, "min_value")
@@ -214,4 +305,75 @@ func TestFloatTransformer_Transform(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mustParseBigInt(t *testing.T, s string) *big.Int {
+	t.Helper()
+	i, ok := new(big.Int).SetString(s, 10)
+	require.True(t, ok, "invalid big.Int literal %q", s)
+	return i
+}
+
+// a numeric column reaches the transformer as a pgtype.Numeric, while the same
+// value on a double precision column reaches it as a float64. Both have to
+// seed the generator identically, or the same source value would anonymize
+// differently depending on the column's declared type.
+func TestFloatTransformer_Transform_numericMatchesFloat64(t *testing.T) {
+	t.Parallel()
+
+	params := transformers.ParameterValues{
+		"generator": deterministic,
+		"min_value": -90.0,
+		"max_value": 90.0,
+		"precision": 6,
+	}
+
+	transformer, err := NewFloatTransformer(params)
+	require.NoError(t, err)
+
+	fromNumeric, err := transformer.Transform(context.Background(), transformers.Value{
+		TransformValue: pgtype.Numeric{Int: big.NewInt(51507351), Exp: -6, Valid: true},
+	})
+	require.NoError(t, err)
+
+	fromFloat, err := transformer.Transform(context.Background(), transformers.Value{
+		TransformValue: 51.507351,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, fromFloat, fromNumeric)
+}
+
+// the same whole numeric reaches this transformer as a pgtype.Numeric from a
+// snapshot and as an int64 from the replication stream, since wal2json renders
+// it as a JSON integer. Both have to seed the generator identically, or a row
+// would anonymize differently depending on which half of the pipeline carried
+// it.
+func TestFloatTransformer_Transform_int64MatchesNumeric(t *testing.T) {
+	t.Parallel()
+
+	transformer, err := NewFloatTransformer(transformers.ParameterValues{
+		"generator": deterministic,
+		"min_value": 0.0,
+		"max_value": 1000.0,
+	})
+	require.NoError(t, err)
+
+	fromNumeric, err := transformer.Transform(context.Background(), transformers.Value{
+		TransformValue: pgtype.Numeric{Int: big.NewInt(1234), Exp: 0, Valid: true},
+	})
+	require.NoError(t, err)
+
+	fromInt64, err := transformer.Transform(context.Background(), transformers.Value{
+		TransformValue: int64(1234),
+	})
+	require.NoError(t, err)
+
+	fromFloat, err := transformer.Transform(context.Background(), transformers.Value{
+		TransformValue: float64(1234),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, fromFloat, fromNumeric)
+	require.Equal(t, fromFloat, fromInt64)
 }

--- a/pkg/transformers/greenmask/greenmask_integer_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_integer_transformer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/eminano/greenmask/pkg/generators"
 	greenmasktransformers "github.com/eminano/greenmask/pkg/generators/transformers"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/xataio/pgstream/pkg/transformers"
 )
 
@@ -114,7 +115,6 @@ func NewIntegerTransformer(params transformers.ParameterValues) (*IntegerTransfo
 
 // Transform converts the input value to a byte slice, passes it through the underlying
 // RandomInt64Transformer, and returns the transformed value as an int64.
-// Supported input types are int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, and byte.
 // If the input value is a byte slice, it is passed through the transformer without modification.
 // If the input value is of an unsupported type, an error is returned.
 func (t *IntegerTransformer) Transform(_ context.Context, value transformers.Value) (any, error) {
@@ -144,6 +144,8 @@ func (t *IntegerTransformer) Transform(_ context.Context, value transformers.Val
 		toTransform = generators.BuildBytesFromUint64(uint64(val))
 	case float64:
 		toTransform = generators.BuildBytesFromUint64(uint64(val))
+	case pgtype.Numeric:
+		toTransform = generators.BuildBytesFromUint64(math.Float64bits(float64FromNumeric(val)))
 	case []byte:
 		toTransform = val
 	default:

--- a/pkg/transformers/greenmask/greenmask_integer_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_integer_transformer_test.go
@@ -5,9 +5,11 @@ package greenmask
 import (
 	"context"
 	"math"
+	"math/big"
 	"testing"
 
 	greenmasktransformers "github.com/eminano/greenmask/pkg/generators/transformers"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 	"github.com/xataio/pgstream/pkg/transformers"
 )
@@ -151,6 +153,48 @@ func TestIntegerTransformer_Transform(t *testing.T) {
 			input: []byte{0, 0, 0, 50},
 			params: map[string]any{
 				"generator": random,
+				"size":      4,
+				"min_value": -100,
+				"max_value": 500,
+			},
+		},
+		{
+			name:  "ok - transform numeric deterministically",
+			input: pgtype.Numeric{Int: big.NewInt(12345678), Exp: -4, Valid: true},
+			params: map[string]any{
+				"generator": deterministic,
+				"size":      4,
+				"min_value": -100,
+				"max_value": 500,
+			},
+		},
+		{
+			// seeded from the bit pattern, so no implementation-defined
+			// uint64 conversion is involved
+			name:  "ok - transform a negative numeric deterministically",
+			input: pgtype.Numeric{Int: big.NewInt(-33868820), Exp: -6, Valid: true},
+			params: map[string]any{
+				"generator": deterministic,
+				"size":      4,
+				"min_value": -100,
+				"max_value": 500,
+			},
+		},
+		{
+			name:  "ok - transform a NaN numeric deterministically",
+			input: pgtype.Numeric{NaN: true, Valid: true},
+			params: map[string]any{
+				"generator": deterministic,
+				"size":      4,
+				"min_value": -100,
+				"max_value": 500,
+			},
+		},
+		{
+			name:  "ok - transform a numeric beyond float64 range",
+			input: pgtype.Numeric{Int: big.NewInt(1), Exp: 400, Valid: true},
+			params: map[string]any{
+				"generator": deterministic,
 				"size":      4,
 				"min_value": -100,
 				"max_value": 500,

--- a/pkg/transformers/greenmask/greenmask_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_transformer.go
@@ -3,7 +3,10 @@
 package greenmask
 
 import (
+	"math"
+
 	greenmasktransformers "github.com/eminano/greenmask/pkg/generators/transformers"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/xataio/pgstream/pkg/transformers"
 	"github.com/xataio/pgstream/pkg/transformers/generators"
 )
@@ -59,4 +62,15 @@ func findParameterArray[T any](params transformers.ParameterValues, name string,
 		return defaultVal, nil
 	}
 	return val, nil
+}
+
+func float64FromNumeric(n pgtype.Numeric) float64 {
+	f, err := n.Float64Value()
+	if err == nil {
+		return f.Float64
+	}
+	if n.Int != nil && n.Int.Sign() < 0 {
+		return -math.MaxFloat64
+	}
+	return math.MaxFloat64
 }

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -57,11 +58,25 @@ const (
 	AND k.ord <= i.indnkeyatts
 	AND n.nspname = $1 AND c.relname = $2
 	ORDER BY idx.relname, k.ord`
-	publicSchema = "public"
-	wildcard     = "*"
+	publicSchema        = "public"
+	wildcard            = "*"
+	numericTypmodOffset = 4
 )
 
-var errInvalidTableName = errors.New("invalid table name, expected format: schema.table or table")
+var (
+	errInvalidTableName = errors.New("invalid table name, expected format: schema.table or table")
+	// ErrNumericRange is returned when a transformer configured on a numeric
+	// column can generate values the column cannot store.
+	ErrNumericRange = errors.New("transformer range does not fit the numeric column")
+)
+
+// columnType is what rules validation needs to know about a column's type: the
+// OID says which transformers accept it, and the modifier carries the
+// precision and scale a numeric column constrains its values to.
+type columnType struct {
+	oid      uint32
+	modifier int32
+}
 
 func NewPostgresTransformerParser(ctx context.Context, pgURL string, builder transformerBuilder, requiredTables []string, opts ...ParserOption) (*PostgresTransformerParser, error) {
 	pool, err := pglib.NewConnPool(ctx, pgURL)
@@ -102,8 +117,8 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 			return nil, err
 		}
 
-		// map column names to column pg type OIDs
-		mappedColumnTypes := make(map[string]uint32, len(fieldDescriptions))
+		// map column names to their pg type OID and modifier
+		mappedColumnTypes := make(map[string]columnType, len(fieldDescriptions))
 		for _, desc := range fieldDescriptions {
 			if _, found := table.ColumnRules[string(desc.Name)]; !found {
 				// column is not configured in rules, error out if strict validation mode is enabled
@@ -112,7 +127,7 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 				}
 				continue
 			}
-			mappedColumnTypes[string(desc.Name)] = desc.DataTypeOID
+			mappedColumnTypes[string(desc.Name)] = columnType{oid: desc.DataTypeOID, modifier: desc.TypeModifier}
 		}
 
 		for colName, transformerRules := range table.ColumnRules {
@@ -137,17 +152,21 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 			}
 
 			// get the data type so that we can later validate if it's compatible with the configured transformer
-			dataTypeOID, found := mappedColumnTypes[colName]
+			colType, found := mappedColumnTypes[colName]
 			if !found {
 				// validate that the column in the rules is present in the table
 				return nil, fmt.Errorf("column %s not found in table %q.%q", colName, table.Schema, table.Table)
 			}
 
-			dataTypeName, err := v.pgtypeMap.TypeForOID(ctx, dataTypeOID)
+			dataTypeName, err := v.pgtypeMap.TypeForOID(ctx, colType.oid)
 
 			// validate that the transformer is compatible with the column type
-			if err != nil || !pgTypeCompatibleWithTransformerType(transformer.CompatibleTypes(), dataTypeOID, dataTypeName) {
-				return nil, fmt.Errorf("transformer '%s' specified for column '%s' in table %q.%q does not support pg data type: %s with OID: %d", transformer.Type(), colName, table.Schema, table.Table, dataTypeName, dataTypeOID)
+			if err != nil || !pgTypeCompatibleWithTransformerType(transformer.CompatibleTypes(), colType.oid, dataTypeName) {
+				return nil, fmt.Errorf("transformer '%s' specified for column '%s' in table %q.%q does not support pg data type: %s with OID: %d", transformer.Type(), colName, table.Schema, table.Table, dataTypeName, colType.oid)
+			}
+
+			if err := validateNumericRange(cfg, colType); err != nil {
+				return nil, fmt.Errorf("column '%s' in table %q.%q: %w", colName, table.Schema, table.Table, err)
 			}
 
 			// add the transformer to the map
@@ -364,7 +383,7 @@ func pgTypeCompatibleWithTransformerType(compatibleTypes []transformers.Supporte
 		return slices.Contains(compatibleTypes, transformers.StringDataType)
 	case pgtype.Float4OID:
 		return slices.Contains(compatibleTypes, transformers.Float32DataType)
-	case pgtype.Float8OID:
+	case pgtype.Float8OID, pgtype.NumericOID:
 		return slices.Contains(compatibleTypes, transformers.Float64DataType)
 	case pgtype.Int2OID:
 		return slices.Contains(compatibleTypes, transformers.Integer16DataType)
@@ -394,5 +413,60 @@ func pgTypeCompatibleWithTransformerType(compatibleTypes []transformers.Supporte
 		default:
 			return false
 		}
+	}
+}
+
+func (c columnType) numericPrecisionScale() (precision, scale int, ok bool) {
+	if c.oid != pgtype.NumericOID || c.modifier < numericTypmodOffset {
+		return 0, 0, false
+	}
+	typmod := c.modifier - numericTypmodOffset
+	return int(typmod>>16) & 0xffff, int(typmod) & 0xffff, true
+}
+
+// validateNumericRange checks that a transformer configured on a numeric
+// column cannot generate a value the column will reject.
+func validateNumericRange(cfg *transformers.Config, colType columnType) error {
+	if cfg.Name != transformers.GreenmaskFloat && cfg.Name != transformers.GreenmaskInteger {
+		return nil
+	}
+	precision, scale, ok := colType.numericPrecisionScale()
+	if !ok {
+		return nil
+	}
+
+	// the largest magnitude a numeric(p,s) can hold, exclusive
+	limit := math.Pow(10, float64(precision-scale))
+
+	for _, param := range []string{"min_value", "max_value"} {
+		value, found := cfg.Parameters[param]
+		if !found {
+			return fmt.Errorf("%w: %q defaults to the full range of its type, which does not fit numeric(%d,%d); set it explicitly",
+				ErrNumericRange, param, precision, scale)
+		}
+		magnitude, err := numericParamMagnitude(value)
+		if err != nil {
+			return fmt.Errorf("%w: %q: %w", ErrNumericRange, param, err)
+		}
+		if magnitude >= limit {
+			return fmt.Errorf("%w: %q is %g, which does not fit numeric(%d,%d) (maximum magnitude %g)",
+				ErrNumericRange, param, magnitude, precision, scale, limit)
+		}
+	}
+	return nil
+}
+
+func numericParamMagnitude(value any) (float64, error) {
+	switch v := value.(type) {
+	case float64:
+		return math.Abs(v), nil
+	case float32:
+		return math.Abs(float64(v)), nil
+	case int:
+		return math.Abs(float64(v)), nil
+	case int64:
+		return math.Abs(float64(v)), nil
+	default:
+		return 0, fmt.Errorf("got %T, want a number", value)
 	}
 }

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	pglib "github.com/xataio/pgstream/internal/postgres"
 	pgmocks "github.com/xataio/pgstream/internal/postgres/mocks"
+	"github.com/xataio/pgstream/pkg/transformers"
 	"github.com/xataio/pgstream/pkg/transformers/builder"
 )
 
@@ -600,6 +601,164 @@ func TestPostgresTransformerParser_uniqueIndexValidation(t *testing.T) {
 				require.Contains(t, err.Error(), tc.wantErrMsg)
 			}
 			require.Equal(t, tc.wantWarnings, parser.Warnings())
+		})
+	}
+}
+
+func Test_pgTypeCompatibleWithTransformerType(t *testing.T) {
+	t.Parallel()
+
+	floatCompatible := []transformers.SupportedDataType{
+		transformers.Float32DataType,
+		transformers.Float64DataType,
+	}
+	stringCompatible := []transformers.SupportedDataType{transformers.StringDataType}
+
+	tests := []struct {
+		name            string
+		compatibleTypes []transformers.SupportedDataType
+		oid             uint32
+		typeName        string
+		want            bool
+	}{
+		{
+			name:            "numeric with a float compatible transformer",
+			compatibleTypes: floatCompatible,
+			oid:             pgtype.NumericOID,
+			typeName:        "numeric",
+			want:            true,
+		},
+		{
+			name:            "numeric with a string only transformer",
+			compatibleTypes: stringCompatible,
+			oid:             pgtype.NumericOID,
+			typeName:        "numeric",
+			want:            false,
+		},
+		{
+			name:            "numeric with a transformer supporting all types",
+			compatibleTypes: []transformers.SupportedDataType{transformers.AllDataTypes},
+			oid:             pgtype.NumericOID,
+			typeName:        "numeric",
+			want:            true,
+		},
+		{
+			name:            "float8 with a float compatible transformer",
+			compatibleTypes: floatCompatible,
+			oid:             pgtype.Float8OID,
+			typeName:        "float8",
+			want:            true,
+		},
+		{
+			name:            "numeric array is not covered",
+			compatibleTypes: floatCompatible,
+			oid:             pgtype.NumericArrayOID,
+			typeName:        "_numeric",
+			want:            false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.want, pgTypeCompatibleWithTransformerType(tc.compatibleTypes, tc.oid, tc.typeName))
+		})
+	}
+}
+
+func Test_validateNumericRange(t *testing.T) {
+	t.Parallel()
+
+	// numeric(9,6): three digits before the point, so magnitudes below 1000
+	constrained := columnType{oid: pgtype.NumericOID, modifier: ((9 << 16) | 6) + 4}
+	unconstrained := columnType{oid: pgtype.NumericOID, modifier: -1}
+	float8 := columnType{oid: pgtype.Float8OID, modifier: -1}
+
+	tests := []struct {
+		name    string
+		cfg     *transformers.Config
+		colType columnType
+		wantErr error
+	}{
+		{
+			name: "range fits the column",
+			cfg: &transformers.Config{Name: transformers.GreenmaskFloat, Parameters: transformers.ParameterValues{
+				"min_value": -90.0, "max_value": 90.0,
+			}},
+			colType: constrained,
+		},
+		{
+			name: "range exceeds the column precision",
+			cfg: &transformers.Config{Name: transformers.GreenmaskFloat, Parameters: transformers.ParameterValues{
+				"min_value": 0.0, "max_value": 100000.0,
+			}},
+			colType: constrained,
+			wantErr: ErrNumericRange,
+		},
+		{
+			name: "negative bound exceeds the column precision",
+			cfg: &transformers.Config{Name: transformers.GreenmaskFloat, Parameters: transformers.ParameterValues{
+				"min_value": -100000.0, "max_value": 0.0,
+			}},
+			colType: constrained,
+			wantErr: ErrNumericRange,
+		},
+		{
+			// the transformer default spans the whole float32 range, which
+			// fits no realistic numeric(p,s)
+			name:    "bounds omitted on a constrained column",
+			cfg:     &transformers.Config{Name: transformers.GreenmaskFloat, Parameters: transformers.ParameterValues{}},
+			colType: constrained,
+			wantErr: ErrNumericRange,
+		},
+		{
+			name: "integer bounds are accepted",
+			cfg: &transformers.Config{Name: transformers.GreenmaskInteger, Parameters: transformers.ParameterValues{
+				"min_value": 0, "max_value": 500,
+			}},
+			colType: constrained,
+		},
+		{
+			name: "integer bounds exceeding the column precision",
+			cfg: &transformers.Config{Name: transformers.GreenmaskInteger, Parameters: transformers.ParameterValues{
+				"min_value": 0, "max_value": 5000,
+			}},
+			colType: constrained,
+			wantErr: ErrNumericRange,
+		},
+		{
+			name: "a non numeric bound is rejected",
+			cfg: &transformers.Config{Name: transformers.GreenmaskFloat, Parameters: transformers.ParameterValues{
+				"min_value": "zero", "max_value": 90.0,
+			}},
+			colType: constrained,
+			wantErr: ErrNumericRange,
+		},
+		{
+			// nothing to check against: any generated value fits
+			name:    "unconstrained numeric is not checked",
+			cfg:     &transformers.Config{Name: transformers.GreenmaskFloat, Parameters: transformers.ParameterValues{}},
+			colType: unconstrained,
+		},
+		{
+			name:    "a non numeric column is not checked",
+			cfg:     &transformers.Config{Name: transformers.GreenmaskFloat, Parameters: transformers.ParameterValues{}},
+			colType: float8,
+		},
+		{
+			// its bounds are timestamps, not numbers
+			name:    "greenmask_unix_timestamp is not checked",
+			cfg:     &transformers.Config{Name: transformers.GreenmaskUnixTimestamp, Parameters: transformers.ParameterValues{}},
+			colType: constrained,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.ErrorIs(t, validateNumericRange(tc.cfg, tc.colType), tc.wantErr)
 		})
 	}
 }


### PR DESCRIPTION
#### Description

Add support for numeric values in transformers.

Previously, pgstream emitted this error:

```
transformer 'greenmask_float' specified for column 'latitude' in table "public"."address" does not support pg data type: numeric with OID: 1700
```

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

-
-
-

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
