### PR TITLE
Add `fpe_ff1` format-preserving transformer for emails, phone numbers

### DIFF
--- a/docs/examples/transformer_rules.yaml
+++ b/docs/examples/transformer_rules.yaml
@@ -15,3 +15,12 @@ transformations:
             # example key only — generate your own with `openssl rand -hex 64`
             key_hex: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
             associated_data: "public.test.document_path"
+        phone_number:
+          name: fpe_ff1
+          parameters:
+            # example key only. make your own with `openssl rand -hex 32`.
+            key_hex: "000102030405060708090a0b0c0d0e0f"
+            associated_data: "public.test.phone_number"
+            alphabet: digits
+            passthrough: keep
+            keep_prefix: 4

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -23,6 +23,7 @@ Each transformer declares how it behaves with respect to uniqueness:
 | Transformer                | Uniqueness       |
 | -------------------------- | ---------------- |
 | `encrypted_aes_siv`        | `preserved`      |
+| `fpe_ff1`                  | `preserved`      |
 | `email`                    | `not_guaranteed` |
 | `greenmask_date`           | `not_guaranteed` |
 | `greenmask_float`          | `not_guaranteed` |
@@ -71,7 +72,9 @@ column_transformers:
 
 If you need an anonymized column to stay unique, use `encrypted_aes_siv`: it is deterministic, so equality relationships survive across rows, tables and runs, and no two distinct inputs share a token. Its output is a base64 token rather than a value in the original format.
 
-⚠️ `encrypted_aes_siv` is **pseudonymization, not anonymization**. The output is reversible by anyone holding `key_hex`, so it remains personal data, and because tokens are stable they can be correlated across tables and across successive dumps. Treat `key_hex` as a secret: inject it from a secret store rather than committing it in the rules file, use a different key per environment, and set `associated_data` (for example `schema.table.column`) so tokens cannot be correlated between columns.
+Use `fpe_ff1` when the column must also keep its format. For example, a phone number must stay a phone number, and a code must still fit a `varchar(12)` column. `fpe_ff1` encrypts with a format-preserving algorithm. The output has the same length and the same characters as the input. Two different inputs always give two different outputs.
+
+⚠️ `encrypted_aes_siv` and `fpe_ff1` are **pseudonymization, not anonymization**. The output is reversible by anyone holding `key_hex`, so it remains personal data, and because tokens are stable they can be correlated across tables and across successive dumps. Treat `key_hex` as a secret: inject it from a secret store rather than committing it in the rules file, use a different key per environment, and set `associated_data` (for example `schema.table.column`) so tokens cannot be correlated between columns.
 
 ### What the check does not cover
 
@@ -1258,6 +1261,95 @@ transformations:
 | `hello world` | `key_hex: "000102…3e3f"`, `associated_data: "public.orders.file_path"` (example above) | `AsC2hoq-Y9V0iqK6JmNIxq0Fsr3SFPo27QNq` |
 
 Every run with the same key and parameters produces the same output. Tokens can be decrypted with any RFC 5297 AES-SIV implementation, for example Tink's `daead/subtle` package in Go.
+
+</details>
+
+ <details>
+  <summary>fpe_ff1</summary>
+
+**Description:** This transformer encrypts values with FF1 ([NIST SP 800-38G](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38G.pdf)). FF1 is a format-preserving encryption algorithm. The output contains the same characters as the input, and it has the same length. An encrypted phone number is still a phone number. An encrypted product code still fits a `varchar(n)` column. The transformer copies the characters that are not in the alphabet to the same positions in the output.
+
+**Uniqueness:** `preserved`. FF1 maps each input to one different output. Two different inputs cannot give the same output. Use this transformer when a unique column must keep its format. Use `encrypted_aes_siv` when the format is not important.
+
+| Supported PostgreSQL types      |
+| ------------------------------- |
+| `text`, `varchar`, `char`, `bpchar` |
+
+| Parameter       | Type   | Default  | Required | Values                                       |
+| --------------- | ------ | -------- | -------- | -------------------------------------------- |
+| key_hex         | string | N/A      | Yes      | 32, 48 or 64 hexadecimal characters          |
+| associated_data | string | ""       | No       | Any string                                   |
+| alphabet        | string | digits   | No       | `digits`, `letters`, `alphanumeric`, or a set of characters |
+| passthrough     | string | keep     | No       | `keep`, `error`                              |
+| keep_prefix     | int    | 0        | No       | Number of characters in the alphabet to keep at the start |
+| keep_suffix     | int    | 0        | No       | Number of characters in the alphabet to keep at the end |
+| min_length      | int    | 0        | No       | 0 sets the minimum that FF1 permits for the alphabet |
+| preserve_from   | string | ""       | No       | A delimiter. The transformer keeps the text from its last occurrence. |
+
+`key_hex` is the AES key in hexadecimal. Use 32, 48 or 64 characters for a key of 128, 192 or 256 bits. To make a key, run `openssl rand -hex 32`. The `encrypted_aes_siv` transformer is different, because it needs a key of 64 bytes.
+
+`associated_data` is the FF1 tweak. The tweak is not secret. It makes the output different for each column when you use the same key. Set it to `schema.table.column`.
+
+`alphabet` is the set of characters that the transformer encrypts. There are three named sets: `digits` (`0-9`), `letters` (`a-zA-Z`) and `alphanumeric` (`0-9a-zA-Z`). Any other value is a set of characters that you write out. Such a set must contain two characters or more, and it must not contain a character two times. The transformer does not encrypt the characters that are not in the alphabet.
+
+`passthrough` controls the characters that are not in the alphabet. The value `keep` copies these characters to the output. Characters such as `-`, `+` and the space stay in a phone number. The value `error` rejects the value.
+
+`keep_prefix` and `keep_suffix` keep a number of characters without a change. Use them to keep a country code or a check digit. These parameters count only the characters in the alphabet. Separators do not increase the count, because the transformer does not encrypt them. For example, set `keep_prefix: 4` for a `digits` column. The transformer then keeps the country code and the operator code of `+36301234567`, `+36 30 123 4567` and `+36-30-123-4567`. The three formats give the same digits in the output. The transformer rejects a value that has too few characters. Refer to the first caution below.
+
+`preserve_from` keeps the end of the value without a change. The part that the transformer keeps starts at the **last** occurrence of the delimiter. Use this parameter when a delimiter marks the part to keep. `keep_suffix` keeps a fixed number of characters, but `preserve_from` keeps a variable number. In an email address, `preserve_from: "@"` keeps the full domain. `preserve_from: "."` keeps only the top-level domain, and it encrypts the domain name. If the value does not contain the delimiter, the transformer encrypts the full value. The delimiter must not contain a character from the alphabet. If it does, pgstream rejects the configuration when it starts. The transformer copies only the characters that are not in the alphabet to the same position in the output. This condition is necessary to keep the outputs unique.
+
+**⚠️ The transformer rejects short values.** FF1 does not encrypt a set of possible values that is smaller than 10<sup>6</sup>, because an attacker can try all of them. For `digits`, a value must contain 6 characters or more from the alphabet. For `letters` and `alphanumeric`, it must contain 4 characters or more. Count the characters after you remove the prefix, the suffix, and the characters that are not in the alphabet. The transformer returns an error for a shorter value. It does not send the original value to the target, because this makes the data visible. The error goes to the [`on_error`](#transformation-rules) policy, where you select `fail`, `pass-through` or `null`. Be careful with `pass-through`, because it writes the original value to the target. `min_length` increases the minimum, for example to 9 digits. It cannot decrease the minimum.
+
+**⚠️ The transformer keeps the format, but the output is not realistic.** A phone number stays a possible phone number, and a code stays a valid code. But with `alphabet: letters`, a company name becomes a random text such as `Dmkh VjksJwk`. The output has the shape of a name and it is unique, but it is not a real company name.
+
+**Email addresses.** With `alphabet: alphanumeric` and `passthrough: keep`, the transformer encrypts the local part, the domain and the top-level domain. The address `john.doe@example.com` becomes `FdSQ.v6s@udengIL.0Td`. The top-level domain is not valid, and a mail server cannot deliver to this address. Use `preserve_from` to correct this:
+
+| `preserve_from` | Result                 | What the transformer encrypts             |
+| --------------- | ---------------------- | ----------------------------------------- |
+| unset           | `FdSQ.v6s@udengIL.0Td` | The full address. The top-level domain is not valid. |
+| `"."`           | `lHtC.Mr7@1uH9RP1.com` | The local part and the domain name. The transformer keeps the top-level domain, thus the address has a correct format. |
+| `"@"`           | `69pe.Nzy@example.com` | The local part only. The address is valid, but the target shows the domain. |
+
+Select the option that agrees with your data. Do not use `preserve_from: "@"` when the domain is sensitive, because the target then contains each source domain. All three options keep the outputs unique. Use `neosync_email` with `preserve_domain: true` when a mail server must deliver to the address. That transformer makes a new local part, but its uniqueness is `not_guaranteed`. Two different addresses can give the same output.
+
+**Security note:** The encryption is deterministic. Equal inputs give equal outputs. This shows which values are equal, but it shows no other data. A person who has the key can decrypt the values. Keep the key in a secret manager, and do not store it with the transformed data.
+
+**Example Configuration:**
+
+```yaml
+transformations:
+  table_transformers:
+    - schema: public
+      table: persons
+      column_transformers:
+        phone_number:
+          name: fpe_ff1
+          parameters:
+            # example key only — generate your own and load it from a secret store
+            key_hex: "000102030405060708090a0b0c0d0e0f"
+            associated_data: "public.persons.phone_number"
+            alphabet: digits
+            passthrough: keep
+            # keep 4 digits: the country code and the operator code.
+            # separators do not increase this count.
+            keep_prefix: 4
+```
+
+**Input-Output Examples:**
+
+| Input                  | Configuration Parameters                                                | Output                 |
+| ---------------------- | ----------------------------------------------------------------------- | ---------------------- |
+| `1234567890`           | `key_hex: "000102…0e0f"`, no `associated_data`                            | `5102547240`           |
+| `1234567890`           | `key_hex: "000102…0e0f"`, `associated_data: "public.persons.phone_number"` | `0453276999`           |
+| `+36301234567`         | as the example above (`keep_prefix: 4`)                                   | `+36303497985`         |
+| `+36 30 123 4567`      | as the example above (`keep_prefix: 4`)                                   | `+36 30 349 7985`      |
+| `(301) 555-0123`       | as the example above (`keep_prefix: 4`)                                   | `(301) 545-8564`       |
+| `Acme Trading`         | `key_hex: "000102…0e0f"`, `alphabet: letters`                             | `Dmkh VjksJwk`         |
+| `john.doe@example.com` | `key_hex: "000102…0e0f"`, `alphabet: alphanumeric`                        | `FdSQ.v6s@udengIL.0Td` |
+| `john.doe@example.com` | `key_hex: "000102…0e0f"`, `alphabet: alphanumeric`, `preserve_from: "."`   | `lHtC.Mr7@1uH9RP1.com` |
+| `john.doe@example.com` | `key_hex: "000102…0e0f"`, `alphabet: alphanumeric`, `preserve_from: "@"`   | `69pe.Nzy@example.com` |
+
+Each run gives the same output for the same key and the same parameters. Any NIST FF1 implementation can decrypt the values. It needs the key, the tweak and the alphabet.
 
 </details>
 

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/tidwall/gjson v1.19.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/tink-crypto/tink-go/v2 v2.8.0
+	gitlab.com/ubiqsecurity/ubiq-fpe-go v0.0.0-20241024183258-f0d5bc065c59
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.70.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.45.0

--- a/go.sum
+++ b/go.sum
@@ -520,6 +520,8 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+gitlab.com/ubiqsecurity/ubiq-fpe-go v0.0.0-20241024183258-f0d5bc065c59 h1:hHsuZH6kaDJoCZDyGps/dxbkxEBujalPMu6hXrHxJlw=
+gitlab.com/ubiqsecurity/ubiq-fpe-go v0.0.0-20241024183258-f0d5bc065c59/go.mod h1:XiIs3QwuPF3dc1lg+XbNKgdMpx1/MikiJcwaPpYBSBg=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 h1:8tvICD4vSTOOsNrsI4Ljf6C+6UKvpTEH5XY3JMoyPoo=

--- a/pkg/transformers/builder/transformer_builder.go
+++ b/pkg/transformers/builder/transformer_builder.go
@@ -90,6 +90,12 @@ var TransformersMap = map[transformers.TransformerType]struct {
 			return transformers.NewEncryptedAESSIVTransformer(cfg.Parameters)
 		},
 	},
+	transformers.FPEFF1: {
+		Definition: transformers.FPEFF1TransformerDefinition(),
+		BuildFn: func(cfg *transformers.Config) (transformers.Transformer, error) {
+			return transformers.NewFPEFF1Transformer(cfg.Parameters)
+		},
+	},
 	// Greenmask transformers
 	transformers.GreenmaskString: {
 		Definition: greenmask.StringTransformerDefinition(),

--- a/pkg/transformers/builder/transformer_concurrency_test.go
+++ b/pkg/transformers/builder/transformer_concurrency_test.go
@@ -102,6 +102,18 @@ func TestTransformers_ConcurrentTransform(t *testing.T) {
 				require.Equal(t, "Hc5d96xIxu2ute1RbFuenEftGxw-P__m1Vv_", got)
 			},
 		},
+		transformers.FPEFF1: {
+			params: transformers.ParameterValues{
+				// bytes 0x00..0x0f — a fixed, obviously-test 128 bit key
+				"key_hex": "000102030405060708090a0b0c0d0e0f",
+			},
+			input: "1234567890",
+			validate: func(t *testing.T, got any) {
+				// FF1 is deterministic, and the pooled ciphers keep mutable
+				// scratch state: a torn one would not produce this token
+				require.Equal(t, "5102547240", got)
+			},
+		},
 		transformers.GreenmaskString: {
 			params:             transformers.ParameterValues{"min_length": 2, "max_length": 12},
 			input:              "hello world",

--- a/pkg/transformers/builder/transformer_uniqueness_test.go
+++ b/pkg/transformers/builder/transformer_uniqueness_test.go
@@ -24,6 +24,7 @@ func TestTransformers_UniquenessMatchesDefinition(t *testing.T) {
 		transformers.LiteralString:          {"literal": "fixed"},
 		transformers.String:                 {},
 		transformers.EncryptedAESSIV:        {"key_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"},
+		transformers.FPEFF1:                 {"key_hex": "000102030405060708090a0b0c0d0e0f"},
 		transformers.GreenmaskString:        {"min_length": 2, "max_length": 12},
 		transformers.GreenmaskFirstName:     {},
 		transformers.GreenmaskInteger:       {"min_value": 0, "max_value": 1000},

--- a/pkg/transformers/fpe_ff1_transformer.go
+++ b/pkg/transformers/fpe_ff1_transformer.go
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformers
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+	"sync"
+
+	ubiq "gitlab.com/ubiqsecurity/ubiq-fpe-go"
+)
+
+// FPEFF1Transformer encrypts values with FF1 (NIST SP 800-38G). The output
+// contains the same characters as the input, and it has the same length. Two
+// different inputs always give two different outputs, thus the transformer is
+// safe on a column with a unique index. The transformer copies the characters
+// that are not in the alphabet to the same positions in the output. A person
+// who has the key can decrypt the values.
+type FPEFF1Transformer struct {
+	ciphers          *sync.Pool
+	alphabet         map[rune]struct{}
+	minLength        int
+	keepPrefix       int
+	keepSuffix       int
+	preserveFrom     []rune
+	errOnNonAlphabet bool
+}
+
+const (
+	fpeFF1AlphabetDigits       = "0123456789"
+	fpeFF1AlphabetLetters      = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	fpeFF1AlphabetAlphanumeric = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	fpeFF1PassthroughKeep  = "keep"
+	fpeFF1PassthroughError = "error"
+
+	fpeFF1MinDomainDigits = 6
+)
+
+var (
+	errFPEFF1KeyNotFound            = errors.New("fpe_ff1_transformer: key_hex parameter not found")
+	errFPEFF1KeyInvalid             = errors.New("fpe_ff1_transformer: key_hex must be 16, 24 or 32 hex-encoded bytes (128, 192 or 256 bit AES key)")
+	errFPEFF1AlphabetTooSmall       = errors.New("fpe_ff1_transformer: alphabet must contain at least 2 characters")
+	errFPEFF1AlphabetDuplicate      = errors.New("fpe_ff1_transformer: alphabet must not contain duplicate characters")
+	errFPEFF1PassthroughValue       = fmt.Errorf("fpe_ff1_transformer: passthrough must be %q or %q", fpeFF1PassthroughKeep, fpeFF1PassthroughError)
+	errFPEFF1KeepNegative           = errors.New("fpe_ff1_transformer: keep_prefix and keep_suffix must not be negative")
+	errFPEFF1PreserveFromInAlphabet = errors.New("fpe_ff1_transformer: preserve_from must not contain characters from the alphabet, because the transformer must find the delimiter in the output")
+	errFPEFF1ValueTooShort          = errors.New("fpe_ff1_transformer: value is too short to encrypt")
+	errFPEFF1CharNotInAlphabet      = errors.New("fpe_ff1_transformer: value contains a character that is not in the alphabet")
+	errFPEFF1CipherUnavailable      = errors.New("fpe_ff1_transformer: failed to build FF1 cipher")
+
+	fpeFF1NamedAlphabets = map[string]string{
+		"digits":       fpeFF1AlphabetDigits,
+		"letters":      fpeFF1AlphabetLetters,
+		"alphanumeric": fpeFF1AlphabetAlphanumeric,
+	}
+
+	fpeFF1CompatibleTypes = []SupportedDataType{
+		StringDataType,
+	}
+
+	fpeFF1Params = []Parameter{
+		{
+			Name:          "key_hex",
+			SupportedType: "string",
+			Default:       nil,
+			Dynamic:       false,
+			Required:      true,
+		},
+		{
+			Name:          "associated_data",
+			SupportedType: "string",
+			Default:       "",
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "alphabet",
+			SupportedType: "string",
+			Default:       "digits",
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "passthrough",
+			SupportedType: "string",
+			Default:       fpeFF1PassthroughKeep,
+			Dynamic:       false,
+			Required:      false,
+			Values:        []any{fpeFF1PassthroughKeep, fpeFF1PassthroughError},
+		},
+		{
+			Name:          "keep_prefix",
+			SupportedType: "int",
+			Default:       0,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "keep_suffix",
+			SupportedType: "int",
+			Default:       0,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "min_length",
+			SupportedType: "int",
+			Default:       0,
+			Dynamic:       false,
+			Required:      false,
+		},
+		{
+			Name:          "preserve_from",
+			SupportedType: "string",
+			Default:       "",
+			Dynamic:       false,
+			Required:      false,
+		},
+	}
+)
+
+func NewFPEFF1Transformer(params ParameterValues) (*FPEFF1Transformer, error) {
+	keyHex, found, err := FindParameter[string](params, "key_hex")
+	if err != nil {
+		return nil, fmt.Errorf("fpe_ff1_transformer: key_hex must be a string: %w", err)
+	}
+	if !found {
+		return nil, errFPEFF1KeyNotFound
+	}
+	key, err := hex.DecodeString(keyHex)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errFPEFF1KeyInvalid, err)
+	}
+	switch len(key) {
+	case 16, 24, 32:
+	default:
+		return nil, fmt.Errorf("%w: got %d bytes", errFPEFF1KeyInvalid, len(key))
+	}
+
+	aad, err := FindParameterWithDefault(params, "associated_data", "")
+	if err != nil {
+		return nil, fmt.Errorf("fpe_ff1_transformer: associated_data must be a string: %w", err)
+	}
+
+	alphabetParam, err := FindParameterWithDefault(params, "alphabet", "digits")
+	if err != nil {
+		return nil, fmt.Errorf("fpe_ff1_transformer: alphabet must be a string: %w", err)
+	}
+	alphabet, alphabetSet, err := resolveFPEFF1Alphabet(alphabetParam)
+	if err != nil {
+		return nil, err
+	}
+
+	passthrough, err := FindParameterWithDefault(params, "passthrough", fpeFF1PassthroughKeep)
+	if err != nil {
+		return nil, fmt.Errorf("fpe_ff1_transformer: passthrough must be a string: %w", err)
+	}
+	if passthrough != fpeFF1PassthroughKeep && passthrough != fpeFF1PassthroughError {
+		return nil, fmt.Errorf("%w: got %q", errFPEFF1PassthroughValue, passthrough)
+	}
+
+	keepPrefix, err := FindParameterWithDefault(params, "keep_prefix", 0)
+	if err != nil {
+		return nil, fmt.Errorf("fpe_ff1_transformer: keep_prefix must be an integer: %w", err)
+	}
+	keepSuffix, err := FindParameterWithDefault(params, "keep_suffix", 0)
+	if err != nil {
+		return nil, fmt.Errorf("fpe_ff1_transformer: keep_suffix must be an integer: %w", err)
+	}
+	if keepPrefix < 0 || keepSuffix < 0 {
+		return nil, errFPEFF1KeepNegative
+	}
+
+	preserveFromParam, err := FindParameterWithDefault(params, "preserve_from", "")
+	if err != nil {
+		return nil, fmt.Errorf("fpe_ff1_transformer: preserve_from must be a string: %w", err)
+	}
+	preserveFrom, err := parseFPEFF1PreserveFrom(preserveFromParam, alphabetSet)
+	if err != nil {
+		return nil, err
+	}
+
+	// FF1 does not encrypt a set of possible values that is smaller than
+	// 10^6, because an attacker can try all of them. min_length increases
+	// this minimum, but it cannot decrease it.
+	secureMinLength := fpeFF1SecureMinLength(len(alphabetSet))
+	minLength, err := FindParameterWithDefault(params, "min_length", 0)
+	if err != nil {
+		return nil, fmt.Errorf("fpe_ff1_transformer: min_length must be an integer: %w", err)
+	}
+	switch {
+	case minLength == 0:
+		minLength = secureMinLength
+	case minLength < secureMinLength:
+		return nil, fmt.Errorf("fpe_ff1_transformer: min_length %d is below the %d characters FF1 requires for an alphabet of %d characters",
+			minLength, secureMinLength, len(alphabetSet))
+	}
+
+	ciphers := &sync.Pool{
+		New: func() any {
+			// the ubiq FF1 context changes its own scratch state during
+			// encryption. two transformations cannot share one cipher.
+			cipher, err := newFPEFF1Cipher(key, []byte(aad), alphabet)
+			if err != nil {
+				return nil
+			}
+			return cipher
+		},
+	}
+
+	// build one cipher now. a bad key or alphabet then stops the pipeline at
+	// start-up, and not at the first row.
+	if _, err := newFPEFF1Cipher(key, []byte(aad), alphabet); err != nil {
+		return nil, fmt.Errorf("%w: %w", errFPEFF1CipherUnavailable, err)
+	}
+
+	return &FPEFF1Transformer{
+		ciphers:          ciphers,
+		alphabet:         alphabetSet,
+		minLength:        minLength,
+		keepPrefix:       keepPrefix,
+		keepSuffix:       keepSuffix,
+		preserveFrom:     preserveFrom,
+		errOnNonAlphabet: passthrough == fpeFF1PassthroughError,
+	}, nil
+}
+
+func newFPEFF1Cipher(key, tweak []byte, alphabet string) (*ubiq.FF1, error) {
+	// 0 and 0 remove the limits on the tweak length. the tweak is
+	// configuration from the operator, not input from an attacker.
+	return ubiq.NewFF1(key, tweak, 0, 0, len([]rune(alphabet)), alphabet)
+}
+
+// resolveFPEFF1Alphabet reads a named alphabet or a set of characters. It
+// returns the characters, and a set that tests membership.
+func resolveFPEFF1Alphabet(param string) (string, map[rune]struct{}, error) {
+	alphabet, found := fpeFF1NamedAlphabets[param]
+	if !found {
+		alphabet = param
+	}
+
+	runes := []rune(alphabet)
+	if len(runes) < 2 {
+		return "", nil, fmt.Errorf("%w: got %d", errFPEFF1AlphabetTooSmall, len(runes))
+	}
+
+	alphabetSet := make(map[rune]struct{}, len(runes))
+	for _, r := range runes {
+		if _, duplicate := alphabetSet[r]; duplicate {
+			return "", nil, fmt.Errorf("%w: %q appears more than once", errFPEFF1AlphabetDuplicate, r)
+		}
+		alphabetSet[r] = struct{}{}
+	}
+
+	return alphabet, alphabetSet, nil
+}
+
+// parseFPEFF1PreserveFrom validates the delimiter that marks the start of the
+// preserved end of the value. Each character of the delimiter must not be in
+// the alphabet. The transformer copies such characters to the same position in
+// the output, thus it finds the delimiter again. The encryption can create or
+// remove a delimiter that is in the alphabet, and the outputs are then not
+// unique.
+func parseFPEFF1PreserveFrom(param string, alphabetSet map[rune]struct{}) ([]rune, error) {
+	if param == "" {
+		return nil, nil
+	}
+
+	delimiter := []rune(param)
+	for _, r := range delimiter {
+		if _, inAlphabet := alphabetSet[r]; inAlphabet {
+			return nil, fmt.Errorf("%w: %q", errFPEFF1PreserveFromInAlphabet, r)
+		}
+	}
+
+	return delimiter, nil
+}
+
+// fpeFF1SecureMinLength returns the shortest input that FF1 encrypts in the
+// given radix. This is the smallest n where radix^n is 10^6 or more.
+func fpeFF1SecureMinLength(radix int) int {
+	return int(math.Ceil(float64(fpeFF1MinDomainDigits) / math.Log10(float64(radix))))
+}
+
+func (ft *FPEFF1Transformer) Transform(_ context.Context, v Value) (any, error) {
+	val, ok := v.TransformValue.(string)
+	if !ok {
+		return nil, fmt.Errorf("expected string, got %T: %w", v.TransformValue, ErrUnsupportedValueType)
+	}
+	return ft.transform(val)
+}
+
+func (ft *FPEFF1Transformer) transform(val string) (string, error) {
+	runes := []rune(val)
+
+	tailStart := len(runes)
+	if from := ft.preservedTailStart(runes); from >= 0 {
+		tailStart = from
+	}
+
+	// keep_prefix and keep_suffix count only the characters in the alphabet.
+	// the transformer does not encrypt separators, thus separators must not
+	// increase the count. keep_prefix 4 then keeps the first four digits of
+	// "+36301234567" and of "+36 30 123 4567".
+	positions := make([]int, 0, tailStart)
+	for i := range tailStart {
+		if _, inAlphabet := ft.alphabet[runes[i]]; inAlphabet {
+			positions = append(positions, i)
+		}
+	}
+
+	required := ft.keepPrefix + ft.keepSuffix + ft.minLength
+	if len(positions) < required {
+		return "", fmt.Errorf("%w: it has %d characters in the alphabet, but %d are necessary",
+			errFPEFF1ValueTooShort, len(positions), required)
+	}
+	positions = positions[ft.keepPrefix : len(positions)-ft.keepSuffix]
+
+	if ft.errOnNonAlphabet {
+		for i := positions[0]; i < positions[len(positions)-1]; i++ {
+			if _, inAlphabet := ft.alphabet[runes[i]]; !inAlphabet {
+				return "", fmt.Errorf("%w: %q", errFPEFF1CharNotInAlphabet, runes[i])
+			}
+		}
+	}
+
+	plaintext := strings.Builder{}
+	for _, pos := range positions {
+		plaintext.WriteRune(runes[pos])
+	}
+
+	ciphertext, err := ft.encrypt(plaintext.String())
+	if err != nil {
+		return "", fmt.Errorf("fpe_ff1_transformer: %w", err)
+	}
+
+	encrypted := []rune(ciphertext)
+	if len(encrypted) != len(positions) {
+		return "", fmt.Errorf("fpe_ff1_transformer: FF1 returned %d characters for an input of %d", len(encrypted), len(positions))
+	}
+	for i, pos := range positions {
+		runes[pos] = encrypted[i]
+	}
+
+	return string(runes), nil
+}
+
+// preservedTailStart returns the index where the preserved end of the value
+// starts. This is the last occurrence of the preserve_from delimiter. The
+// function returns -1 when preserve_from is empty, or when the value does not
+// contain the delimiter.
+func (ft *FPEFF1Transformer) preservedTailStart(runes []rune) int {
+	if len(ft.preserveFrom) == 0 {
+		return -1
+	}
+	for i := len(runes) - len(ft.preserveFrom); i >= 0; i-- {
+		if slices.Equal(runes[i:i+len(ft.preserveFrom)], ft.preserveFrom) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (ft *FPEFF1Transformer) encrypt(plaintext string) (string, error) {
+	cipher, _ := ft.ciphers.Get().(*ubiq.FF1)
+	if cipher == nil {
+		return "", errFPEFF1CipherUnavailable
+	}
+	defer ft.ciphers.Put(cipher)
+
+	// a nil tweak selects the associated_data from the constructor
+	return cipher.Encrypt(plaintext, nil)
+}
+
+func (ft *FPEFF1Transformer) CompatibleTypes() []SupportedDataType {
+	return fpeFF1CompatibleTypes
+}
+
+func (ft *FPEFF1Transformer) Type() TransformerType {
+	return FPEFF1
+}
+
+func (ft *FPEFF1Transformer) IsDynamic() bool {
+	return false
+}
+
+func (ft *FPEFF1Transformer) Uniqueness() Uniqueness {
+	return UniquenessPreserved
+}
+
+func (ft *FPEFF1Transformer) Close() error {
+	return nil
+}
+
+func FPEFF1TransformerDefinition() *Definition {
+	return &Definition{
+		SupportedTypes: fpeFF1CompatibleTypes,
+		Parameters:     fpeFF1Params,
+		Uniqueness:     UniquenessPreserved,
+	}
+}

--- a/pkg/transformers/fpe_ff1_transformer_test.go
+++ b/pkg/transformers/fpe_ff1_transformer_test.go
@@ -1,0 +1,583 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformers
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// a fixed test key of 128 bits: the bytes 0x00 to 0x0f
+const testFPEFF1KeyHex = "000102030405060708090a0b0c0d0e0f"
+
+func TestNewFPEFF1Transformer(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		params  ParameterValues
+		wantErr error
+	}{
+		{
+			name:    "ok - valid key",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex},
+			wantErr: nil,
+		},
+		{
+			name: "ok - all parameters",
+			params: ParameterValues{
+				"key_hex":         testFPEFF1KeyHex,
+				"associated_data": "public.persons.phone_number",
+				"alphabet":        "alphanumeric",
+				"passthrough":     "error",
+				"keep_prefix":     2,
+				"keep_suffix":     1,
+				"min_length":      8,
+			},
+			wantErr: nil,
+		},
+		{
+			name:    "ok - 192 bit key",
+			params:  ParameterValues{"key_hex": strings.Repeat("ab", 24)},
+			wantErr: nil,
+		},
+		{
+			name:    "ok - 256 bit key",
+			params:  ParameterValues{"key_hex": strings.Repeat("ab", 32)},
+			wantErr: nil,
+		},
+		{
+			name:    "ok - literal alphabet",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex, "alphabet": "ABCDEF"},
+			wantErr: nil,
+		},
+		{
+			name:    "error - key_hex missing",
+			params:  ParameterValues{},
+			wantErr: errFPEFF1KeyNotFound,
+		},
+		{
+			name:    "error - key_hex not a string",
+			params:  ParameterValues{"key_hex": 123},
+			wantErr: ErrInvalidParameters,
+		},
+		{
+			name:    "error - key_hex not valid hex",
+			params:  ParameterValues{"key_hex": strings.Repeat("zx", 16)},
+			wantErr: errFPEFF1KeyInvalid,
+		},
+		{
+			name:    "error - key_hex wrong length",
+			params:  ParameterValues{"key_hex": strings.Repeat("ab", 20)},
+			wantErr: errFPEFF1KeyInvalid,
+		},
+		{
+			name:    "error - associated_data not a string",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex, "associated_data": 1},
+			wantErr: ErrInvalidParameters,
+		},
+		{
+			name:    "error - alphabet too small",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex, "alphabet": "0"},
+			wantErr: errFPEFF1AlphabetTooSmall,
+		},
+		{
+			name:    "error - alphabet with duplicate characters",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex, "alphabet": "01230"},
+			wantErr: errFPEFF1AlphabetDuplicate,
+		},
+		{
+			name:    "ok - preserve_from",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex, "alphabet": "alphanumeric", "preserve_from": "@"},
+			wantErr: nil,
+		},
+		{
+			name:    "error - preserve_from overlaps the alphabet",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex, "alphabet": "alphanumeric", "preserve_from": "x"},
+			wantErr: errFPEFF1PreserveFromInAlphabet,
+		},
+		{
+			name:    "error - preserve_from not a string",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex, "preserve_from": 1},
+			wantErr: ErrInvalidParameters,
+		},
+		{
+			name:    "error - unknown passthrough",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex, "passthrough": "skip"},
+			wantErr: errFPEFF1PassthroughValue,
+		},
+		{
+			name:    "error - negative keep_prefix",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex, "keep_prefix": -1},
+			wantErr: errFPEFF1KeepNegative,
+		},
+		{
+			name:    "error - negative keep_suffix",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex, "keep_suffix": -1},
+			wantErr: errFPEFF1KeepNegative,
+		},
+		{
+			name:    "error - keep_prefix not an integer",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex, "keep_prefix": "2"},
+			wantErr: ErrInvalidParameters,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			transformer, err := NewFPEFF1Transformer(tc.params)
+			require.ErrorIs(t, err, tc.wantErr)
+			if tc.wantErr != nil {
+				return
+			}
+			require.Equal(t, FPEFF1, transformer.Type())
+			require.False(t, transformer.IsDynamic())
+			require.Equal(t, UniquenessPreserved, transformer.Uniqueness())
+			require.Equal(t, fpeFF1CompatibleTypes, transformer.CompatibleTypes())
+			require.NoError(t, transformer.Close())
+		})
+	}
+}
+
+// min_length increases the minimum that FF1 imposes. it cannot decrease it,
+// because an attacker can try all values of a smaller set
+func TestFPEFF1Transformer_minLength(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 6, fpeFF1SecureMinLength(10))
+	require.Equal(t, 4, fpeFF1SecureMinLength(52))
+	require.Equal(t, 4, fpeFF1SecureMinLength(62))
+
+	t.Run("error - below the FF1 floor", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewFPEFF1Transformer(ParameterValues{"key_hex": testFPEFF1KeyHex, "min_length": 5})
+		require.ErrorContains(t, err, "min_length 5 is below the 6 characters")
+	})
+
+	t.Run("ok - defaults to the FF1 floor", func(t *testing.T) {
+		t.Parallel()
+
+		transformer, err := NewFPEFF1Transformer(ParameterValues{"key_hex": testFPEFF1KeyHex})
+		require.NoError(t, err)
+		require.Equal(t, 6, transformer.minLength)
+	})
+
+	t.Run("error - raised floor rejects a shorter value", func(t *testing.T) {
+		t.Parallel()
+
+		transformer, err := NewFPEFF1Transformer(ParameterValues{"key_hex": testFPEFF1KeyHex, "min_length": 9})
+		require.NoError(t, err)
+
+		_, err = transformer.Transform(context.Background(), NewValue("12345678", "text", nil))
+		require.ErrorIs(t, err, errFPEFF1ValueTooShort)
+
+		got, err := transformer.Transform(context.Background(), NewValue("123456789", "text", nil))
+		require.NoError(t, err)
+		require.Len(t, got, 9)
+	})
+}
+
+func TestFPEFF1Transformer_Transform(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		params   ParameterValues
+		input    any
+		validate func(*testing.T, string)
+		wantErr  error
+	}{
+		{
+			name:   "ok - digits keep their format",
+			params: ParameterValues{"key_hex": testFPEFF1KeyHex},
+			input:  "1234567890",
+			validate: func(t *testing.T, got string) {
+				require.Len(t, got, 10)
+				require.NotEqual(t, "1234567890", got)
+				for _, r := range got {
+					require.Contains(t, fpeFF1AlphabetDigits, string(r))
+				}
+			},
+		},
+		{
+			name: "ok - prefix and non alphabet characters survive",
+			params: ParameterValues{
+				"key_hex":     testFPEFF1KeyHex,
+				"keep_prefix": 5,
+			},
+			input: "+36301234567",
+			validate: func(t *testing.T, got string) {
+				require.Len(t, got, len("+36301234567"))
+				require.True(t, strings.HasPrefix(got, "+3630"))
+				require.NotEqual(t, "+36301234567", got)
+			},
+		},
+		{
+			name: "ok - suffix is preserved",
+			params: ParameterValues{
+				"key_hex":     testFPEFF1KeyHex,
+				"keep_suffix": 3,
+			},
+			input: "1234567890",
+			validate: func(t *testing.T, got string) {
+				require.True(t, strings.HasSuffix(got, "890"))
+				require.NotEqual(t, "1234567890", got)
+			},
+		},
+		{
+			name: "ok - separators keep their positions",
+			params: ParameterValues{
+				"key_hex": testFPEFF1KeyHex,
+			},
+			input: "123-456-7890",
+			validate: func(t *testing.T, got string) {
+				require.Len(t, got, len("123-456-7890"))
+				require.Equal(t, "-", string(got[3]))
+				require.Equal(t, "-", string(got[7]))
+			},
+		},
+		{
+			name: "ok - letters alphabet",
+			params: ParameterValues{
+				"key_hex":  testFPEFF1KeyHex,
+				"alphabet": "letters",
+			},
+			input: "Acme Trading",
+			validate: func(t *testing.T, got string) {
+				require.Len(t, got, len("Acme Trading"))
+				require.Equal(t, " ", string(got[4]))
+				require.NotEqual(t, "Acme Trading", got)
+			},
+		},
+		{
+			name: "ok - multibyte alphabet",
+			params: ParameterValues{
+				"key_hex":  testFPEFF1KeyHex,
+				"alphabet": "áéíóúüőű",
+			},
+			input: "áéíóúüőű",
+			validate: func(t *testing.T, got string) {
+				require.Equal(t, 8, len([]rune(got)))
+				require.NotEqual(t, "áéíóúüőű", got)
+				for _, r := range got {
+					require.Contains(t, "áéíóúüőű", string(r))
+				}
+			},
+		},
+		{
+			name: "ok - preserve_from keeps the domain",
+			params: ParameterValues{
+				"key_hex":       testFPEFF1KeyHex,
+				"alphabet":      "alphanumeric",
+				"preserve_from": "@",
+			},
+			input: "john.doe@example.com",
+			validate: func(t *testing.T, got string) {
+				require.Len(t, got, len("john.doe@example.com"))
+				require.True(t, strings.HasSuffix(got, "@example.com"))
+				require.NotEqual(t, "john.doe@example.com", got)
+			},
+		},
+		{
+			name: "ok - preserve_from keeps only the tld",
+			params: ParameterValues{
+				"key_hex":       testFPEFF1KeyHex,
+				"alphabet":      "alphanumeric",
+				"preserve_from": ".",
+			},
+			input: "john.doe@example.com",
+			validate: func(t *testing.T, got string) {
+				require.Len(t, got, len("john.doe@example.com"))
+				require.True(t, strings.HasSuffix(got, ".com"))
+				// the transformer still encrypts the domain name
+				require.NotContains(t, got, "example")
+				require.Equal(t, "@", string(got[8]))
+			},
+		},
+		{
+			name: "ok - preserve_from absent from the value encrypts everything",
+			params: ParameterValues{
+				"key_hex":       testFPEFF1KeyHex,
+				"alphabet":      "alphanumeric",
+				"preserve_from": "@",
+			},
+			input: "notanemail",
+			validate: func(t *testing.T, got string) {
+				require.Len(t, got, len("notanemail"))
+				require.NotEqual(t, "notanemail", got)
+				require.NotContains(t, got, "@")
+			},
+		},
+		{
+			name: "error - preserve_from leaves too little to encrypt",
+			params: ParameterValues{
+				"key_hex":       testFPEFF1KeyHex,
+				"alphabet":      "alphanumeric",
+				"preserve_from": "@",
+			},
+			input:   "abc@example.com",
+			wantErr: errFPEFF1ValueTooShort,
+		},
+		{
+			name:    "error - value too short",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex},
+			input:   "12345",
+			wantErr: errFPEFF1ValueTooShort,
+		},
+		{
+			name: "error - too few characters in the alphabet",
+			params: ParameterValues{
+				"key_hex": testFPEFF1KeyHex,
+			},
+			input:   "12-34-5-abcd",
+			wantErr: errFPEFF1ValueTooShort,
+		},
+		{
+			name: "error - prefix and suffix leave nothing to encrypt",
+			params: ParameterValues{
+				"key_hex":     testFPEFF1KeyHex,
+				"keep_prefix": 3,
+				"keep_suffix": 3,
+			},
+			input:   "12345678",
+			wantErr: errFPEFF1ValueTooShort,
+		},
+		{
+			name: "error - passthrough error rejects a foreign character",
+			params: ParameterValues{
+				"key_hex":     testFPEFF1KeyHex,
+				"passthrough": fpeFF1PassthroughError,
+			},
+			input:   "123-456-7890",
+			wantErr: errFPEFF1CharNotInAlphabet,
+		},
+		{
+			name:    "error - unsupported value type",
+			params:  ParameterValues{"key_hex": testFPEFF1KeyHex},
+			input:   1234567890,
+			wantErr: ErrUnsupportedValueType,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			transformer, err := NewFPEFF1Transformer(tc.params)
+			require.NoError(t, err)
+
+			got, err := transformer.Transform(context.Background(), NewValue(tc.input, "text", nil))
+			require.ErrorIs(t, err, tc.wantErr)
+			if tc.wantErr != nil {
+				return
+			}
+
+			gotStr, ok := got.(string)
+			require.True(t, ok, "expected string, got %T", got)
+			tc.validate(t, gotStr)
+		})
+	}
+}
+
+// the error must give the minimum. the user then selects between a larger
+// min_length and an on_error policy
+func TestFPEFF1Transformer_tooShortErrorNamesTheMinimum(t *testing.T) {
+	t.Parallel()
+
+	transformer, err := NewFPEFF1Transformer(ParameterValues{"key_hex": testFPEFF1KeyHex})
+	require.NoError(t, err)
+
+	_, err = transformer.Transform(context.Background(), NewValue("12345", "text", nil))
+	require.ErrorContains(t, err, "but 6 are necessary")
+}
+
+// separators must not increase the keep_prefix count. one count must serve
+// each format of the same phone number
+func TestFPEFF1Transformer_keepCountsAlphabetCharactersOnly(t *testing.T) {
+	t.Parallel()
+
+	transformer, err := NewFPEFF1Transformer(ParameterValues{
+		"key_hex":     testFPEFF1KeyHex,
+		"keep_prefix": 4,
+	})
+	require.NoError(t, err)
+
+	// the same number in four formats. each output keeps the country code 36
+	// and the operator code 30
+	for _, tc := range []struct {
+		input      string
+		wantPrefix string
+	}{
+		{"+36301234567", "+3630"},
+		{"+36 30 123 4567", "+36 30"},
+		{"+36-30-123-4567", "+36-30"},
+		{"0036301234567", "0036"},
+	} {
+		got, err := transformer.Transform(context.Background(), NewValue(tc.input, "text", nil))
+		require.NoError(t, err)
+
+		gotStr, ok := got.(string)
+		require.True(t, ok, "expected string, got %T", got)
+		require.Len(t, gotStr, len(tc.input))
+		require.True(t, strings.HasPrefix(gotStr, tc.wantPrefix),
+			"%q: expected prefix %q, got %q", tc.input, tc.wantPrefix, gotStr)
+	}
+}
+
+// keep_suffix counts in the same way. it keeps a check digit after a separator
+func TestFPEFF1Transformer_keepSuffixCountsAlphabetCharactersOnly(t *testing.T) {
+	t.Parallel()
+
+	transformer, err := NewFPEFF1Transformer(ParameterValues{
+		"key_hex":     testFPEFF1KeyHex,
+		"keep_suffix": 2,
+	})
+	require.NoError(t, err)
+
+	got, err := transformer.Transform(context.Background(), NewValue("123456789-42", "text", nil))
+	require.NoError(t, err)
+
+	gotStr, ok := got.(string)
+	require.True(t, ok, "expected string, got %T", got)
+	require.True(t, strings.HasSuffix(gotStr, "-42"), "expected the check digits to survive, got %q", gotStr)
+}
+
+func TestFPEFF1Transformer_deterministic(t *testing.T) {
+	t.Parallel()
+
+	transformer, err := NewFPEFF1Transformer(ParameterValues{"key_hex": testFPEFF1KeyHex})
+	require.NoError(t, err)
+
+	first, err := transformer.Transform(context.Background(), NewValue("1234567890", "text", nil))
+	require.NoError(t, err)
+
+	second, err := transformer.Transform(context.Background(), NewValue("1234567890", "text", nil))
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+
+	// a second transformer with the same parameters gives the same output.
+	// the mapping is thus stable between runs
+	other, err := NewFPEFF1Transformer(ParameterValues{"key_hex": testFPEFF1KeyHex})
+	require.NoError(t, err)
+
+	third, err := other.Transform(context.Background(), NewValue("1234567890", "text", nil))
+	require.NoError(t, err)
+	require.Equal(t, first, third)
+}
+
+func TestFPEFF1Transformer_associatedDataSeparatesColumns(t *testing.T) {
+	t.Parallel()
+
+	transformerA, err := NewFPEFF1Transformer(ParameterValues{
+		"key_hex":         testFPEFF1KeyHex,
+		"associated_data": "public.persons.phone_number",
+	})
+	require.NoError(t, err)
+
+	transformerB, err := NewFPEFF1Transformer(ParameterValues{
+		"key_hex":         testFPEFF1KeyHex,
+		"associated_data": "public.persons.fax_number",
+	})
+	require.NoError(t, err)
+
+	gotA, err := transformerA.Transform(context.Background(), NewValue("1234567890", "text", nil))
+	require.NoError(t, err)
+
+	gotB, err := transformerB.Transform(context.Background(), NewValue("1234567890", "text", nil))
+	require.NoError(t, err)
+
+	require.NotEqual(t, gotA, gotB)
+}
+
+// the transformer reports UniquenessPreserved. pgstream validate rules uses
+// this report for a column with a unique index
+func TestFPEFF1Transformer_injective(t *testing.T) {
+	t.Parallel()
+
+	transformer, err := NewFPEFF1Transformer(ParameterValues{"key_hex": testFPEFF1KeyHex})
+	require.NoError(t, err)
+
+	const (
+		from = 1000000
+		to   = 1010000
+	)
+
+	outputs := make(map[string]int, to-from)
+	for i := from; i < to; i++ {
+		input := strconv.Itoa(i)
+
+		got, err := transformer.Transform(context.Background(), NewValue(input, "text", nil))
+		require.NoError(t, err)
+
+		gotStr, ok := got.(string)
+		require.True(t, ok, "expected string, got %T", got)
+		require.Len(t, gotStr, len(input))
+
+		if collision, found := outputs[gotStr]; found {
+			t.Fatalf("inputs %d and %d both encrypt to %q", collision, i, gotStr)
+		}
+		outputs[gotStr] = i
+	}
+	require.Len(t, outputs, to-from)
+}
+
+// the preserved end of the value has a variable length. the outputs stay
+// unique because the delimiter is not in the alphabet. the encryption cannot
+// create or remove such a delimiter, thus the transformer finds the same
+// position in the output
+func TestFPEFF1Transformer_injectiveWithPreserveFrom(t *testing.T) {
+	t.Parallel()
+
+	transformer, err := NewFPEFF1Transformer(ParameterValues{
+		"key_hex":       testFPEFF1KeyHex,
+		"alphabet":      "alphanumeric",
+		"preserve_from": "@",
+	})
+	require.NoError(t, err)
+
+	inputs := []string{
+		"john.doe@example.com",
+		"john.doe@example.org",
+		"john.doe@examples.com",
+		"jane.doe@example.com",
+		"johndoe.@example.com",
+		"john.doe@ex.ample.com",
+	}
+
+	outputs := make(map[string]string, len(inputs))
+	for _, input := range inputs {
+		got, err := transformer.Transform(context.Background(), NewValue(input, "text", nil))
+		require.NoError(t, err)
+
+		gotStr, ok := got.(string)
+		require.True(t, ok, "expected string, got %T", got)
+		require.Len(t, gotStr, len(input))
+
+		collision, found := outputs[gotStr]
+		require.False(t, found, "inputs %q and %q both encrypt to %q", collision, input, gotStr)
+		outputs[gotStr] = input
+	}
+}
+
+// with passthrough keep, the characters that are not in the alphabet stay in
+// their positions. two values that are different only in those positions must
+// give two different outputs
+func TestFPEFF1Transformer_injectiveWithPassthrough(t *testing.T) {
+	t.Parallel()
+
+	transformer, err := NewFPEFF1Transformer(ParameterValues{"key_hex": testFPEFF1KeyHex})
+	require.NoError(t, err)
+
+	first, err := transformer.Transform(context.Background(), NewValue("123-4567890", "text", nil))
+	require.NoError(t, err)
+
+	second, err := transformer.Transform(context.Background(), NewValue("1234-567890", "text", nil))
+	require.NoError(t, err)
+
+	require.NotEqual(t, first, second)
+}

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -81,6 +81,7 @@ const (
 	Hstore                 TransformerType = "hstore"
 	PGAnonymizer           TransformerType = "pg_anonymizer"
 	EncryptedAESSIV        TransformerType = "encrypted_aes_siv"
+	FPEFF1                 TransformerType = "fpe_ff1"
 )
 
 type SupportedDataType string

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
@@ -529,7 +529,7 @@ func TestPostgresTransformerParser_uniqueIndexValidation(t *testing.T) {
 			},
 			wantWarnings: []string{
 				`"public"."test": unique index "test_name_email_key" (name, email) is covered by a transformer that maps distinct values to the same output ("name" uses "masking"), ` +
-					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, or set allow_uniqueness_loss on the column to override`,
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv or fpe_ff1, or set allow_uniqueness_loss on the column to override`,
 			},
 		},
 		{

--- a/pkg/wal/processor/transformer/wal_transformer_uniqueness.go
+++ b/pkg/wal/processor/transformer/wal_transformer_uniqueness.go
@@ -69,7 +69,7 @@ func validateUniqueness(schema, table string, indexes []uniqueIndex, columnTrans
 		case len(lossy) > 0:
 			findings.errors = append(findings.errors, fmt.Sprintf(
 				"%s: %s is covered by a transformer that maps distinct values to the same output (%s), which will cause duplicate key violations. "+
-					"Use a transformer that preserves uniqueness, such as encrypted_aes_siv, or set allow_uniqueness_loss on the column to override",
+					"Use a transformer that preserves uniqueness, such as encrypted_aes_siv or fpe_ff1, or set allow_uniqueness_loss on the column to override",
 				schemaTableKey(schema, table), index.describe(), strings.Join(lossy, ", ")))
 		case len(notGuaranteed) > 0:
 			findings.warnings = append(findings.warnings, fmt.Sprintf(

--- a/pkg/wal/processor/transformer/wal_transformer_uniqueness_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_uniqueness_test.go
@@ -55,7 +55,7 @@ func TestValidateUniqueness(t *testing.T) {
 			columnTransformers: ColumnTransformers{"email": newUniquenessMock(transformers.UniquenessLossy)},
 			wantErrors: []string{
 				`"public"."users": unique index "users_email_key" (email) is covered by a transformer that maps distinct values to the same output ("email" uses "mock"), ` +
-					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv or fpe_ff1, ` +
 					`or set allow_uniqueness_loss on the column to override`,
 			},
 		},
@@ -65,7 +65,7 @@ func TestValidateUniqueness(t *testing.T) {
 			columnTransformers: ColumnTransformers{"pms_patient_id": newUniquenessMock(transformers.UniquenessLossy)},
 			wantErrors: []string{
 				`"public"."users": unique index "patients_pms_idx" (pms_patient_id, pms_type) is covered by a transformer that maps distinct values to the same output ` +
-					`("pms_patient_id" uses "mock"), which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`("pms_patient_id" uses "mock"), which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv or fpe_ff1, ` +
 					`or set allow_uniqueness_loss on the column to override`,
 			},
 		},
@@ -75,7 +75,7 @@ func TestValidateUniqueness(t *testing.T) {
 			columnTransformers: ColumnTransformers{"id": newUniquenessMock(transformers.UniquenessLossy)},
 			wantErrors: []string{
 				`"public"."users": primary key "users_pkey" (id) is covered by a transformer that maps distinct values to the same output ("id" uses "mock"), ` +
-					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv or fpe_ff1, ` +
 					`or set allow_uniqueness_loss on the column to override`,
 			},
 		},
@@ -97,7 +97,7 @@ func TestValidateUniqueness(t *testing.T) {
 			},
 			wantErrors: []string{
 				`"public"."users": unique index "users_idx" (email, name) is covered by a transformer that maps distinct values to the same output ("name" uses "mock"), ` +
-					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv or fpe_ff1, ` +
 					`or set allow_uniqueness_loss on the column to override`,
 			},
 		},
@@ -119,10 +119,10 @@ func TestValidateUniqueness(t *testing.T) {
 			},
 			wantErrors: []string{
 				`"public"."users": unique index "users_a_key" (a) is covered by a transformer that maps distinct values to the same output ("a" uses "mock"), ` +
-					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv or fpe_ff1, ` +
 					`or set allow_uniqueness_loss on the column to override`,
 				`"public"."users": unique index "users_z_key" (z) is covered by a transformer that maps distinct values to the same output ("z" uses "mock"), ` +
-					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv, ` +
+					`which will cause duplicate key violations. Use a transformer that preserves uniqueness, such as encrypted_aes_siv or fpe_ff1, ` +
 					`or set allow_uniqueness_loss on the column to override`,
 			},
 		},

--- a/transformers-definition.json
+++ b/transformers-definition.json
@@ -57,6 +57,75 @@
       ]
     },
     {
+      "name": "fpe_ff1",
+      "supported_types": [
+        "string"
+      ],
+      "uniqueness": "preserved",
+      "parameters": [
+        {
+          "name": "key_hex",
+          "supported_type": "string",
+          "default": null,
+          "dynamic": false,
+          "required": true
+        },
+        {
+          "name": "associated_data",
+          "supported_type": "string",
+          "default": "",
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "alphabet",
+          "supported_type": "string",
+          "default": "digits",
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "passthrough",
+          "supported_type": "string",
+          "default": "keep",
+          "dynamic": false,
+          "required": false,
+          "values": [
+            "keep",
+            "error"
+          ]
+        },
+        {
+          "name": "keep_prefix",
+          "supported_type": "int",
+          "default": 0,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "keep_suffix",
+          "supported_type": "int",
+          "default": 0,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "min_length",
+          "supported_type": "int",
+          "default": 0,
+          "dynamic": false,
+          "required": false
+        },
+        {
+          "name": "preserve_from",
+          "supported_type": "string",
+          "default": "",
+          "dynamic": false,
+          "required": false
+        }
+      ]
+    },
+    {
       "name": "greenmask_boolean",
       "supported_types": [
         "boolean",


### PR DESCRIPTION
#### Description

Adds `fpe_ff1`, a format-preserving encryption transformer. The output contains the same characters as the input and has the same length. An encrypted phone number is still a phone number. An encrypted product code still fits its `varchar(n)` column.

FF1 ([NIST SP 800-38G](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38G.pdf)) maps each input to one different output, so the transformer reports `UniquenessPreserved`. This is the second transformer with that property, and the first one whose output keeps the original format.

##### Examples

**Phone numbers.** `keep_prefix` counts only the digits, so one rule serves each format. It keeps the country code and the operator code.

```yaml
phone_number:
  name: fpe_ff1
  parameters:
    key_hex: ${FPE_KEY}
    associated_data: public.persons.phone_number
    alphabet: digits
    passthrough: keep
    keep_prefix: 4
```

| Input | Output |
| --- | --- |
| `+36301234567` | `+36303497985` |
| `+36 30 123 4567` | `+36 30 349 7985` |
| `+36-30-123-4567` | `+36-30-349-7985` |
| `(301) 555-0123` | `(301) 545-8564` |
| `0036301234567` | `0036504298689` |

The `+`, the spaces, the dashes and the parentheses keep their positions.

**Email addresses.** `preserve_from` keeps the end of the address. Use `"."` to keep the top-level domain, or `"@"` to keep the full domain.

```yaml
email:
  name: fpe_ff1
  parameters:
    key_hex: ${FPE_KEY}
    associated_data: public.persons.email
    alphabet: alphanumeric
    passthrough: keep
    preserve_from: "."
```

| Input | No `preserve_from` | `preserve_from: "."` | `preserve_from: "@"` |
| --- | --- | --- | --- |
| `john.doe@example.com` | `ojQu.bEQ@vzRRomO.Bgy` | `P520.HK0@TIg6Vrz.com` | `NGka.u45@example.com` |
| `support@xata.io` | `CYY5D41@jXNq.A9` | `3z7RBAl@DOH4.io` | `9TthcTe@xata.io` |
| `jane@acme.co.uk` | `QPLJ@ZrPc.2f.8p` | `M1Pt@ArVc.Ca.uk` | `uHXE@acme.co.uk` |

Note the third row. `preserve_from: "."` finds the last dot, so `.co.uk` keeps only `.uk` and the transformer encrypts `co`. Use `preserve_from: "@"` for a valid address, but then the target contains each source domain. All three options keep the outputs unique.

##### Related Issue(s)

- Related to #1136.

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- `pkg/transformers/fpe_ff1_transformer.go`. The transformer uses `gitlab.com/ubiqsecurity/ubiq-fpe-go` (MIT). Parameters: `key_hex`, `associated_data` (the FF1 tweak), `alphabet` (`digits`, `letters`, `alphanumeric`, or a set of characters), `passthrough`, `keep_prefix`, `keep_suffix`, `min_length` and `preserve_from`.
- `keep_prefix` and `keep_suffix` count only the characters in the alphabet. Separators do not increase the count.
- `preserve_from` keeps the end of the value from the last occurrence of a delimiter. Each character of the delimiter must not be in the alphabet, because the transformer must find the delimiter in the output.

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
