### PR TITLE
Pass connection configuration to dialer

### DIFF
--- a/internal/postgres/pg_conn.go
+++ b/internal/postgres/pg_conn.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -13,13 +14,71 @@ type Conn struct {
 	conn *pgx.Conn
 }
 
-func NewConn(ctx context.Context, url string) (*Conn, error) {
+// ConnOption customises the driver connection configuration before the
+// connection is opened. It runs after the URL is parsed and after pgstream has
+// applied its own settings, so its mutations are the last word.
+//
+// The option may run concurrently, because callers open connections in
+// parallel, so it must be safe for concurrent use.
+type ConnOption func(*pgx.ConnConfig)
+
+// DialFunc opens a connection to an address that is already resolved.
+type DialFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+// LookupFunc resolves a host name to the addresses to try.
+type LookupFunc func(ctx context.Context, host string) ([]string, error)
+
+// WithDialFunc dials through dial instead of through pgstream's own dialler.
+// The address dial receives is the resolved address the connection will use,
+// for every connection target including the fallbacks the driver derives from
+// a multi-host URL or from sslmode=prefer, so it is the placement that decides
+// which address is reached.
+//
+// A nil dial leaves the dialler unchanged.
+func WithDialFunc(dial DialFunc) ConnOption {
+	return func(cfg *pgx.ConnConfig) {
+		if dial == nil {
+			return
+		}
+		cfg.DialFunc = func(ctx context.Context, network, address string) (net.Conn, error) {
+			conn, err := dial(ctx, network, address)
+			if err != nil {
+				return nil, err
+			}
+			if err := applyTCPKeepalive(conn); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("failed configuring keepalive on the dialled connection: %w", err)
+			}
+			return conn, nil
+		}
+	}
+}
+
+// WithLookupFunc resolves host names through lookup instead of through the
+// system resolver. It applies to every connection target, fallbacks included.
+//
+// A nil lookup leaves the resolver unchanged.
+func WithLookupFunc(lookup LookupFunc) ConnOption {
+	return func(cfg *pgx.ConnConfig) {
+		if lookup == nil {
+			return
+		}
+		cfg.LookupFunc = func(ctx context.Context, host string) ([]string, error) {
+			return lookup(ctx, host)
+		}
+	}
+}
+
+func NewConn(ctx context.Context, url string, opts ...ConnOption) (*Conn, error) {
 	pgCfg, err := ParseConfig(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed parsing postgres connection string: %w", MapError(err))
 	}
 
 	configureTCPKeepalive(pgCfg)
+	for _, opt := range opts {
+		opt(pgCfg)
+	}
 
 	conn, err := pgx.ConnectConfig(ctx, pgCfg)
 	if err != nil {

--- a/internal/postgres/pg_conn_test.go
+++ b/internal/postgres/pg_conn_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithDialFunc_DialsTheResolvedAddress pins that the two options together
+// decide which address is reached: the lookup answers from memory and the dial
+// receives that answer, so no name is resolved twice.
+func TestWithDialFunc_DialsTheResolvedAddress(t *testing.T) {
+	t.Parallel()
+
+	addresses := []string{}
+	lookup := func(_ context.Context, host string) ([]string, error) {
+		require.Equal(t, "pgstream.example", host)
+		return []string{"192.0.2.1"}, nil
+	}
+	dial := func(_ context.Context, _, address string) (net.Conn, error) {
+		addresses = append(addresses, address)
+		return nil, errRefused
+	}
+
+	_, err := NewConn(context.Background(), testConnURL, WithLookupFunc(lookup), WithDialFunc(dial))
+	require.ErrorIs(t, err, errRefused)
+	require.NotEmpty(t, addresses)
+	for _, address := range addresses {
+		require.Equal(t, "192.0.2.1:5432", address)
+	}
+}
+
+func TestWithDialFunc_NilLeavesTheDiallerUnchanged(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := ParseConfig(testConnURL)
+	require.NoError(t, err)
+	configureTCPKeepalive(cfg)
+
+	pgstreamDialler := cfg.DialFunc
+	require.NotNil(t, pgstreamDialler)
+
+	WithDialFunc(nil)(cfg)
+	require.NotNil(t, cfg.DialFunc)
+
+	lookup := cfg.LookupFunc
+	WithLookupFunc(nil)(cfg)
+	require.Equal(t, lookup == nil, cfg.LookupFunc == nil)
+}
+
+// TestWithDialFunc_AppliesKeepalive pins that a caller-supplied dialler does
+// not cost the connection pgstream's keepalive settings: a broken connection
+// is still detected on the same timescale as one pgstream dialled itself.
+func TestWithDialFunc_AppliesKeepalive(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			conn.Close()
+		}
+	}()
+
+	dialled := 0
+	cfg, err := ParseConfig(testConnURL)
+	require.NoError(t, err)
+	WithDialFunc(func(ctx context.Context, network, _ string) (net.Conn, error) {
+		dialled++
+		return net.Dial(network, listener.Addr().String())
+	})(cfg)
+
+	conn, err := cfg.DialFunc(context.Background(), "tcp", "192.0.2.1:5432")
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	require.Equal(t, 1, dialled)
+	require.IsType(t, &net.TCPConn{}, conn, "the caller's connection must be returned as it is")
+}
+
+func TestApplyTCPKeepalive(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() })
+
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			conn.Close()
+		}
+	}()
+
+	tcpConn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() { tcpConn.Close() })
+	require.NoError(t, applyTCPKeepalive(tcpConn))
+
+	// a connection that is not TCP carries no keepalive settings
+	pipe, _ := net.Pipe()
+	t.Cleanup(func() { pipe.Close() })
+	require.NoError(t, applyTCPKeepalive(pipe))
+}
+
+// TestWithLookupFunc_ResolvesEveryTarget pins that the resolver applies to
+// every connection target the driver derives from the URL, fallbacks included.
+func TestWithLookupFunc_ResolvesEveryTarget(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := ParseConfig(testConnURL)
+	require.NoError(t, err)
+	require.NotEmpty(t, cfg.Fallbacks, "the default sslmode must produce a fallback target")
+
+	lookups := 0
+	WithLookupFunc(func(context.Context, string) ([]string, error) {
+		lookups++
+		return []string{"192.0.2.1"}, nil
+	})(cfg)
+	WithDialFunc(func(context.Context, string, string) (net.Conn, error) {
+		return nil, errRefused
+	})(cfg)
+
+	_, err = pgx.ConnectConfig(context.Background(), cfg)
+	require.Error(t, err)
+	require.GreaterOrEqual(t, lookups, len(cfg.Fallbacks)+1,
+		"every target must resolve through the supplied resolver")
+}

--- a/internal/postgres/pg_lazy_conn.go
+++ b/internal/postgres/pg_lazy_conn.go
@@ -15,14 +15,16 @@ type AcquireFunc func(ctx context.Context) (Querier, error)
 // preflight check engine that runs checks one after another).
 type LazyConn struct {
 	url  string
+	opts []ConnOption
 	conn *Conn
 	err  error
 }
 
 // NewLazyConn returns a LazyConn that will open a connection to url on first
-// Acquire.
-func NewLazyConn(url string) *LazyConn {
-	return &LazyConn{url: url}
+// Acquire. The connection options are stored and applied on that first dial,
+// not at construction.
+func NewLazyConn(url string, opts ...ConnOption) *LazyConn {
+	return &LazyConn{url: url, opts: opts}
 }
 
 // Acquire returns the cached conn, opening it on the first call. A dial
@@ -32,7 +34,7 @@ func (l *LazyConn) Acquire(ctx context.Context) (Querier, error) {
 	if l.conn != nil || l.err != nil {
 		return l.conn, l.err
 	}
-	l.conn, l.err = NewConn(ctx, l.url)
+	l.conn, l.err = NewConn(ctx, l.url, l.opts...)
 	return l.conn, l.err
 }
 

--- a/internal/postgres/pg_lazy_conn_test.go
+++ b/internal/postgres/pg_lazy_conn_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+const testConnURL = "postgres://user:pass@pgstream.example:5432/testdb"
+
+var errRefused = errors.New("dialling refused by test")
+
+// refusingHook makes every dial attempt fail without touching the network: the
+// lookup answers from memory and the dialler refuses. It records the
+// configurations it was given.
+func refusingHook(seen *[]*pgx.ConnConfig) ConnOption {
+	return func(cfg *pgx.ConnConfig) {
+		*seen = append(*seen, cfg)
+		cfg.LookupFunc = func(context.Context, string) ([]string, error) {
+			return []string{"192.0.2.1"}, nil
+		}
+		cfg.DialFunc = func(context.Context, string, string) (net.Conn, error) {
+			return nil, errRefused
+		}
+	}
+}
+
+func TestNewConn_ConnOption(t *testing.T) {
+	t.Parallel()
+
+	var seen []*pgx.ConnConfig
+	conn, err := NewConn(context.Background(), testConnURL, refusingHook(&seen))
+	require.Error(t, err)
+	require.Nil(t, conn)
+	require.Len(t, seen, 1)
+	require.Equal(t, "pgstream.example", seen[0].Host)
+	require.Equal(t, "testdb", seen[0].Database)
+}
+
+// TestNewConn_ConnOptionRunsAfterKeepalive pins the ordering the option
+// contract promises: the hook sees the configuration pgstream has already
+// applied, and its own dialler survives.
+func TestNewConn_ConnOptionRunsAfterKeepalive(t *testing.T) {
+	t.Parallel()
+
+	var (
+		keepaliveDialFunc bool
+		connectTimeout    time.Duration
+		dialled           int
+	)
+	hook := func(cfg *pgx.ConnConfig) {
+		keepaliveDialFunc = cfg.DialFunc != nil
+		connectTimeout = cfg.ConnectTimeout
+		cfg.LookupFunc = func(context.Context, string) ([]string, error) {
+			return []string{"192.0.2.1"}, nil
+		}
+		cfg.DialFunc = func(context.Context, string, string) (net.Conn, error) {
+			dialled++
+			return nil, errRefused
+		}
+	}
+
+	_, err := NewConn(context.Background(), testConnURL, hook)
+	require.Error(t, err)
+	require.True(t, keepaliveDialFunc, "hook must run after TCP keepalive configuration")
+	require.Equal(t, 90*time.Second, connectTimeout)
+	require.Positive(t, dialled, "the hook's dialler must be the one used")
+}
+
+func TestNewConn_ConnOptionOrder(t *testing.T) {
+	t.Parallel()
+
+	order := []string{}
+	first := func(*pgx.ConnConfig) { order = append(order, "first") }
+	second := func(cfg *pgx.ConnConfig) {
+		order = append(order, "second")
+		cfg.LookupFunc = func(context.Context, string) ([]string, error) {
+			return []string{"192.0.2.1"}, nil
+		}
+		cfg.DialFunc = func(context.Context, string, string) (net.Conn, error) {
+			return nil, errRefused
+		}
+	}
+
+	_, err := NewConn(context.Background(), testConnURL, first, second)
+	require.Error(t, err)
+	require.Equal(t, []string{"first", "second"}, order)
+}
+
+func TestNewConn_InvalidURLDoesNotRunOptions(t *testing.T) {
+	t.Parallel()
+
+	called := 0
+	_, err := NewConn(context.Background(), "not-a-postgres-url", func(*pgx.ConnConfig) { called++ })
+	require.Error(t, err)
+	require.Equal(t, 0, called)
+}
+
+// TestLazyConn_OptionsAppliedOnFirstDial pins that the options are stored at
+// construction and applied when the connection is finally opened, once.
+func TestLazyConn_OptionsAppliedOnFirstDial(t *testing.T) {
+	t.Parallel()
+
+	var seen []*pgx.ConnConfig
+	lazy := NewLazyConn(testConnURL, refusingHook(&seen))
+	require.Empty(t, seen, "construction must not configure a connection")
+
+	_, err := lazy.Acquire(context.Background())
+	require.Error(t, err)
+	require.Len(t, seen, 1)
+
+	// the dial error is memoised, so no second connection is configured
+	_, err = lazy.Acquire(context.Background())
+	require.Error(t, err)
+	require.Len(t, seen, 1)
+
+	require.NoError(t, lazy.Close(context.Background()))
+}
+
+func TestLazyConn_NoOptions(t *testing.T) {
+	t.Parallel()
+
+	lazy := NewLazyConn(testConnURL)
+	require.Empty(t, lazy.opts)
+}

--- a/internal/postgres/pg_utils.go
+++ b/internal/postgres/pg_utils.go
@@ -500,16 +500,8 @@ func configureTCPKeepalive(cfg *pgx.ConnConfig) {
 
 	cfg.DialFunc = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		d := &net.Dialer{
-			Timeout: 90 * time.Second, // Timeout for establishing connection (allows for branch wake-up)
-			// KeepAliveConfig uses Go defaults:
-			// - Idle: 15s, Interval: 15s, Count: 9
-			// This gives ~150s detection time for broken connections
-			KeepAliveConfig: net.KeepAliveConfig{
-				Enable:   true,
-				Idle:     15 * time.Second,
-				Interval: 15 * time.Second,
-				Count:    9,
-			},
+			Timeout:         dialTimeout, // Timeout for establishing connection (allows for branch wake-up)
+			KeepAliveConfig: keepAliveConfig(),
 		}
 
 		conn, err := d.DialContext(ctx, network, addr)
@@ -519,4 +511,31 @@ func configureTCPKeepalive(cfg *pgx.ConnConfig) {
 
 		return conn, nil
 	}
+}
+
+// dialTimeout bounds a single TCP dial.
+const dialTimeout = 90 * time.Second
+
+// keepAliveConfig returns the TCP keepalive settings every pgstream connection
+// uses. KeepAliveConfig uses Go defaults: Idle 15s, Interval 15s, Count 9,
+// which gives ~150s detection time for broken connections.
+func keepAliveConfig() net.KeepAliveConfig {
+	return net.KeepAliveConfig{
+		Enable:   true,
+		Idle:     15 * time.Second,
+		Interval: 15 * time.Second,
+		Count:    9,
+	}
+}
+
+// applyTCPKeepalive puts pgstream's keepalive settings on an already open
+// connection, so a connection opened by a caller-supplied dialler is detected
+// as broken on the same timescale as one pgstream dialled itself. A connection
+// that is not TCP carries no keepalive settings and is left alone.
+func applyTCPKeepalive(conn net.Conn) error {
+	tcp, ok := conn.(*net.TCPConn)
+	if !ok {
+		return nil
+	}
+	return tcp.SetKeepAliveConfig(keepAliveConfig())
 }

--- a/pkg/stream/preflight/CLAUDE.md
+++ b/pkg/stream/preflight/CLAUDE.md
@@ -6,7 +6,7 @@ Guidance for Claude Code when working inside `pkg/stream/preflight`. The planned
 
 - `preflight.go` — `Check` interface (`Name()` + `Run(ctx) ([]Finding, error)`), the optional `Detailer` / `Summarizer` interfaces described under [Reporting what a check observed](#reporting-what-a-check-observed), `Finding`, `CheckResult`, `Report`, `Run(ctx, []Check, ...RunOption)` engine. The engine calls each optional interface after `Run`, so a check populates them from state it gathered while running.
 - `printer.go` — `ReportPrinter{Report}` is the only thing that formats reports, rendering each result's `Summary` beside its name. The `Report` struct itself stays pure data.
-- `builder.go` — `Builder` struct (returns `[]Check` + optional cleanup), `Builders` registry slice, per-category builder functions (`BuildConnectivityChecks`, …), `BuildChecks(cfg, selected)`.
+- `builder.go` — `Builder` struct (returns `[]Check` + optional cleanup), `Builders` registry slice, per-category builder functions (`BuildConnectivityChecks`, …), `BuildChecks(cfg, selected, opts...)`. A builder takes `(*stream.Config, ...ConnOption)`: the config says which checks apply, the options configure every connection those checks open. `ConnOption` is driver-neutral — `WithDialFunc` and `WithLookupFunc` take stdlib types, and `postgresConnOptions` renders them for `internal/postgres`, so pgx stays out of the package's public API.
 - One file per category of concrete checks (`connectivity.go`, `replication.go`, …).
 
 The shared-conn primitive lives one floor down at `internal/postgres.LazyConn` so other callers can reuse it.
@@ -17,14 +17,15 @@ Adding a check is meant to be a small, mechanical edit. Keep it that way.
 
 1. **Pick a category.** Categories group checks of the same concern (`connectivity`, `replication`, `access`, `schema`, `resources`).
    - Joining an existing category: skip to step 2.
-   - Creating a new one: add a `Category` constant in `preflight.go`, a builder func + `Builders` entry in `builder.go`, and a boolean flag on `checkCmd` in `cmd/root_cmd.go`. The flag string must match `Builder.Flag`.
+   - Creating a new one: add a `Category` constant in `preflight.go`, a builder func (`func(*stream.Config, ...ConnOption) ([]Check, CleanupFunc)`) + `Builders` entry in `builder.go`, and a boolean flag on `checkCmd` in `cmd/root_cmd.go`. The flag string must match `Builder.Flag`.
 2. **Implement the check.** New struct in `<thing>.go`, satisfying the `Check` interface.
    - **Every `Finding` is blocking.** A check that finds nothing wrong returns a `nil` slice.
    - **Return `error` only when the check itself couldn't run** (timeout, internal bug, malformed input). A detected problem is a `Finding`, not an error.
    - **Put remediation in `Finding.Message`** — the user should be able to act on it without reading source.
 3. **Report what it observed**, if it observed anything worth reporting — see [Reporting what a check observed](#reporting-what-a-check-observed). Most checks need none of this: a check that only passes or fails implements no optional interface.
 4. **Materialise instances in the category builder** (e.g. `BuildConnectivityChecks`). The builder is the applicability gate: it reads `*stream.Config` and decides which instances are relevant. Inapplicable checks are silently omitted today; an explicit "skipped: <reason>" mechanism is deferred (see `docs/migration_preflight_issue.md` "Architecture decisions" #6).
-   - **If checks in the category share a Postgres connection**, call `postgres.NewLazyConn(url)` in the builder, hand `src.Acquire` (a `postgres.AcquireFunc`) to every check, and return `src.Close` as the cleanup. See `BuildReplicationChecks` for the pattern. The engine runs sequentially, so the first check to call `Source(ctx)` opens the conn and the rest reuse it. A failed dial is memoised too — only one connection attempt happens, even if every check reports its own check error.
+   - **If checks in the category share a Postgres connection**, call `postgres.NewLazyConn(url, postgresConnOptions(opts)...)` in the builder, hand `src.Acquire` (a `postgres.AcquireFunc`) to every check, and return `src.Close` as the cleanup. See `BuildReplicationChecks` for the pattern. The engine runs sequentially, so the first check to call `Source(ctx)` opens the conn and the rest reuse it. A failed dial is memoised too — only one connection attempt happens, even if every check reports its own check error.
+   - **Every connection must carry the connection options.** Forwarding them is what lets a library caller decide which address a check reaches, and the guarantee only holds while every builder does it. A check that opens its own connection instead of sharing one takes a `ConnOptions []ConnOption` field, set from the builder's `opts`, and passes `postgresConnOptions(c.ConnOptions)...` to `postgres.NewConn` — see `ConnectivityCheck`. `TestBuildSourceChecks_ConnOptions` fails when a connection escapes the options, so add the new category's URLs to the configuration it builds.
 5. **Tests.** Unit-test the check directly against mocked dependencies (`internal/postgres/mocks` has the postgres conn mock). For new categories, exercise the builder selection path through the cmd layer too.
 
 ## Reporting what a check observed

--- a/pkg/stream/preflight/builder.go
+++ b/pkg/stream/preflight/builder.go
@@ -5,6 +5,7 @@ package preflight
 import (
 	"context"
 	"errors"
+	"net"
 
 	"github.com/xataio/pgstream/internal/postgres"
 	pgsnapshotgenerator "github.com/xataio/pgstream/pkg/snapshot/generator/postgres/data"
@@ -17,14 +18,60 @@ import (
 // connection). Builders return nil when there's nothing to clean up.
 type CleanupFunc func(context.Context) error
 
+// DialFunc opens a connection to an address that is already resolved.
+type DialFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+// LookupFunc resolves a host name to the addresses to try.
+type LookupFunc func(ctx context.Context, host string) ([]string, error)
+
+// ConnOption configures every connection the checks a builder returns open,
+// including the connections the exported snapshot probe opens. Supplying no
+// option leaves the connections exactly as pgstream configures them.
+type ConnOption func(*connOptions)
+
+type connOptions struct {
+	dial   DialFunc
+	lookup LookupFunc
+}
+
+func WithDialFunc(dial DialFunc) ConnOption {
+	return func(o *connOptions) { o.dial = dial }
+}
+
+func WithLookupFunc(lookup LookupFunc) ConnOption {
+	return func(o *connOptions) { o.lookup = lookup }
+}
+
+// postgresConnOptions renders the options as the connection options
+// internal/postgres takes. No option means no connection option, so
+// connections are configured exactly as they are without one.
+func postgresConnOptions(opts []ConnOption) []postgres.ConnOption {
+	var o connOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	pgOpts := []postgres.ConnOption{}
+	if o.dial != nil {
+		pgOpts = append(pgOpts, postgres.WithDialFunc(postgres.DialFunc(o.dial)))
+	}
+	if o.lookup != nil {
+		pgOpts = append(pgOpts, postgres.WithLookupFunc(postgres.LookupFunc(o.lookup)))
+	}
+	if len(pgOpts) == 0 {
+		return nil
+	}
+	return pgOpts
+}
+
 // Builder turns a stream.Config into the concrete checks for a category, plus
-// an optional cleanup function that releases resources the checks share (e.g.
-// a Postgres connection). Each new category adds an entry to Builders and a
-// matching CLI flag in cmd/root_cmd.go.
+// an optional cleanup function that releases resources the checks share (e.g. a
+// Postgres connection). The connection options apply to every connection those
+// checks open. Each new category adds an entry to Builders and a matching CLI
+// flag in cmd/root_cmd.go.
 type Builder struct {
 	Category Category
 	Flag     string
-	Build    func(*stream.Config) ([]Check, CleanupFunc)
+	Build    func(*stream.Config, ...ConnOption) ([]Check, CleanupFunc)
 }
 
 // Builders is the registry of category builders. Adding a new category = one
@@ -47,6 +94,11 @@ type sourceOptions struct {
 	replicationSlot string
 	snapshotData    *pgsnapshotgenerator.Config
 	categories      []Category
+	conn            []ConnOption
+}
+
+func WithConnOptions(opts ...ConnOption) SourceOption {
+	return func(o *sourceOptions) { o.conn = opts }
 }
 
 // WithSourceCategories restricts the run to the given categories, in the order
@@ -80,7 +132,7 @@ func BuildSourceChecks(sourceURL string, opts ...SourceOption) ([]Check, Cleanup
 		opt(&o)
 	}
 
-	checks, cleanup := BuildChecks(o.streamConfig(sourceURL), o.categories)
+	checks, cleanup := BuildChecks(o.streamConfig(sourceURL), o.categories, o.conn...)
 	return checks, cleanup, nil
 }
 
@@ -112,12 +164,12 @@ func (o *sourceOptions) streamConfig(sourceURL string) *stream.Config {
 // snapshot connection-headroom check is added only when a data snapshot is
 // configured, because it sizes snapshot_workers x table_workers against the
 // source's max_connections.
-func BuildResourcesChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
+func BuildResourcesChecks(cfg *stream.Config, opts ...ConnOption) ([]Check, CleanupFunc) {
 	url := cfg.SourcePostgresURL()
 	if url == "" {
 		return nil, nil
 	}
-	src := postgres.NewLazyConn(url)
+	src := postgres.NewLazyConn(url, postgresConnOptions(opts)...)
 	checks := []Check{
 		&DatabaseSizeCheck{Source: src.Acquire},
 	}
@@ -131,16 +183,15 @@ func BuildResourcesChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 // A source check is added when a source postgres URL is configured; a target
 // check is added when a postgres target is configured. Each check opens its
 // own conn (to its own URL), so no shared cleanup is needed.
-func BuildConnectivityChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
+func BuildConnectivityChecks(cfg *stream.Config, opts ...ConnOption) ([]Check, CleanupFunc) {
 	checks := []Check{}
 	if url := cfg.SourcePostgresURL(); url != "" {
-		checks = append(checks, &ConnectivityCheck{Label: "source", URL: url})
+		checks = append(checks, &ConnectivityCheck{Label: "source", URL: url, ConnOptions: opts})
 		if demand, ok := cfg.SnapshotConnectionDemand(); ok {
+			dial := probeDialer(url, opts...)
 			checks = append(checks, &SourceSnapshotInstanceCheck{
 				Probe: func(ctx context.Context, probes int) (int, error) {
-					return postgres.ProbeExportedSnapshotVisibility(ctx, func(ctx context.Context) (postgres.Querier, error) {
-						return postgres.NewConn(ctx, url)
-					}, probes)
+					return postgres.ProbeExportedSnapshotVisibility(ctx, dial, probes)
 				},
 				Probes: snapshotInstanceProbes(demand),
 			})
@@ -148,10 +199,21 @@ func BuildConnectivityChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 	}
 	if cfg.Processor.Postgres != nil {
 		if url := cfg.Processor.Postgres.BatchWriter.URL; url != "" {
-			checks = append(checks, &ConnectivityCheck{Label: "target", URL: url})
+			checks = append(checks, &ConnectivityCheck{Label: "target", URL: url, ConnOptions: opts})
 		}
 	}
 	return checks, nil
+}
+
+// probeDialer returns the dial function the exported snapshot probe calls once
+// per connection it opens, so every one of those connections carries the
+// connection options. The probe dials its probe connections in parallel, so
+// the dialler and the resolver the options carry run concurrently.
+func probeDialer(url string, opts ...ConnOption) func(context.Context) (postgres.Querier, error) {
+	connOpts := postgresConnOptions(opts)
+	return func(ctx context.Context) (postgres.Querier, error) {
+		return postgres.NewConn(ctx, url, connOpts...)
+	}
 }
 
 func snapshotInstanceProbes(demand uint) int {
@@ -170,7 +232,7 @@ func snapshotInstanceProbes(demand uint) int {
 // to cfg, plus a cleanup function that closes the shared source connection.
 // Replication checks only apply when the source is configured with a
 // replication slot.
-func BuildReplicationChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
+func BuildReplicationChecks(cfg *stream.Config, opts ...ConnOption) ([]Check, CleanupFunc) {
 	if cfg.PostgresReplicationSlot() == "" {
 		return nil, nil
 	}
@@ -178,7 +240,7 @@ func BuildReplicationChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 	if url == "" {
 		return nil, nil
 	}
-	src := postgres.NewLazyConn(url)
+	src := postgres.NewLazyConn(url, postgresConnOptions(opts)...)
 	return []Check{
 		&WALLevelCheck{Source: src.Acquire},
 		&WAL2JSONCheck{Source: src.Acquire},
@@ -190,12 +252,12 @@ func BuildReplicationChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 
 // BuildAccessChecks returns the access-preflight checks applicable to cfg,
 // plus a cleanup function that closes the shared source connection.
-func BuildAccessChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
+func BuildAccessChecks(cfg *stream.Config, opts ...ConnOption) ([]Check, CleanupFunc) {
 	sourceURL := cfg.SourcePostgresURL()
 	if sourceURL == "" {
 		return nil, nil
 	}
-	src := postgres.NewLazyConn(sourceURL)
+	src := postgres.NewLazyConn(sourceURL, postgresConnOptions(opts)...)
 	selection := cfg.AccessTableSelection()
 	checks := []Check{
 		&SourceTableSelectPrivilegesCheck{
@@ -217,7 +279,7 @@ func BuildAccessChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 		checkURL, err := targetPrivilegeCheckURL(targetURL, createDB)
 		acquire := func(context.Context) (postgres.Querier, error) { return nil, err }
 		if err == nil {
-			target := postgres.NewLazyConn(checkURL)
+			target := postgres.NewLazyConn(checkURL, postgresConnOptions(opts)...)
 			acquire = target.Acquire
 			cleanups = append(cleanups, target.Close)
 		}
@@ -253,12 +315,12 @@ func targetPrivilegeCheckURL(targetURL string, createTargetDB bool) (string, err
 // against the target when a Postgres target URL is configured. The range-type
 // check is added when the target is Postgres; the extension check additionally
 // needs the target URL to query the target.
-func BuildSchemaChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
+func BuildSchemaChecks(cfg *stream.Config, opts ...ConnOption) ([]Check, CleanupFunc) {
 	url := cfg.SourcePostgresURL()
 	if url == "" {
 		return nil, nil
 	}
-	src := postgres.NewLazyConn(url)
+	src := postgres.NewLazyConn(url, postgresConnOptions(opts)...)
 	selection := cfg.AccessTableSelection()
 	versionCheck := &PostgresVersionCheck{Source: src.Acquire}
 	checks := []Check{
@@ -275,7 +337,7 @@ func BuildSchemaChecks(cfg *stream.Config) ([]Check, CleanupFunc) {
 			Selection: selection,
 		})
 		if targetURL := cfg.Processor.Postgres.BatchWriter.URL; targetURL != "" {
-			tgt := postgres.NewLazyConn(targetURL)
+			tgt := postgres.NewLazyConn(targetURL, postgresConnOptions(opts)...)
 			cleanups = append(cleanups, tgt.Close)
 			versionCheck.Target = tgt.Acquire
 			checks = append(checks, &SchemaExtensionCompatibilityCheck{
@@ -305,8 +367,9 @@ func joinCleanups(cleanups []CleanupFunc) CleanupFunc {
 // preserving the registration order in Builders, plus a single cleanup
 // function that releases every category's resources. The returned cleanup is
 // always non-nil; callers can defer it unconditionally. An empty selection
-// runs every registered category.
-func BuildChecks(cfg *stream.Config, selected []Category) ([]Check, CleanupFunc) {
+// runs every registered category. The connection options apply to every
+// connection the resulting checks open.
+func BuildChecks(cfg *stream.Config, selected []Category, opts ...ConnOption) ([]Check, CleanupFunc) {
 	want := make(map[Category]bool, len(selected))
 	for _, c := range selected {
 		want[c] = true
@@ -315,7 +378,7 @@ func BuildChecks(cfg *stream.Config, selected []Category) ([]Check, CleanupFunc)
 	cleanups := []CleanupFunc{}
 	for _, b := range Builders {
 		if len(want) == 0 || want[b.Category] {
-			cs, cleanup := b.Build(cfg)
+			cs, cleanup := b.Build(cfg, opts...)
 			checks = append(checks, cs...)
 			if cleanup != nil {
 				cleanups = append(cleanups, cleanup)

--- a/pkg/stream/preflight/builder_test.go
+++ b/pkg/stream/preflight/builder_test.go
@@ -4,12 +4,27 @@ package preflight
 
 import (
 	"context"
+	"errors"
+	"net"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	pgdumprestore "github.com/xataio/pgstream/pkg/snapshot/generator/postgres/schema/pgdumprestore"
+	"github.com/xataio/pgstream/pkg/stream"
+	snapshotbuilder "github.com/xataio/pgstream/pkg/wal/listener/snapshot/builder"
+	pgprocessor "github.com/xataio/pgstream/pkg/wal/processor/postgres"
 )
 
-const testSourceURL = "postgres://user:pass@localhost:5432/mydb"
+const (
+	testSourceURL = "postgres://user:pass@localhost:5432/mydb"
+
+	// hook tests dial these, so they name hosts that resolve nowhere: the hook
+	// under test answers the lookup itself and refuses the dial.
+	testHookSourceURL = "postgres://user:pass@source.invalid:5432/mydb"
+	testHookTargetURL = "postgres://user:pass@target.invalid:5432/targetdb"
+)
 
 func checkNames(checks []Check) []string {
 	names := make([]string, 0, len(checks))
@@ -149,4 +164,276 @@ func TestBuildSourceChecks_MissingURL(t *testing.T) {
 	require.Empty(t, checks)
 	require.NotNil(t, cleanup, "cleanup must be safe to defer on error")
 	require.NoError(t, cleanup(context.Background()))
+}
+
+// errHookRefused is the sentinel the refusing dialler returns. A check that
+// reports it went through the hook; a check that escaped the hook reaches the
+// real resolver and fails with something else.
+const errHookRefused = "dialling refused by test"
+
+// countingRefusingConn makes every dial fail without touching the network: the
+// lookup answers from memory and the dialler refuses. It counts both, so a
+// connection that escaped the options is visible as a missing count as well as
+// through the error it fails with.
+type countingRefusingConn struct {
+	mu      sync.Mutex
+	lookups int
+	dials   int
+}
+
+func (c *countingRefusingConn) options() []ConnOption {
+	return []ConnOption{
+		WithLookupFunc(func(context.Context, string) ([]string, error) {
+			c.mu.Lock()
+			c.lookups++
+			c.mu.Unlock()
+			return []string{"192.0.2.1"}, nil
+		}),
+		WithDialFunc(func(context.Context, string, string) (net.Conn, error) {
+			c.mu.Lock()
+			c.dials++
+			c.mu.Unlock()
+			return nil, errors.New(errHookRefused)
+		}),
+	}
+}
+
+func (c *countingRefusingConn) counts() (lookups, dials int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lookups, c.dials
+}
+
+// lookupsPerConnection measures how many times one connection resolves its
+// host. The driver expands a URL into one connection target per fallback (the
+// default sslmode=prefer produces one), and resolves each, so the count is a
+// property of the URL rather than a number worth hard-coding.
+func lookupsPerConnection(t *testing.T) int {
+	t.Helper()
+
+	c := &countingRefusingConn{}
+	_, err := probeDialer(testHookSourceURL, c.options()...)(context.Background())
+	require.ErrorContains(t, err, errHookRefused)
+
+	lookups, _ := c.counts()
+	require.Positive(t, lookups)
+	return lookups
+}
+
+// requireRefusedByHook asserts every check failed through the dialler the
+// options installed. A connection that escaped them would resolve the host
+// itself and fail with a different error, so this, and not the bare "the check
+// did not pass", is what proves the options decided which address was reached.
+func requireRefusedByHook(t *testing.T, report Report) {
+	t.Helper()
+
+	require.NotEmpty(t, report.Results)
+	for _, res := range report.Results {
+		msg := ""
+		if res.Err != nil {
+			msg = res.Err.Error()
+		}
+		for _, f := range res.Findings {
+			msg += " " + f.Message
+		}
+		require.Contains(t, msg, errHookRefused,
+			"check %q did not fail through the supplied dialler", res.Name)
+	}
+}
+
+// TestBuildSourceChecks_ConnOptions pins that the options reach every
+// connection a full source run opens — each category's shared connection, the
+// connectivity check's own connection and the exported snapshot probe's — and
+// that the supplied dialler decides which address is reached, so every check
+// reports a connection failure instead of connecting.
+func TestBuildSourceChecks_ConnOptions(t *testing.T) {
+	t.Parallel()
+
+	// One per category shared connection (replication, access, schema,
+	// resources), one for the connectivity check and one for the exported
+	// snapshot probe's exporting connection. The dialler refuses that
+	// exporting dial, so the probe never reaches its parallel probe
+	// connections; those are covered by TestProbeDialer_ConnOptions.
+	const wantConnectionsBeforeFirstRefusal = 6
+
+	perConn := lookupsPerConnection(t)
+
+	c := &countingRefusingConn{}
+	checks, cleanup, err := BuildSourceChecks(testHookSourceURL, WithConnOptions(c.options()...))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cleanup(context.Background())) })
+
+	report := Run(context.Background(), checks)
+	require.Len(t, report.Results, len(checks))
+	requireRefusedByHook(t, report)
+
+	lookups, dials := c.counts()
+	require.Equal(t, wantConnectionsBeforeFirstRefusal*perConn, lookups,
+		"every connection must resolve through the supplied resolver")
+	require.GreaterOrEqual(t, dials, wantConnectionsBeforeFirstRefusal,
+		"the supplied dialler must be the one used")
+}
+
+// TestProbeDialer_ConnOptions pins the half of the coverage the source run
+// cannot reach: the exported snapshot probe opens one connection per probe,
+// and every one of them carries the options. The probe dials in parallel, so
+// this also exercises the concurrency the options must tolerate.
+func TestProbeDialer_ConnOptions(t *testing.T) {
+	t.Parallel()
+
+	const probes = 8
+
+	perConn := lookupsPerConnection(t)
+
+	c := &countingRefusingConn{}
+	dial := probeDialer(testHookSourceURL, c.options()...)
+
+	errs := make([]error, probes)
+	var wg sync.WaitGroup
+	for i := 0; i < probes; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = dial(context.Background())
+		}(i)
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		require.ErrorContains(t, err, errHookRefused)
+	}
+
+	lookups, dials := c.counts()
+	require.Equal(t, probes*perConn, lookups, "every probe connection must carry the options")
+	require.GreaterOrEqual(t, dials, probes)
+}
+
+// TestBuildSourceChecks_NoConnOptions pins that the connections are configured
+// exactly as before when no option is supplied.
+func TestBuildSourceChecks_NoConnOptions(t *testing.T) {
+	t.Parallel()
+
+	checks, cleanup, err := BuildSourceChecks(testHookSourceURL)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cleanup(context.Background())) })
+
+	for _, c := range checks {
+		if cc, ok := c.(*ConnectivityCheck); ok {
+			require.Empty(t, cc.ConnOptions)
+		}
+	}
+	require.Nil(t, postgresConnOptions(nil))
+}
+
+func TestPostgresConnOptions(t *testing.T) {
+	t.Parallel()
+
+	dial := func(context.Context, string, string) (net.Conn, error) { return nil, errors.New("refused") }
+	lookup := func(context.Context, string) ([]string, error) { return nil, errors.New("unresolved") }
+
+	tests := []struct {
+		name string
+		opts []ConnOption
+		want int
+	}{
+		{name: "none", opts: nil, want: 0},
+		{name: "dial only", opts: []ConnOption{WithDialFunc(dial)}, want: 1},
+		{name: "lookup only", opts: []ConnOption{WithLookupFunc(lookup)}, want: 1},
+		{name: "both", opts: []ConnOption{WithDialFunc(dial), WithLookupFunc(lookup)}, want: 2},
+		{name: "nil funcs", opts: []ConnOption{WithDialFunc(nil), WithLookupFunc(nil)}, want: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Len(t, postgresConnOptions(tc.opts), tc.want)
+		})
+	}
+}
+
+// TestBuildAccessChecks_ConnOptions pins that the options reach the target
+// connection the access builder opens as well as the source one.
+func TestBuildAccessChecks_ConnOptions(t *testing.T) {
+	t.Parallel()
+
+	perConn := lookupsPerConnection(t)
+	c := &countingRefusingConn{}
+	cfg := &stream.Config{
+		Listener: stream.ListenerConfig{
+			Postgres: &stream.PostgresListenerConfig{
+				URL: testHookSourceURL,
+				Snapshot: &snapshotbuilder.SnapshotListenerConfig{
+					Schema: &snapshotbuilder.SchemaSnapshotConfig{
+						DumpRestore: &pgdumprestore.Config{
+							TargetPGURL:    testHookTargetURL,
+							CreateTargetDB: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	checks, cleanup := BuildAccessChecks(cfg, c.options()...)
+	require.NotNil(t, cleanup)
+	t.Cleanup(func() { require.NoError(t, cleanup(context.Background())) })
+
+	requireRefusedByHook(t, Run(context.Background(), checks))
+
+	lookups, _ := c.counts()
+	require.Equal(t, 2*perConn, lookups, "the source and target connections must both carry the options")
+}
+
+// TestBuildSchemaChecks_ConnOptions pins that the target connection the schema
+// builder opens carries the options too. The checks only reach the target once
+// the source answers, so the test acquires both connections directly.
+func TestBuildSchemaChecks_ConnOptions(t *testing.T) {
+	t.Parallel()
+
+	perConn := lookupsPerConnection(t)
+	c := &countingRefusingConn{}
+	cfg := &stream.Config{
+		Listener: stream.ListenerConfig{
+			Postgres: &stream.PostgresListenerConfig{URL: testHookSourceURL},
+		},
+		Processor: stream.ProcessorConfig{
+			Postgres: &stream.PostgresProcessorConfig{
+				BatchWriter: pgprocessor.Config{URL: testHookTargetURL},
+			},
+		},
+	}
+
+	checks, cleanup := BuildSchemaChecks(cfg, c.options()...)
+	require.NotNil(t, cleanup)
+	t.Cleanup(func() { require.NoError(t, cleanup(context.Background())) })
+
+	versionCheck, ok := checks[0].(*PostgresVersionCheck)
+	require.True(t, ok)
+	require.NotNil(t, versionCheck.Target)
+
+	_, err := versionCheck.Source(context.Background())
+	require.Error(t, err)
+	_, err = versionCheck.Target(context.Background())
+	require.Error(t, err)
+
+	lookups, _ := c.counts()
+	require.Equal(t, 2*perConn, lookups)
+}
+
+// TestBuilders_OneEntryPerCategory pins the registry contract: a category is
+// one Builders entry, and every entry is complete.
+func TestBuilders_OneEntryPerCategory(t *testing.T) {
+	t.Parallel()
+
+	seen := map[Category]bool{}
+	flags := map[string]bool{}
+	for _, b := range Builders {
+		require.NotEmpty(t, b.Category)
+		require.NotEmpty(t, b.Flag)
+		require.NotNil(t, b.Build)
+		require.False(t, seen[b.Category], "duplicate category %q", b.Category)
+		require.False(t, flags[b.Flag], "duplicate flag %q", b.Flag)
+		seen[b.Category] = true
+		flags[b.Flag] = true
+	}
 }

--- a/pkg/stream/preflight/connectivity.go
+++ b/pkg/stream/preflight/connectivity.go
@@ -15,6 +15,9 @@ import (
 type ConnectivityCheck struct {
 	Label string
 	URL   string
+	// ConnOptions configure the connection the check opens. Optional. See
+	// WithDialFunc and WithLookupFunc for the contract they must keep.
+	ConnOptions []ConnOption
 }
 
 func (c *ConnectivityCheck) Name() string {
@@ -22,7 +25,7 @@ func (c *ConnectivityCheck) Name() string {
 }
 
 func (c *ConnectivityCheck) Run(ctx context.Context) ([]Finding, error) {
-	conn, err := postgres.NewConn(ctx, c.URL)
+	conn, err := postgres.NewConn(ctx, c.URL, postgresConnOptions(c.ConnOptions)...)
 	if err != nil {
 		return []Finding{{Message: fmt.Sprintf("unable to connect: %v", err)}}, nil
 	}


### PR DESCRIPTION
#### Description

`pkg/stream/preflight` builds every Postgres connection from a URL alone, so a library caller cannot decide which address a check reaches. This PR adds two connection options, `WithDialFunc` and `WithLookupFunc`, that apply to every connection the checks open.

From now on preflight checks can reject loopback, link-local and RFC1918 destinations before any bytes are sent.

With no options supplied, behaviour and connection configuration are exactly as before. The CLI is unchanged and no flag is added.

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Add `preflight.WithDialFunc` and `preflight.WithLookupFunc`, and `WithConnOptions` to pass them `BuildSourceChecks`

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
