### PR TITLE
Bind the env vars the configuration reads

### DIFF
--- a/cmd/config/config_env.go
+++ b/cmd/config/config_env.go
@@ -31,10 +31,23 @@ import (
 )
 
 func init() {
+	bindEnvVars()
+}
+
+// bindEnvVars registers every environment variable the configuration reads.
+// viper resolves an environment variable only for the keys registered here:
+// the AutomaticEnv fallback the root command sets up looks each key up under a
+// second PGSTREAM_ prefix, so it never matches these names. A key that is read
+// but not registered is silently ignored when an operator exports it.
+//
+// Tests that reset viper's global state have to call this again.
+func bindEnvVars() {
 	viper.BindEnv("PGSTREAM_METRICS_ENDPOINT")
 	viper.BindEnv("PGSTREAM_METRICS_COLLECTION_INTERVAL")
 	viper.BindEnv("PGSTREAM_TRACES_ENDPOINT")
 	viper.BindEnv("PGSTREAM_TRACES_SAMPLE_RATIO")
+	viper.BindEnv("PGSTREAM_METRICS_PROMETHEUS_ENABLED")
+	viper.BindEnv("PGSTREAM_METRICS_PROMETHEUS_ENDPOINT")
 
 	viper.BindEnv("PGSTREAM_HEALTH_CHECK_ENABLED")
 	viper.BindEnv("PGSTREAM_HEALTH_CHECK_ADDRESS")
@@ -48,6 +61,8 @@ func init() {
 	viper.BindEnv("PGSTREAM_POSTGRES_LISTENER_DISABLE_RETRIES")
 	viper.BindEnv("PGSTREAM_POSTGRES_REPLICATION_SLOT_NAME")
 	viper.BindEnv("PGSTREAM_POSTGRES_REPLICATION_PLUGIN_INCLUDE_XIDS")
+	viper.BindEnv("PGSTREAM_POSTGRES_REPLICATION_PLUGIN_ADD_TABLES")
+	viper.BindEnv("PGSTREAM_POSTGRES_REPLICATION_PLUGIN_FILTER_TABLES")
 
 	viper.BindEnv("PGSTREAM_POSTGRES_SNAPSHOT_BATCH_BYTES")
 	viper.BindEnv("PGSTREAM_POSTGRES_SNAPSHOT_SCHEMA_WORKERS")

--- a/cmd/config/config_env_binding_test.go
+++ b/cmd/config/config_env_binding_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	viperReadRegex     = regexp.MustCompile(`viper\.Get\w*\("(PGSTREAM_[A-Z0-9_]+)"\)`)
+	viperBindEnvRegex  = regexp.MustCompile(`viper\.BindEnv\("(PGSTREAM_[A-Z0-9_]+)"\)`)
+	errUnboundEnvVarFn = "environment variables read by cmd/config but never registered in bindEnvVars, so exporting them has no effect"
+)
+
+// Test_bindEnvVars_readKeysAreBound guards a class of silent misconfiguration
+// rather than a single variable. viper resolves an environment variable only
+// for the keys bound with BindEnv: the AutomaticEnv fallback the root command
+// installs looks each key up under a second PGSTREAM_ prefix, so it never
+// matches these names, and a key that is read but not bound is ignored with no
+// error anywhere. The keys are scanned out of the source because the read and
+// the registration sit in different places and nothing else ties them together.
+//
+// Keys assembled at runtime (the backoff and TLS helpers build theirs from a
+// prefix) are not matched by the scan and are not covered.
+func Test_bindEnvVars_readKeysAreBound(t *testing.T) {
+	readKeys := map[string]string{}
+	boundKeys := map[string]struct{}{}
+
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		src, err := os.ReadFile(name)
+		require.NoError(t, err)
+		for _, match := range viperReadRegex.FindAllStringSubmatch(string(src), -1) {
+			readKeys[match[1]] = name
+		}
+		for _, match := range viperBindEnvRegex.FindAllStringSubmatch(string(src), -1) {
+			boundKeys[match[1]] = struct{}{}
+		}
+	}
+
+	// a scan that finds nothing would pass without checking anything
+	require.NotEmpty(t, readKeys)
+	require.NotEmpty(t, boundKeys)
+
+	unbound := []string{}
+	for key, file := range readKeys {
+		if _, found := boundKeys[key]; !found {
+			unbound = append(unbound, key+" (read in "+file+")")
+		}
+	}
+	slices.Sort(unbound)
+	require.Empty(t, unbound, errUnboundEnvVarFn)
+}
+
+// Test_bindEnvVars_resolvesFromTheEnvironment covers what the scan above
+// cannot: that a registered key is actually resolved from the process
+// environment. The other tests in this package share viper's global config
+// map with the ones that load test_config.env, so a value can appear to come
+// from the environment while it is really being read out of that file.
+func Test_bindEnvVars_resolvesFromTheEnvironment(t *testing.T) {
+	reset := func() {
+		viper.Reset()
+		bindEnvVars()
+	}
+	reset()
+	t.Cleanup(reset)
+
+	t.Setenv("PGSTREAM_POSTGRES_SNAPSHOT_ROLE", "a-role-from-the-environment")
+	require.Equal(t, "a-role-from-the-environment", viper.GetString("PGSTREAM_POSTGRES_SNAPSHOT_ROLE"))
+}


### PR DESCRIPTION
#### Description

viper resolves an environment variable only for the keys registered with BindEnv. The AutomaticEnv fallback the root command installs does not cover them: it looks each key up under a second PGSTREAM_ prefix, so it never matches a name that already starts with one. A key that is read but never registered is therefore ignored when an operator exports it, with nothing logged and no error.

Four documented variables were in that state, silently doing nothing
outside a config file:

* `PGSTREAM_METRICS_PROMETHEUS_ENABLED`
* `PGSTREAM_METRICS_PROMETHEUS_ENDPOINT`
* `PGSTREAM_POSTGRES_REPLICATION_PLUGIN_ADD_TABLES`
* `PGSTREAM_POSTGRES_REPLICATION_PLUGIN_FILTER_TABLES`

Register them, and add a test that scans the package for the keys it
reads and fails on any that is never bound.

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
