### PR TITLE
Add database size reporting

### DIFF
--- a/pkg/stream/preflight/CLAUDE.md
+++ b/pkg/stream/preflight/CLAUDE.md
@@ -4,8 +4,8 @@ Guidance for Claude Code when working inside `pkg/stream/preflight`. The planned
 
 ## Package shape
 
-- `preflight.go` — `Check` interface (`Name()` + `Run(ctx) ([]Finding, error)`), optional `Detailer` interface (`Details() map[string]any` — structured, non-finding context the engine merges into the result's JSON only; not shown in the human report), `Finding`, `CheckResult`, `Report`, `Run(ctx, []Check, ...RunOption)` engine.
-- `printer.go` — `ReportPrinter{Report}` is the only thing that formats reports. The `Report` struct itself stays pure data.
+- `preflight.go` — `Check` interface (`Name()` + `Run(ctx) ([]Finding, error)`), the optional `Detailer` / `Summarizer` interfaces described under [Reporting what a check observed](#reporting-what-a-check-observed), `Finding`, `CheckResult`, `Report`, `Run(ctx, []Check, ...RunOption)` engine. The engine calls each optional interface after `Run`, so a check populates them from state it gathered while running.
+- `printer.go` — `ReportPrinter{Report}` is the only thing that formats reports, rendering each result's `Summary` beside its name. The `Report` struct itself stays pure data.
 - `builder.go` — `Builder` struct (returns `[]Check` + optional cleanup), `Builders` registry slice, per-category builder functions (`BuildConnectivityChecks`, …), `BuildChecks(cfg, selected)`.
 - One file per category of concrete checks (`connectivity.go`, `replication.go`, …).
 
@@ -22,12 +22,28 @@ Adding a check is meant to be a small, mechanical edit. Keep it that way.
    - **Every `Finding` is blocking.** A check that finds nothing wrong returns a `nil` slice.
    - **Return `error` only when the check itself couldn't run** (timeout, internal bug, malformed input). A detected problem is a `Finding`, not an error.
    - **Put remediation in `Finding.Message`** — the user should be able to act on it without reading source.
-3. **Materialise instances in the category builder** (e.g. `BuildConnectivityChecks`). The builder is the applicability gate: it reads `*stream.Config` and decides which instances are relevant. Inapplicable checks are silently omitted today; an explicit "skipped: <reason>" mechanism is deferred (see `docs/migration_preflight_issue.md` "Architecture decisions" #6).
+3. **Report what it observed**, if it observed anything worth reporting — see [Reporting what a check observed](#reporting-what-a-check-observed). Most checks need none of this: a check that only passes or fails implements no optional interface.
+4. **Materialise instances in the category builder** (e.g. `BuildConnectivityChecks`). The builder is the applicability gate: it reads `*stream.Config` and decides which instances are relevant. Inapplicable checks are silently omitted today; an explicit "skipped: <reason>" mechanism is deferred (see `docs/migration_preflight_issue.md` "Architecture decisions" #6).
    - **If checks in the category share a Postgres connection**, call `postgres.NewLazyConn(url)` in the builder, hand `src.Acquire` (a `postgres.AcquireFunc`) to every check, and return `src.Close` as the cleanup. See `BuildReplicationChecks` for the pattern. The engine runs sequentially, so the first check to call `Source(ctx)` opens the conn and the rest reuse it. A failed dial is memoised too — only one connection attempt happens, even if every check reports its own check error.
-4. **Tests.** Unit-test the check directly against mocked dependencies (`internal/postgres/mocks` has the postgres conn mock). For new categories, exercise the builder selection path through the cmd layer too.
+5. **Tests.** Unit-test the check directly against mocked dependencies (`internal/postgres/mocks` has the postgres conn mock). For new categories, exercise the builder selection path through the cmd layer too.
+
+## Reporting what a check observed
+
+Two optional interfaces, split by **data vs presentation**. Both read the state the check gathered during `Run`, and each feeds one report.
+
+| | JSON | human |
+| --- | --- | --- |
+| `Details() map[string]any` | nested under the result's `details` key | — |
+| `Summary() string` | — | rendered beside the check name |
+
+- **Typed facts go in `Details`.** Keep values machine-readable: a size belongs here as a byte count, a version as a string. One fact, one representation — never a pre-rendered string beside the value it renders.
+- **A headline worth one line goes in `Summary`.** Which facts lead and how they read is judgement specific to the check — a generic renderer over `Details` cannot infer it, and would print keys in alphabetical order. Formatting for the reader happens here, never in `Details`; `prettySize` renders byte counts.
+
+Findings are unaffected: remediation belongs in `Finding.Message` whether or not a check reports anything else.
 
 ## Do not
 
 - Do not add `init()`-time registration, dependency injection frameworks, or other indirection — `Builders` is the registry, keep it a plain literal slice.
 - Do not move rendering logic onto `Report`. `ReportPrinter` owns formatting; `Report` stays data-only.
 - Do not import `pkg/stream` from anywhere except `builder.go`. Engine code (`preflight.go`, `printer.go`, individual check files) stays stream-agnostic so it can be reused.
+- Do not put display strings in `Details`, and do not let a check's SQL format them (`pg_size_pretty` and friends). `Details` carries typed values and `Summary`/`ExpandedSummary` render them, so the JSON and human reports cannot drift apart.

--- a/pkg/stream/preflight/builder.go
+++ b/pkg/stream/preflight/builder.go
@@ -33,24 +33,25 @@ var Builders = []Builder{
 	{CategoryResources, "resources", BuildResourcesChecks},
 }
 
-// BuildResourcesChecks returns the resource-capacity preflight checks
-// applicable to cfg, plus a cleanup function that closes the shared source
-// connection. The snapshot connection-headroom check only applies when a data
-// snapshot is configured (it sizes snapshot_workers × table_workers against the
-// source's max_connections).
+// BuildResourcesChecks returns the resource-capacity preflight checks that
+// apply to cfg, plus a cleanup function that closes the shared source
+// connection. The database-size report applies to any configured source. The
+// snapshot connection-headroom check is added only when a data snapshot is
+// configured, because it sizes snapshot_workers x table_workers against the
+// source's max_connections.
 func BuildResourcesChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 	url := cfg.SourcePostgresURL()
 	if url == "" {
 		return nil, nil
 	}
-	demand, ok := cfg.SnapshotConnectionDemand()
-	if !ok {
-		return nil, nil
-	}
 	src := postgres.NewLazyConn(url)
-	return []Check{
-		&SnapshotConnectionsCheck{Source: src.Acquire, Demand: demand},
-	}, src.Close
+	checks := []Check{
+		&DatabaseSizeCheck{Source: src.Acquire},
+	}
+	if demand, ok := cfg.SnapshotConnectionDemand(); ok {
+		checks = append(checks, &SnapshotConnectionsCheck{Source: src.Acquire, Demand: demand})
+	}
+	return checks, src.Close
 }
 
 // BuildConnectivityChecks returns the connectivity checks applicable to cfg.

--- a/pkg/stream/preflight/preflight.go
+++ b/pkg/stream/preflight/preflight.go
@@ -34,40 +34,52 @@ type Check interface {
 	Run(ctx context.Context) ([]Finding, error)
 }
 
-// Detailer is an optional interface a Check may implement to attach structured,
-// non-finding context to its result (e.g. the set of extensions it inspected).
-// The engine calls Details after Run, so a check populates it from state it
-// gathered while running. Each key is merged into the check's JSON object; it is
-// only surfaced in the JSON report, not the human-readable one.
+// Detailer is an optional interface. A Check implements it to attach
+// structured, non-finding context to its result, for example the extensions it
+// inspected. The engine calls Details after Run and puts the result in the JSON
+// report only, under the "details" key.
 type Detailer interface {
 	Details() map[string]any
 }
 
+// Summarizer is an optional interface. A Check implements it to report one
+// short line about what it observed, such as a size or a version. The engine
+// calls Summary after Run and prints the result next to the check name in the
+// human-readable report only.
+type Summarizer interface {
+	Summary() string
+}
+
 // CheckResult bundles a check's name with whatever it produced.
 type CheckResult struct {
-	Name     string    `json:"name"`
-	Findings []Finding `json:"findings"`
-	Err      error     `json:"-"`
-	// Details holds optional structured context from a Detailer check. Keys are
-	// merged into the result's JSON object alongside name/findings/error.
-	Details map[string]any `json:"-"`
+	Name     string         `json:"name"`
+	Findings []Finding      `json:"findings"`
+	Err      error          `json:"-"`
+	Details  map[string]any `json:"-"`
+	Summary  string         `json:"-"`
+}
+
+// checkResultJSON is the wire shape of a CheckResult. Nesting Details lets a
+// check name its keys freely, because those keys cannot collide with the
+// engine's own fields. A struct also fixes the field order, which a map does
+// not.
+type checkResultJSON struct {
+	Name     string         `json:"name"`
+	Findings []Finding      `json:"findings"`
+	Error    string         `json:"error,omitempty"`
+	Details  map[string]any `json:"details,omitempty"`
 }
 
 // MarshalJSON renders Err as a string so the report is consumable from a
-// non-Go process (the default error marshaling drops the message), and merges
-// any Details keys into the object.
+// non-Go process (the default error marshaling drops the message).
 func (r CheckResult) MarshalJSON() ([]byte, error) {
-	out := map[string]any{
-		"name":     r.Name,
-		"findings": r.Findings,
+	out := checkResultJSON{
+		Name:     r.Name,
+		Findings: r.Findings,
+		Details:  r.Details,
 	}
 	if r.Err != nil {
-		out["error"] = r.Err.Error()
-	}
-	for k, v := range r.Details {
-		if _, taken := out[k]; !taken {
-			out[k] = v
-		}
+		out.Error = r.Err.Error()
 	}
 	return json.Marshal(out)
 }
@@ -116,6 +128,9 @@ func Run(ctx context.Context, checks []Check, opts ...RunOption) Report {
 		}
 		if d, ok := c.(Detailer); ok {
 			res.Details = d.Details()
+		}
+		if s, ok := c.(Summarizer); ok {
+			res.Summary = s.Summary()
 		}
 		results = append(results, res)
 	}

--- a/pkg/stream/preflight/preflight_test.go
+++ b/pkg/stream/preflight/preflight_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -114,7 +115,7 @@ func TestRun_CapturesDetailsFromDetailerChecks(t *testing.T) {
 	require.Nil(t, report.Results[1].Details)
 }
 
-func TestCheckResult_JSONMarshalMergesDetails(t *testing.T) {
+func TestCheckResult_JSONNestsDetails(t *testing.T) {
 	t.Parallel()
 
 	res := CheckResult{
@@ -124,7 +125,7 @@ func TestCheckResult_JSONMarshalMergesDetails(t *testing.T) {
 
 	data, err := json.Marshal(res)
 	require.NoError(t, err)
-	require.JSONEq(t, `{"name":"schema_extension_compatibility","findings":null,"source_extensions":["hstore","postgis"]}`, string(data))
+	require.JSONEq(t, `{"name":"schema_extension_compatibility","findings":null,"details":{"source_extensions":["hstore","postgis"]}}`, string(data))
 }
 
 func TestReportPrinter_PrettyPrintOmitsDetails(t *testing.T) {
@@ -140,6 +141,85 @@ func TestReportPrinter_PrettyPrintOmitsDetails(t *testing.T) {
 
 	// details are JSON-only; the human report never mentions them
 	require.Equal(t, "✔ clean\nran 1 checks\n", out)
+}
+
+type stubSummarizerCheck struct {
+	stubCheck
+	summary string
+}
+
+func (s *stubSummarizerCheck) Summary() string { return s.summary }
+
+func TestRun_CapturesSummariesFromSummarizerChecks(t *testing.T) {
+	t.Parallel()
+
+	checks := []Check{
+		&stubSummarizerCheck{
+			stubCheck: stubCheck{name: "database_size"},
+			summary:   "12 MB",
+		},
+		&stubCheck{name: "no-summary"},
+	}
+
+	report := Run(context.Background(), checks)
+
+	require.Equal(t, "12 MB", report.Results[0].Summary)
+	require.Empty(t, report.Results[1].Summary)
+}
+
+func TestCheckResult_JSONOmitsSummary(t *testing.T) {
+	t.Parallel()
+
+	res := CheckResult{
+		Name:    "database_size",
+		Summary: "12 MB",
+		Details: map[string]any{"database_size_bytes": int64(12582912)},
+	}
+
+	data, err := json.Marshal(res)
+	require.NoError(t, err)
+	// JSON carries the typed Details, never the rendered summary string
+	require.JSONEq(t, `{"name":"database_size","findings":null,"details":{"database_size_bytes":12582912}}`, string(data))
+}
+
+func TestReportPrinter_PrettyPrintSummaries(t *testing.T) {
+	t.Parallel()
+
+	report := Report{
+		Results: []CheckResult{
+			{Name: "wal_level"},
+			{Name: "postgres_version", Summary: "16.4"},
+			{Name: "database_size", Summary: "12 MB"},
+		},
+	}
+
+	out := ReportPrinter{Report: report}.PrettyPrint()
+
+	require.Equal(t, strings.Join([]string{
+		"✔ wal_level",
+		"✔ postgres_version  16.4",
+		"✔ database_size     12 MB",
+		"ran 3 checks",
+		"",
+	}, "\n"), out)
+}
+
+func TestReportPrinter_PrettyPrintSkipsSummaryOnFailure(t *testing.T) {
+	t.Parallel()
+
+	printer := ReportPrinter{Report: Report{Results: []CheckResult{
+		{
+			Name:     "postgres_version",
+			Summary:  "source 16.4 → target 15.2",
+			Findings: []Finding{{Message: "downgrade"}},
+		},
+		{Name: "database_size", Summary: "never read", Err: errors.New("boom")},
+	}}}
+
+	out := printer.PrettyPrint()
+
+	// the finding is what the reader needs; the summary never reaches a ✘ line
+	require.Equal(t, "✘ postgres_version: downgrade\n✘ database_size: check failed: boom\nran 2 checks\n", out)
 }
 
 func TestReportPrinter_MarshalJSONDelegatesToReport(t *testing.T) {

--- a/pkg/stream/preflight/printer.go
+++ b/pkg/stream/preflight/printer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 // ReportPrinter renders a Report for display. It satisfies the cmd-side
@@ -19,20 +20,63 @@ type ReportPrinter struct {
 // PrettyPrint renders the report as a human-readable string.
 func (p ReportPrinter) PrettyPrint() string {
 	var sb strings.Builder
+	width := p.summaryColumn()
 	for _, res := range p.Report.Results {
 		if res.Err == nil && len(res.Findings) == 0 {
-			fmt.Fprintf(&sb, "✔ %s\n", res.Name)
+			writePassed(&sb, res, width)
 			continue
 		}
-		if res.Err != nil {
-			fmt.Fprintf(&sb, "✘ %s: check failed: %v\n", res.Name, res.Err)
-		}
-		for _, f := range res.Findings {
-			fmt.Fprintf(&sb, "✘ %s: %s\n", res.Name, f.Message)
-		}
+		writeFailed(&sb, res)
 	}
 	fmt.Fprintf(&sb, "ran %d checks\n", len(p.Report.Results))
 	return sb.String()
+}
+
+// writePassed renders a check that found nothing wrong. If the check has a
+// summary, it goes in the aligned column.
+func writePassed(sb *strings.Builder, res CheckResult, width int) {
+	if res.Summary == "" {
+		fmt.Fprintf(sb, "✔ %s\n", res.Name)
+		return
+	}
+	fmt.Fprintf(sb, "✔ %s%s  %s\n", res.Name, padding(res.Name, width), res.Summary)
+}
+
+// writeFailed renders the check error and every finding. It omits the summary,
+// because the finding messages carry what the reader needs. A check that
+// stopped part way through can also summarise only what it read.
+func writeFailed(sb *strings.Builder, res CheckResult) {
+	if res.Err != nil {
+		fmt.Fprintf(sb, "✘ %s: check failed: %v\n", res.Name, res.Err)
+	}
+	for _, f := range res.Findings {
+		fmt.Fprintf(sb, "✘ %s: %s\n", res.Name, f.Message)
+	}
+}
+
+// summaryColumn returns the column that the summaries line up in. The longest
+// name that has a summary sets the width. Checks without a summary do not
+// widen it.
+func (p ReportPrinter) summaryColumn() int {
+	width := 0
+	for _, res := range p.Report.Results {
+		if res.Summary == "" || res.Err != nil || len(res.Findings) > 0 {
+			continue
+		}
+		if n := utf8.RuneCountInString(res.Name); n > width {
+			width = n
+		}
+	}
+	return width
+}
+
+// padding returns the spaces that extend name to width. It counts runes, so
+// non-ASCII check names stay aligned.
+func padding(name string, width int) string {
+	if n := utf8.RuneCountInString(name); n < width {
+		return strings.Repeat(" ", width-n)
+	}
+	return ""
 }
 
 // MarshalJSON delegates to the underlying Report so a printer marshals to the

--- a/pkg/stream/preflight/resources.go
+++ b/pkg/stream/preflight/resources.go
@@ -9,6 +9,42 @@ import (
 	"github.com/xataio/pgstream/internal/postgres"
 )
 
+// DatabaseSizeCheck reports the on-disk size of the source database, so that a
+// migration run records the size it worked against. No database size is wrong
+// on its own, so the check is informational and never produces a finding. Note
+// that pg_database_size covers the whole database, including indexes and bloat,
+// while a data snapshot copies less.
+type DatabaseSizeCheck struct {
+	Source postgres.AcquireFunc
+
+	// sizeBytes is read during Run and reported through Details and Summary. It
+	// stays zero until Run reads it.
+	sizeBytes int64
+}
+
+func (c *DatabaseSizeCheck) Name() string { return "database_size" }
+
+func (c *DatabaseSizeCheck) Run(ctx context.Context) ([]Finding, error) {
+	conn, err := c.Source(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to source: %w", err)
+	}
+
+	if err := conn.QueryRow(ctx, []any{&c.sizeBytes}, "SELECT pg_database_size(current_database())"); err != nil {
+		return nil, fmt.Errorf("querying database size: %w", err)
+	}
+	return nil, nil
+}
+
+// Details reports the size as a byte count, so that a JSON consumer can
+// calculate with it. Summary renders that count for a reader.
+func (c *DatabaseSizeCheck) Details() map[string]any {
+	return map[string]any{"database_size_bytes": c.sizeBytes}
+}
+
+// Summary renders the size for the human-readable report.
+func (c *DatabaseSizeCheck) Summary() string { return prettySize(c.sizeBytes) }
+
 // SnapshotConnectionsCheck verifies the source Postgres has enough spare
 // connection slots to serve the snapshot's peak concurrency
 // (snapshot_workers × table_workers) on top of what is already in use, without
@@ -48,7 +84,8 @@ func (c *SnapshotConnectionsCheck) Run(ctx context.Context) ([]Finding, error) {
 		return []Finding{{
 			Message: fmt.Sprintf(
 				"snapshot needs %d concurrent connections (snapshot_workers × table_workers) but source has only %d available (max_connections=%d, superuser_reserved_connections=%d, %d in use); lower snapshot_workers/table_workers, raise max_connections (requires restart), or reduce existing connections",
-				c.Demand, available, maxConns, reserved, used),
+				c.Demand, available, maxConns, reserved, used,
+			),
 		}}, nil
 	}
 	return nil, nil

--- a/pkg/stream/preflight/resources_test.go
+++ b/pkg/stream/preflight/resources_test.go
@@ -118,9 +118,10 @@ func TestBuildResourcesChecks(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		cfg        *stream.Config
-		wantChecks int
+		name      string
+		cfg       *stream.Config
+		wantNames []string
+		// wantDemand is asserted only when the headroom check is expected.
 		wantDemand uint
 	}{
 		{
@@ -128,12 +129,13 @@ func TestBuildResourcesChecks(t *testing.T) {
 			cfg:  &stream.Config{},
 		},
 		{
-			name: "source without data snapshot returns no checks",
+			name: "source without data snapshot reports size only",
 			cfg: &stream.Config{
 				Listener: stream.ListenerConfig{
 					Postgres: &stream.PostgresListenerConfig{URL: "postgres://source"},
 				},
 			},
+			wantNames: []string{"database_size"},
 		},
 		{
 			name: "data snapshot with defaults sizes 1x4",
@@ -147,7 +149,7 @@ func TestBuildResourcesChecks(t *testing.T) {
 					},
 				},
 			},
-			wantChecks: 1,
+			wantNames:  []string{"database_size", "snapshot_connection_headroom"},
 			wantDemand: 4,
 		},
 		{
@@ -162,7 +164,7 @@ func TestBuildResourcesChecks(t *testing.T) {
 					},
 				},
 			},
-			wantChecks: 1,
+			wantNames:  []string{"database_size", "snapshot_connection_headroom"},
 			wantDemand: 15,
 		},
 	}
@@ -173,17 +175,107 @@ func TestBuildResourcesChecks(t *testing.T) {
 
 			checks, cleanup := BuildResourcesChecks(tc.cfg)
 
-			require.Len(t, checks, tc.wantChecks)
-			if tc.wantChecks == 0 {
+			if len(tc.wantNames) == 0 {
+				require.Empty(t, checks)
 				require.Nil(t, cleanup)
 				return
 			}
+			names := make([]string, 0, len(checks))
+			for _, c := range checks {
+				names = append(names, c.Name())
+			}
+			require.Equal(t, tc.wantNames, names)
 			require.NotNil(t, cleanup)
-			connCheck, ok := checks[0].(*SnapshotConnectionsCheck)
+			if tc.wantDemand == 0 {
+				return
+			}
+			connCheck, ok := checks[1].(*SnapshotConnectionsCheck)
 			require.True(t, ok)
 			require.Equal(t, tc.wantDemand, connCheck.Demand)
 		})
 	}
+}
+
+func TestDatabaseSizeCheck_Run(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		sizeBytes int64
+		wantSize  string
+	}{
+		{name: "empty database", sizeBytes: 0, wantSize: "0 bytes"},
+		{name: "under the kilobyte step", sizeBytes: 512, wantSize: "512 bytes"},
+		{name: "kilobytes", sizeBytes: 10 * 1024, wantSize: "10 kB"},
+		{name: "megabytes", sizeBytes: 5 * 1024 * 1024, wantSize: "5120 kB"},
+		{name: "gigabytes", sizeBytes: 42 * 1024 * 1024 * 1024, wantSize: "42 GB"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			check := &DatabaseSizeCheck{
+				Source: func(context.Context) (postgres.Querier, error) {
+					return &mocks.Querier{
+						QueryRowFn: func(_ context.Context, dest []any, query string, _ ...any) error {
+							require.Contains(t, query, "pg_database_size")
+							sizeDest, ok := dest[0].(*int64)
+							require.True(t, ok)
+							*sizeDest = tc.sizeBytes
+							return nil
+						},
+					}, nil
+				},
+			}
+
+			findings, err := check.Run(context.Background())
+
+			require.NoError(t, err)
+			require.Empty(t, findings, "the size report is informational")
+			// Details stays typed; Summary renders it
+			require.Equal(t, map[string]any{"database_size_bytes": tc.sizeBytes}, check.Details())
+			require.Equal(t, tc.wantSize, check.Summary())
+		})
+	}
+}
+
+func TestDatabaseSizeCheck_Run_ConnectFails(t *testing.T) {
+	t.Parallel()
+
+	connErr := errors.New("boom")
+	check := &DatabaseSizeCheck{
+		Source: func(context.Context) (postgres.Querier, error) {
+			return nil, connErr
+		},
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.Nil(t, findings)
+	require.ErrorIs(t, err, connErr)
+	require.ErrorContains(t, err, "connecting to source")
+}
+
+func TestDatabaseSizeCheck_Run_QueryFails(t *testing.T) {
+	t.Parallel()
+
+	queryErr := errors.New("query failed")
+	check := &DatabaseSizeCheck{
+		Source: func(context.Context) (postgres.Querier, error) {
+			return &mocks.Querier{
+				QueryRowFn: func(context.Context, []any, string, ...any) error {
+					return queryErr
+				},
+			}, nil
+		},
+	}
+
+	findings, err := check.Run(context.Background())
+
+	require.Nil(t, findings)
+	require.ErrorIs(t, err, queryErr)
+	require.ErrorContains(t, err, "querying database size")
 }
 
 func TestSnapshotConnectionsCheck_Run_ConnectFails(t *testing.T) {

--- a/pkg/stream/preflight/schema_test.go
+++ b/pkg/stream/preflight/schema_test.go
@@ -401,7 +401,7 @@ func TestSchemaExtensionCompatibilityCheck_Details_EmptyWhenNoExtensions(t *test
 	require.Equal(t, map[string]any{"source_extensions": []string{}}, check.Details())
 	data, err := json.Marshal(CheckResult{Name: "x", Details: check.Details()})
 	require.NoError(t, err)
-	require.JSONEq(t, `{"name":"x","findings":null,"source_extensions":[]}`, string(data))
+	require.JSONEq(t, `{"name":"x","findings":null,"details":{"source_extensions":[]}}`, string(data))
 }
 
 func TestSchemaExtensionCompatibilityCheck_Run_MissingExtensionReturnsFinding(t *testing.T) {

--- a/pkg/stream/preflight/size.go
+++ b/pkg/stream/preflight/size.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import "fmt"
+
+// prettySize renders a byte count in the same format as pg_size_pretty. Size
+// checks report bytes through Details and render them here, so this is the one
+// place where a byte count becomes text. Postgres steps up to the next unit
+// when the value reaches 10 times that unit, and rounds half away from zero at
+// each step (see pg_size_pretty in src/backend/utils/adt/dbsize.c).
+func prettySize(bytes int64) string {
+	const (
+		unit  = 1024
+		limit = 10 * unit
+	)
+	if abs(bytes) < limit {
+		return fmt.Sprintf("%d bytes", bytes)
+	}
+	size := bytes
+	for _, suffix := range []string{"kB", "MB", "GB", "TB"} {
+		size = roundedDiv(size, unit)
+		if abs(size) < limit || suffix == "TB" {
+			return fmt.Sprintf("%d %s", size, suffix)
+		}
+	}
+	return fmt.Sprintf("%d TB", size)
+}
+
+// roundedDiv divides value by divisor and rounds half away from zero. This
+// matches the rounding that Postgres applies at each unit step.
+func roundedDiv(value, divisor int64) int64 {
+	half := divisor / 2
+	if value < 0 {
+		return -((-value + half) / divisor)
+	}
+	return (value + half) / divisor
+}
+
+func abs(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/pkg/stream/preflight/size_test.go
+++ b/pkg/stream/preflight/size_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrettySize pins prettySize to pg_size_pretty. The expectations were read
+// off a live PostgreSQL 16 (SELECT pg_size_pretty(b::bigint)), so a drift in
+// the Go implementation shows up as a mismatch with the server that formats the
+// per-row strings printed beside these totals.
+func TestPrettySize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		bytes int64
+		want  string
+	}{
+		{-10485760, "-10 MB"},
+		{-1024, "-1024 bytes"},
+		{0, "0 bytes"},
+		{1, "1 bytes"},
+		{512, "512 bytes"},
+		{1023, "1023 bytes"},
+		{1024, "1024 bytes"},
+		{10239, "10239 bytes"},
+		{10240, "10 kB"},
+		{10241, "10 kB"},
+		{524288, "512 kB"},
+		{1048576, "1024 kB"},
+		{1384448, "1352 kB"},
+		{2752512, "2688 kB"},
+		{4857856, "4744 kB"},
+		{10485759, "10 MB"},
+		{10485760, "10 MB"},
+		{10485761, "10 MB"},
+		{1073741824, "1024 MB"},
+		{5000000000, "4768 MB"},
+		{10737418239, "10 GB"},
+		{10737418240, "10 GB"},
+		{1099511627776, "1024 GB"},
+		{10995116277760, "10 TB"},
+		{10995116277761, "10 TB"},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprint(tc.bytes), func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, prettySize(tc.bytes))
+		})
+	}
+}

--- a/pkg/stream/preflight/version.go
+++ b/pkg/stream/preflight/version.go
@@ -98,6 +98,15 @@ func (c *PostgresVersionCheck) Details() map[string]any {
 	return details
 }
 
+// Summary reports the version for the human-readable report. It reports the
+// source version alone when there is no target, and both versions otherwise.
+func (c *PostgresVersionCheck) Summary() string {
+	if c.Target == nil {
+		return c.sourceVersion.String()
+	}
+	return fmt.Sprintf("source %s → target %s", c.sourceVersion, c.targetVersion)
+}
+
 // queryPostgresVersion reads server_version_num from conn.
 func queryPostgresVersion(ctx context.Context, conn postgres.Querier) (pgVersion, error) {
 	var num int

--- a/pkg/wal/processor/postgres/postgres_bulk_ingest_writer_test.go
+++ b/pkg/wal/processor/postgres/postgres_bulk_ingest_writer_test.go
@@ -196,6 +196,17 @@ func TestBulkIngestWriter_ProcessWALEvent(t *testing.T) {
 				batchSenderBuilder: tc.batchSenderBuilder,
 			}
 
+			// Snapshot the senders the test case seeded. The writer builds
+			// further senders into the same map while processing, so reading
+			// it back once processing has started is both racy and
+			// non-deterministic.
+			senders := make(map[string]*batchmocks.BatchSender[*query], len(tc.batchSenderMap))
+			for key, sender := range tc.batchSenderMap {
+				mockSender, ok := sender.(*batchmocks.BatchSender[*query])
+				require.True(t, ok)
+				senders[key] = mockSender
+			}
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
@@ -212,12 +223,9 @@ func TestBulkIngestWriter_ProcessWALEvent(t *testing.T) {
 			}()
 
 			eg := errgroup.Group{}
-			for key, sender := range writer.batchSenderMap.GetMap() {
+			for key, sender := range senders {
 				eg.Go(func() error {
-					s, ok := sender.(*batchmocks.BatchSender[*query])
-					require.True(t, ok)
-					msgs := s.GetWALMessages()
-					require.Equal(t, tc.wantMsgs[key], msgs)
+					require.Equal(t, tc.wantMsgs[key], sender.GetWALMessages())
 					return nil
 				})
 			}


### PR DESCRIPTION
#### Description

Adds `DatabaseSizeCheck`, an informational preflight check reporting the on-disk size of the source database, so a migration run keeps a record of the source it was sized against. No database size is wrong on its own, so the check never produces a finding.

Making that size visible needed two supporting changes: a way for a check to contribute a human-readable line, and a fix to how `Details` is nested in the JSON report.

This is reported to help the user determine the size of the target database.

```
✔ postgres_version  16.11
✔ database_size     35 MB
```

```json
{ "name": "database_size", "findings": null,
  "details": { "database_size_bytes": 36590051 } }
```


#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- `DatabaseSizeCheck` in the `resources` category, reporting as `database_size` and running `pg_database_size(current_database())`
- Optional `Summarizer` interface beside `Detailer`. A check returns one line, and `ReportPrinter` renders it next to the check name in an aligned column. `PostgresVersionCheck` adopts it too.
- `prettySize`, a `pg_size_pretty`-compatible formatter. Byte counts stay raw in `Details` and become text in one place only, matching the formatting the server itself produces.
- `CheckResult.MarshalJSON` now marshals a `checkResultJSON` struct, nesting `Details` under a `details` key instead of flattening it into the result object.

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
