### PR TITLE
Add ID and name to every preflight finding

### DIFF
--- a/pkg/stream/preflight/CLAUDE.md
+++ b/pkg/stream/preflight/CLAUDE.md
@@ -21,12 +21,30 @@ Adding a check is meant to be a small, mechanical edit. Keep it that way.
 2. **Implement the check.** New struct in `<thing>.go`, satisfying the `Check` interface.
    - **Every `Finding` is blocking.** A check that finds nothing wrong returns a `nil` slice.
    - **Return `error` only when the check itself couldn't run** (timeout, internal bug, malformed input). A detected problem is a `Finding`, not an error.
+   - **Every finding declares an `ID` and a `Title`** — see [Identifying a finding](#identifying-a-finding).
    - **Put remediation in `Finding.Message`** — the user should be able to act on it without reading source.
 3. **Report what it observed**, if it observed anything worth reporting — see [Reporting what a check observed](#reporting-what-a-check-observed). Most checks need none of this: a check that only passes or fails implements no optional interface.
 4. **Materialise instances in the category builder** (e.g. `BuildConnectivityChecks`). The builder is the applicability gate: it reads `*stream.Config` and decides which instances are relevant. Inapplicable checks are silently omitted today; an explicit "skipped: <reason>" mechanism is deferred (see `docs/migration_preflight_issue.md` "Architecture decisions" #6).
    - **If checks in the category share a Postgres connection**, call `postgres.NewLazyConn(url, postgresConnOptions(opts)...)` in the builder, hand `src.Acquire` (a `postgres.AcquireFunc`) to every check, and return `src.Close` as the cleanup. See `BuildReplicationChecks` for the pattern. The engine runs sequentially, so the first check to call `Source(ctx)` opens the conn and the rest reuse it. A failed dial is memoised too — only one connection attempt happens, even if every check reports its own check error.
    - **Every connection must carry the connection options.** Forwarding them is what lets a library caller decide which address a check reaches, and the guarantee only holds while every builder does it. A check that opens its own connection instead of sharing one takes a `ConnOptions []ConnOption` field, set from the builder's `opts`, and passes `postgresConnOptions(c.ConnOptions)...` to `postgres.NewConn` — see `ConnectivityCheck`. `TestBuildSourceChecks_ConnOptions` fails when a connection escapes the options, so add the new category's URLs to the configuration it builds.
 5. **Tests.** Unit-test the check directly against mocked dependencies (`internal/postgres/mocks` has the postgres conn mock). For new categories, exercise the builder selection path through the cmd layer too.
+
+## Identifying a finding
+
+`Finding` carries four fields. A construction site sets all four; a test reads the package source and fails a site that omits one.
+
+| field | contains | consumed by |
+| --- | --- | --- |
+| `ID` | a stable slug naming the *kind* of problem | metrics keys, consumer copy |
+| `Title` | one short line naming the problem | a heading in a consumer's UI |
+| `Detail` | the specifics: the tables, the version, the setting value | a body in a consumer's UI |
+| `Message` | the single line the CLI prints | `pgstream check` |
+
+- **Declare the id as a constant in `finding_ids.go`.** `ID` names that constant; it is never a computed string. One id names exactly one construction site, and a test enforces both rules.
+- **An id is stable.** Once released it does not change, because consumers key metrics and their own copy on it. Ids are lowercase letters, digits and underscores.
+- **`ID` and `Title` never carry data read from the database under test.** Instance specifics — schema, table, column, role, version, setting value — go in `Detail` and `Message` only. One kind of problem found on twenty tables is one finding with twenty tables in `Detail`. A test enforces this by shape: `ID` must name a constant and `Title` must be a plain string literal, so neither can interpolate a value.
+- **A check that reports several kinds of problem declares an id per kind.** `assessReplicaIdentity` is the pattern: one helper, four ids.
+- **`Message` keeps the CLI output stable.** The printer renders `Message` alone, so changing it changes what a user reads.
 
 ## Reporting what a check observed
 

--- a/pkg/stream/preflight/access.go
+++ b/pkg/stream/preflight/access.go
@@ -148,7 +148,7 @@ func (c *SourceTableSelectPrivilegesCheck) Run(ctx context.Context) ([]Finding, 
 			continue
 		}
 		if !row.HasSelect {
-			findings = append(findings, Finding{Message: sourceTableSelectPrivilegeMessage(row)})
+			findings = append(findings, sourceTableSelectPrivilegeFinding(row))
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -184,7 +184,7 @@ func (c *SourceSequenceSelectPrivilegesCheck) Run(ctx context.Context) ([]Findin
 			continue
 		}
 		if !row.HasSelect {
-			findings = append(findings, Finding{Message: sourceSequenceSelectPrivilegeMessage(row)})
+			findings = append(findings, sourceSequenceSelectPrivilegeFinding(row))
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -208,9 +208,7 @@ func (c *TargetCreateDBPrivilegeCheck) Run(ctx context.Context) ([]Finding, erro
 	if hasCreateDB {
 		return nil, nil
 	}
-	return []Finding{
-		{Message: targetCreateDBPrivilegeMessage(role)},
-	}, nil
+	return []Finding{targetCreateDBPrivilegeFinding(role)}, nil
 }
 
 func (c *TargetCreateRolePrivilegeCheck) Run(ctx context.Context) ([]Finding, error) {
@@ -231,9 +229,7 @@ func (c *TargetCreateRolePrivilegeCheck) Run(ctx context.Context) ([]Finding, er
 	if hasCreateRole {
 		return nil, nil
 	}
-	return []Finding{{
-		Message: targetCreateRolePrivilegeMessage(role),
-	}}, nil
+	return []Finding{targetCreateRolePrivilegeFinding(role)}, nil
 }
 
 type sourceTableSelectPrivilegeRow struct {
@@ -298,35 +294,44 @@ func schemaHasWildcard(tables postgres.SchemaTableMap, schema string) bool {
 	return found
 }
 
-func sourceTableSelectPrivilegeMessage(row sourceTableSelectPrivilegeRow) string {
+func sourceTableSelectPrivilegeFinding(row sourceTableSelectPrivilegeRow) Finding {
 	quotedTable := postgres.QuoteIdentifier(row.Schema) + "." + postgres.QuoteIdentifier(row.Table)
 	quotedRole := postgres.QuoteIdentifier(row.Role)
-	return fmt.Sprintf(
-		"source role %q lacks SELECT on %s.%s; run GRANT SELECT ON TABLE %s TO %s",
-		row.Role, row.Schema, row.Table, quotedTable, quotedRole,
-	)
+	return Finding{
+		ID:      FindingIDSourceTableSelectPrivilegeMissing,
+		Title:   "The source role cannot read a table",
+		Detail:  fmt.Sprintf("The source role %q does not have SELECT on the table %s.%s. Run GRANT SELECT ON TABLE %s TO %s.", row.Role, row.Schema, row.Table, quotedTable, quotedRole),
+		Message: fmt.Sprintf("source role %q lacks SELECT on %s.%s; run GRANT SELECT ON TABLE %s TO %s", row.Role, row.Schema, row.Table, quotedTable, quotedRole),
+	}
 }
 
-func sourceSequenceSelectPrivilegeMessage(row sourceSequenceSelectPrivilegeRow) string {
+func sourceSequenceSelectPrivilegeFinding(row sourceSequenceSelectPrivilegeRow) Finding {
 	quotedSequence := postgres.QuoteIdentifier(row.SequenceSchema) + "." + postgres.QuoteIdentifier(row.Sequence)
 	quotedRole := postgres.QuoteIdentifier(row.Role)
-	return fmt.Sprintf(
-		"source role %q lacks SELECT on sequence %s.%s; run GRANT SELECT ON SEQUENCE %s TO %s",
-		row.Role, row.SequenceSchema, row.Sequence, quotedSequence, quotedRole,
-	)
+	return Finding{
+		ID:      FindingIDSourceSequenceSelectPrivilegeMissing,
+		Title:   "The source role cannot read a sequence",
+		Detail:  fmt.Sprintf("The source role %q does not have SELECT on the sequence %s.%s. Run GRANT SELECT ON SEQUENCE %s TO %s.", row.Role, row.SequenceSchema, row.Sequence, quotedSequence, quotedRole),
+		Message: fmt.Sprintf("source role %q lacks SELECT on sequence %s.%s; run GRANT SELECT ON SEQUENCE %s TO %s", row.Role, row.SequenceSchema, row.Sequence, quotedSequence, quotedRole),
+	}
 }
 
-func targetCreateDBPrivilegeMessage(role string) string {
+func targetCreateDBPrivilegeFinding(role string) Finding {
 	quotedRole := postgres.QuoteIdentifier(role)
-	return fmt.Sprintf(
-		"target role %q lacks CREATEDB; run ALTER ROLE %s CREATEDB",
-		role, quotedRole,
-	)
+	return Finding{
+		ID:      FindingIDTargetCreateDBPrivilegeMissing,
+		Title:   "The target role does not have the CREATEDB privilege",
+		Detail:  fmt.Sprintf("The target role %q does not have CREATEDB. Run ALTER ROLE %s CREATEDB.", role, quotedRole),
+		Message: fmt.Sprintf("target role %q lacks CREATEDB; run ALTER ROLE %s CREATEDB", role, quotedRole),
+	}
 }
 
-func targetCreateRolePrivilegeMessage(role string) string {
+func targetCreateRolePrivilegeFinding(role string) Finding {
 	quotedRole := postgres.QuoteIdentifier(role)
-	return fmt.Sprintf(
-		"target role %q lacks CREATEROLE; run ALTER ROLE %s CREATEROLE", role, quotedRole,
-	)
+	return Finding{
+		ID:      FindingIDTargetCreateRolePrivilegeMissing,
+		Title:   "The target role does not have the CREATEROLE privilege",
+		Detail:  fmt.Sprintf("The target role %q does not have CREATEROLE. Run ALTER ROLE %s CREATEROLE.", role, quotedRole),
+		Message: fmt.Sprintf("target role %q lacks CREATEROLE; run ALTER ROLE %s CREATEROLE", role, quotedRole),
+	}
 }

--- a/pkg/stream/preflight/access_test.go
+++ b/pkg/stream/preflight/access_test.go
@@ -603,68 +603,68 @@ func TestTargetCreateRolePrivilegeCheck_Name(t *testing.T) {
 	require.Equal(t, "target_createrole_privilege", (&TargetCreateRolePrivilegeCheck{}).Name())
 }
 
-func TestSourceTableSelectPrivilegeMessage(t *testing.T) {
+func TestSourceTableSelectPrivilegeFinding(t *testing.T) {
 	t.Parallel()
 
-	msg := sourceTableSelectPrivilegeMessage(sourceTableSelectPrivilegeRow{
+	msg := sourceTableSelectPrivilegeFinding(sourceTableSelectPrivilegeRow{
 		Role:   "pgstream_user",
 		Schema: "public",
 		Table:  "orders",
 	})
 
-	require.Contains(t, msg, `source role "pgstream_user"`)
-	require.Contains(t, msg, "lacks SELECT on public.orders;")
-	require.Contains(t, msg, `GRANT SELECT ON TABLE "public"."orders" TO "pgstream_user"`)
+	require.Contains(t, msg.Message, `source role "pgstream_user"`)
+	require.Contains(t, msg.Message, "lacks SELECT on public.orders;")
+	require.Contains(t, msg.Message, `GRANT SELECT ON TABLE "public"."orders" TO "pgstream_user"`)
 }
 
-func TestSourceTableSelectPrivilegeMessage_QuotesOnlyRemediation(t *testing.T) {
+func TestSourceTableSelectPrivilegeFinding_QuotesOnlyRemediation(t *testing.T) {
 	t.Parallel()
 
 	// Descriptive prose stays human-readable (unquoted); the GRANT statement
 	// gets postgres.QuoteIdentifier so it's executable on case-sensitive or
 	// special-character names.
-	msg := sourceTableSelectPrivilegeMessage(sourceTableSelectPrivilegeRow{
+	msg := sourceTableSelectPrivilegeFinding(sourceTableSelectPrivilegeRow{
 		Role:   "Replicator",
 		Schema: "Reporting",
 		Table:  "DailyRollup",
 	})
 
-	require.Contains(t, msg, "lacks SELECT on Reporting.DailyRollup;")
-	require.Contains(t, msg, `GRANT SELECT ON TABLE "Reporting"."DailyRollup" TO "Replicator"`)
+	require.Contains(t, msg.Message, "lacks SELECT on Reporting.DailyRollup;")
+	require.Contains(t, msg.Message, `GRANT SELECT ON TABLE "Reporting"."DailyRollup" TO "Replicator"`)
 }
 
-func TestSourceSequenceSelectPrivilegeMessage(t *testing.T) {
+func TestSourceSequenceSelectPrivilegeFinding(t *testing.T) {
 	t.Parallel()
 
-	msg := sourceSequenceSelectPrivilegeMessage(sourceSequenceSelectPrivilegeRow{
+	msg := sourceSequenceSelectPrivilegeFinding(sourceSequenceSelectPrivilegeRow{
 		Role:           "pgstream_user",
 		SequenceSchema: "public",
 		Sequence:       "orders_id_seq",
 	})
 
-	require.Contains(t, msg, `source role "pgstream_user"`)
-	require.Contains(t, msg, "lacks SELECT on sequence public.orders_id_seq;")
-	require.Contains(t, msg, `GRANT SELECT ON SEQUENCE "public"."orders_id_seq" TO "pgstream_user"`)
+	require.Contains(t, msg.Message, `source role "pgstream_user"`)
+	require.Contains(t, msg.Message, "lacks SELECT on sequence public.orders_id_seq;")
+	require.Contains(t, msg.Message, `GRANT SELECT ON SEQUENCE "public"."orders_id_seq" TO "pgstream_user"`)
 }
 
-func TestTargetCreateDBPrivilegeMessage(t *testing.T) {
+func TestTargetCreateDBPrivilegeFinding(t *testing.T) {
 	t.Parallel()
 
-	msg := targetCreateDBPrivilegeMessage("pgstreamtarget")
+	msg := targetCreateDBPrivilegeFinding("pgstreamtarget")
 
-	require.Contains(t, msg, `target role "pgstreamtarget"`)
-	require.Contains(t, msg, "lacks CREATEDB")
-	require.Contains(t, msg, `ALTER ROLE "pgstreamtarget" CREATEDB`)
+	require.Contains(t, msg.Message, `target role "pgstreamtarget"`)
+	require.Contains(t, msg.Message, "lacks CREATEDB")
+	require.Contains(t, msg.Message, `ALTER ROLE "pgstreamtarget" CREATEDB`)
 }
 
-func TestTargetCreateRolePrivilegeMessage(t *testing.T) {
+func TestTargetCreateRolePrivilegeFinding(t *testing.T) {
 	t.Parallel()
 
-	msg := targetCreateRolePrivilegeMessage("pgstreamtarget")
+	msg := targetCreateRolePrivilegeFinding("pgstreamtarget")
 
-	require.Contains(t, msg, `target role "pgstreamtarget"`)
-	require.Contains(t, msg, "lacks CREATEROLE")
-	require.Contains(t, msg, `ALTER ROLE "pgstreamtarget" CREATEROLE`)
+	require.Contains(t, msg.Message, `target role "pgstreamtarget"`)
+	require.Contains(t, msg.Message, "lacks CREATEROLE")
+	require.Contains(t, msg.Message, `ALTER ROLE "pgstreamtarget" CREATEROLE`)
 }
 
 func TestBuildAccessChecks(t *testing.T) {

--- a/pkg/stream/preflight/connectivity.go
+++ b/pkg/stream/preflight/connectivity.go
@@ -27,12 +27,22 @@ func (c *ConnectivityCheck) Name() string {
 func (c *ConnectivityCheck) Run(ctx context.Context) ([]Finding, error) {
 	conn, err := postgres.NewConn(ctx, c.URL, postgresConnOptions(c.ConnOptions)...)
 	if err != nil {
-		return []Finding{{Message: fmt.Sprintf("unable to connect: %v", err)}}, nil
+		return []Finding{{
+			ID:      FindingIDConnectionFailed,
+			Title:   "The database does not accept a connection",
+			Detail:  fmt.Sprintf("The connection attempt fails with: %v", err),
+			Message: fmt.Sprintf("unable to connect: %v", err),
+		}}, nil
 	}
 	defer conn.Close(ctx)
 
 	if err := conn.Ping(ctx); err != nil {
-		return []Finding{{Message: fmt.Sprintf("ping failed: %v", err)}}, nil
+		return []Finding{{
+			ID:      FindingIDConnectionPingFailed,
+			Title:   "The database does not answer a ping",
+			Detail:  fmt.Sprintf("The ping fails with: %v", err),
+			Message: fmt.Sprintf("ping failed: %v", err),
+		}}, nil
 	}
 
 	return nil, nil

--- a/pkg/stream/preflight/finding_ids.go
+++ b/pkg/stream/preflight/finding_ids.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+// Finding ids name the kind of problem a check reports, never the instance of
+// it. An id is stable: once released it does not change, because consumers key
+// metrics and their own copy on it. An id contains lowercase letters, digits
+// and underscores only, so it can never carry a value read from the database
+// under test.
+const (
+	FindingIDConnectionFailed     = "connection_failed"
+	FindingIDConnectionPingFailed = "connection_ping_failed"
+
+	FindingIDWALLevelNotLogical               = "wal_level_not_logical"
+	FindingIDWAL2JSONUnavailable              = "wal2json_unavailable"
+	FindingIDReplicationSlotHeadroomExhausted = "replication_slot_headroom_exhausted"
+	FindingIDReplicationRoleAttributeMissing  = "replication_role_attribute_missing"
+
+	FindingIDReplicaIdentityNoPrimaryKey  = "replica_identity_no_primary_key"
+	FindingIDReplicaIdentityNothing       = "replica_identity_nothing"
+	FindingIDReplicaIdentityIndexUnusable = "replica_identity_index_unusable"
+	FindingIDReplicaIdentityUnknown       = "replica_identity_unknown"
+
+	FindingIDSourceTableSelectPrivilegeMissing    = "source_table_select_privilege_missing"
+	FindingIDSourceSequenceSelectPrivilegeMissing = "source_sequence_select_privilege_missing"
+	FindingIDTargetCreateDBPrivilegeMissing       = "target_createdb_privilege_missing"
+	FindingIDTargetCreateRolePrivilegeMissing     = "target_createrole_privilege_missing"
+
+	FindingIDUnsupportedColumnType  = "unsupported_column_type"
+	FindingIDUnsupportedRangeType   = "unsupported_range_type"
+	FindingIDTargetExtensionMissing = "target_extension_missing"
+
+	FindingIDSnapshotConnectionHeadroomInsufficient = "snapshot_connection_headroom_insufficient"
+	FindingIDSourceMultipleInstances                = "source_multiple_instances"
+
+	FindingIDTargetVersionOlderThanSource = "target_version_older_than_source"
+)

--- a/pkg/stream/preflight/finding_ids_test.go
+++ b/pkg/stream/preflight/finding_ids_test.go
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/postgres/mocks"
+)
+
+// findingIDPattern is the shape every finding id must have: lowercase letters
+// and digits, grouped by single underscores. It admits no character a value
+// read from the database could carry, so an interpolated id fails the test.
+var findingIDPattern = regexp.MustCompile(`^[a-z][a-z0-9]*(_[a-z0-9]+)*$`)
+
+func TestFindingIDs_PatternAndUniqueness(t *testing.T) {
+	t.Parallel()
+
+	ids := declaredFindingIDs(t)
+	require.NotEmpty(t, ids)
+
+	seen := map[string]string{}
+	for name, id := range ids {
+		require.Regexpf(t, findingIDPattern, id, "finding id %q (%s) does not match the id pattern", id, name)
+		other, duplicate := seen[id]
+		require.Falsef(t, duplicate, "finding id %q is declared by both %s and %s", id, other, name)
+		seen[id] = name
+	}
+}
+
+// TestFindingIDs_EveryConstructionSiteIsComplete reads the package source and
+// asserts that every Finding built by a check declares an id, a title, a detail
+// and a message, that the id is a declared constant rather than a computed
+// string, and that the title is a plain string literal. The last two rules are
+// what keep data read from the database out of ID and Title: neither field can
+// interpolate a value it never receives.
+func TestFindingIDs_EveryConstructionSiteIsComplete(t *testing.T) {
+	t.Parallel()
+
+	declared := declaredFindingIDs(t)
+	used := map[string]int{}
+
+	for _, lit := range findingLiterals(t) {
+		fields := map[string]ast.Expr{}
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			require.True(t, ok, "a Finding literal uses positional fields")
+			key, ok := kv.Key.(*ast.Ident)
+			require.True(t, ok)
+			fields[key.Name] = kv.Value
+		}
+
+		for _, field := range []string{"ID", "Title", "Detail", "Message"} {
+			value, ok := fields[field]
+			require.Truef(t, ok, "a Finding literal does not set %s", field)
+			require.NotEmptyf(t, literalText(value), "a Finding literal sets an empty %s", field)
+		}
+
+		title, ok := fields["Title"].(*ast.BasicLit)
+		require.True(t, ok, "a Finding literal computes its Title instead of writing a string literal")
+		require.Equal(t, token.STRING, title.Kind, "a Finding literal's Title is not a string literal")
+
+		id, ok := fields["ID"].(*ast.Ident)
+		require.True(t, ok, "a Finding literal computes its ID instead of naming a constant")
+		require.Containsf(t, declared, id.Name, "%s is not a declared finding id constant", id.Name)
+		used[id.Name]++
+	}
+
+	for name := range declared {
+		require.Equalf(t, 1, used[name], "%s names %d finding construction sites, expected 1", name, used[name])
+	}
+}
+
+// TestFindings_SourceDataStaysOutOfIDAndTitle proves a finding keeps the data
+// it read from the database in Detail and Message only, so a consumer can count
+// findings by ID and show Title without exposing a customer schema.
+func TestFindings_SourceDataStaysOutOfIDAndTitle(t *testing.T) {
+	t.Parallel()
+
+	const (
+		distinctiveSchema   = "customer_billing_eu"
+		distinctiveTable    = "invoice_line_item_archive"
+		distinctiveColumn   = "settlement_window"
+		distinctiveType     = "money_amount_v2"
+		distinctiveRole     = "acme_replication_reader"
+		distinctiveSequence = "invoice_line_item_archive_id_seq"
+	)
+
+	tests := []struct {
+		name     string
+		check    Check
+		wantID   string
+		wantData []string
+	}{
+		{
+			name: "replica identity names the table in the detail only",
+			check: &ReplicaIdentityCheck{
+				Source: replicaIdentitySource(t, []replicaIdentityRow{
+					{Schema: distinctiveSchema, Name: distinctiveTable, Relreplident: "d"},
+				}),
+			},
+			wantID:   FindingIDReplicaIdentityNoPrimaryKey,
+			wantData: []string{distinctiveSchema, distinctiveTable},
+		},
+		{
+			name: "unsupported column type names the column in the detail only",
+			check: &SchemaTypeCompatibilityCheck{
+				Source: sourceWithColumns(t, []schemaColumnRow{{
+					Schema: distinctiveSchema, Table: distinctiveTable, Column: distinctiveColumn,
+					BaseOID: oidUnknown, TypeName: distinctiveType, TypeKind: "c",
+				}}),
+			},
+			wantID:   FindingIDUnsupportedColumnType,
+			wantData: []string{distinctiveSchema, distinctiveTable, distinctiveColumn, distinctiveType},
+		},
+		{
+			name: "missing table privilege names the table and role in the detail only",
+			check: &SourceTableSelectPrivilegesCheck{
+				Source: sourceWithRows(t, []sourceTableSelectPrivilegeRow{
+					{Role: distinctiveRole, Schema: distinctiveSchema, Table: distinctiveTable, HasSelect: false},
+				}),
+			},
+			wantID:   FindingIDSourceTableSelectPrivilegeMissing,
+			wantData: []string{distinctiveSchema, distinctiveTable, distinctiveRole},
+		},
+		{
+			name: "missing sequence privilege names the sequence in the detail only",
+			check: &SourceSequenceSelectPrivilegesCheck{
+				Source: sourceWithSequenceRows(t, []sourceSequenceSelectPrivilegeRow{{
+					Role: distinctiveRole, TableSchema: distinctiveSchema, Table: distinctiveTable,
+					SequenceSchema: distinctiveSchema, Sequence: distinctiveSequence, HasSelect: false,
+				}}),
+			},
+			wantID:   FindingIDSourceSequenceSelectPrivilegeMissing,
+			wantData: []string{distinctiveSchema, distinctiveSequence, distinctiveRole},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			findings, err := tc.check.Run(context.Background())
+			require.NoError(t, err)
+			require.Len(t, findings, 1)
+
+			finding := findings[0]
+			require.Equal(t, tc.wantID, finding.ID)
+			require.NotEmpty(t, finding.Title)
+			require.NotEmpty(t, finding.Detail)
+			require.NotEmpty(t, finding.Message)
+
+			for _, data := range tc.wantData {
+				require.NotContainsf(t, finding.ID, data, "the id carries source data")
+				require.NotContainsf(t, finding.Title, data, "the title carries source data")
+				require.Contains(t, finding.Detail, data)
+				require.Contains(t, finding.Message, data)
+			}
+		})
+	}
+}
+
+// TestFindings_MessageIsStable pins the exact Message of every finding kind
+// whose text is deterministic. Message is the line `pgstream check` prints, so
+// changing one of these strings changes what a user reads. Detail restates the
+// same facts in the prose a consumer's UI renders, and the two are written side
+// by side at every construction site — this test is what stops an edit meant
+// for Detail from landing in Message unnoticed.
+//
+// The two connectivity kinds are absent: their Message is a fixed prefix
+// followed by the driver's error text, which a unit test cannot pin.
+func TestFindings_MessageIsStable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		wantID      string
+		wantMessage string
+		build       func(t *testing.T) Finding
+	}{
+		{
+			wantID:      FindingIDSourceTableSelectPrivilegeMissing,
+			wantMessage: `source role "pgstream_user" lacks SELECT on public.orders; run GRANT SELECT ON TABLE "public"."orders" TO "pgstream_user"`,
+			build: func(*testing.T) Finding {
+				return sourceTableSelectPrivilegeFinding(sourceTableSelectPrivilegeRow{
+					Role: "pgstream_user", Schema: "public", Table: "orders",
+				})
+			},
+		},
+		{
+			wantID:      FindingIDSourceSequenceSelectPrivilegeMissing,
+			wantMessage: `source role "pgstream_user" lacks SELECT on sequence public.orders_id_seq; run GRANT SELECT ON SEQUENCE "public"."orders_id_seq" TO "pgstream_user"`,
+			build: func(*testing.T) Finding {
+				return sourceSequenceSelectPrivilegeFinding(sourceSequenceSelectPrivilegeRow{
+					Role: "pgstream_user", SequenceSchema: "public", Sequence: "orders_id_seq",
+				})
+			},
+		},
+		{
+			wantID:      FindingIDTargetCreateDBPrivilegeMissing,
+			wantMessage: `target role "pgstreamtarget" lacks CREATEDB; run ALTER ROLE "pgstreamtarget" CREATEDB`,
+			build:       func(*testing.T) Finding { return targetCreateDBPrivilegeFinding("pgstreamtarget") },
+		},
+		{
+			wantID:      FindingIDTargetCreateRolePrivilegeMissing,
+			wantMessage: `target role "pgstreamtarget" lacks CREATEROLE; run ALTER ROLE "pgstreamtarget" CREATEROLE`,
+			build:       func(*testing.T) Finding { return targetCreateRolePrivilegeFinding("pgstreamtarget") },
+		},
+		{
+			wantID:      FindingIDReplicaIdentityNoPrimaryKey,
+			wantMessage: `"public"."audit_log": REPLICA IDENTITY=default but no PRIMARY KEY; UPDATE/DELETE WAL events will be skipped — add a PRIMARY KEY, set REPLICA IDENTITY FULL, or REPLICA IDENTITY USING INDEX <unique non-partial NOT-NULL index>`,
+			build: func(*testing.T) Finding {
+				finding, _ := assessReplicaIdentity(replicaIdentityRow{Schema: "public", Name: "audit_log", Relreplident: "d"})
+				return finding
+			},
+		},
+		{
+			wantID:      FindingIDReplicaIdentityNothing,
+			wantMessage: `"public"."events": REPLICA IDENTITY=nothing; UPDATE/DELETE WAL events will be skipped — set REPLICA IDENTITY DEFAULT / FULL / USING INDEX`,
+			build: func(*testing.T) Finding {
+				finding, _ := assessReplicaIdentity(replicaIdentityRow{Schema: "public", Name: "events", Relreplident: "n", HasPK: true})
+				return finding
+			},
+		},
+		{
+			wantID:      FindingIDReplicaIdentityIndexUnusable,
+			wantMessage: `"public"."t": REPLICA IDENTITY=index but the chosen index is invalid, non-unique, partial, or includes nullable columns — pick a different index or use REPLICA IDENTITY FULL`,
+			build: func(*testing.T) Finding {
+				finding, _ := assessReplicaIdentity(replicaIdentityRow{Schema: "public", Name: "t", Relreplident: "i"})
+				return finding
+			},
+		},
+		{
+			wantID:      FindingIDReplicaIdentityUnknown,
+			wantMessage: `"public"."t": unknown REPLICA IDENTITY="z" on this Postgres version`,
+			build: func(*testing.T) Finding {
+				finding, _ := assessReplicaIdentity(replicaIdentityRow{Schema: "public", Name: "t", Relreplident: "z"})
+				return finding
+			},
+		},
+		{
+			wantID:      FindingIDUnsupportedColumnType,
+			wantMessage: `"public"."t"."c": type "geometry" unknown type; Cast the column to a supported type or exclude the table from the migration. To request support, open an issue in the repo: https://github.com/xataio/pgstream/issues/new`,
+			build: func(*testing.T) Finding {
+				return unsupportedColumnTypeFinding(schemaColumnRow{
+					Schema: "public", Table: "t", Column: "c", TypeName: "geometry", TypeKind: "b",
+				})
+			},
+		},
+		{
+			wantID:      FindingIDUnsupportedRangeType,
+			wantMessage: `"public"."t"."c": range type "numrange" unknown type; pgstream only encodes int4range, int8range, and tstzrange values. Cast the column to a supported type or exclude the table from the migration. To request support, open an issue in the repo: https://github.com/xataio/pgstream/issues/new`,
+			build: func(*testing.T) Finding {
+				finding, _ := unsupportedRangeTypeFinding(schemaColumnRow{
+					Schema: "public", Table: "t", Column: "c", TypeName: "numrange", TypeKind: "r",
+				})
+				return finding
+			},
+		},
+		{
+			wantID:      FindingIDTargetExtensionMissing,
+			wantMessage: `1 extension installed on source but missing on the target: "postgis" (source schema "public"); run the following on the target before migrating, or the schema will fail to apply: CREATE EXTENSION IF NOT EXISTS "postgis";`,
+			build: func(*testing.T) Finding {
+				return missingExtensionsFinding([]missingExtension{{name: "postgis", schema: "public"}})
+			},
+		},
+		{
+			wantID:      FindingIDWALLevelNotLogical,
+			wantMessage: `wal_level="replica" on source; set wal_level=logical in postgresql.conf and restart for logical replication`,
+			build: func(t *testing.T) Finding {
+				return singleFinding(t, &WALLevelCheck{Source: queryRowSource(t, func(t *testing.T, dest []any) {
+					level, ok := dest[0].(*string)
+					require.True(t, ok)
+					*level = "replica"
+				})})
+			},
+		},
+		{
+			wantID:      FindingIDWAL2JSONUnavailable,
+			wantMessage: `wal2json output plugin not available on source; install the wal2json package, and on postgres 17.11+ add wal2json to output_plugin_libraries (it defaults to "pgoutput, test_decoding") and reload the server — that allowlist is checked before the library is loaded, so an installed wal2json is still refused while it is missing from it`,
+			build: func(t *testing.T) Finding {
+				return singleFinding(t, &WAL2JSONCheck{Source: func(context.Context) (postgres.Querier, error) {
+					return &mocks.Querier{
+						QueryRowFn: func(context.Context, []any, string, ...any) error {
+							return errors.New(`could not access file "wal2json"`)
+						},
+					}, nil
+				}})
+			},
+		},
+		{
+			wantID:      FindingIDReplicationSlotHeadroomExhausted,
+			wantMessage: "no replication slot headroom: 10/10 slots in use; raise max_replication_slots (requires restart) or drop unused slots",
+			build: func(t *testing.T) Finding {
+				return singleFinding(t, &ReplicationSlotHeadroomCheck{Source: queryRowSource(t, func(t *testing.T, dest []any) {
+					maxSlots, ok := dest[0].(*int)
+					require.True(t, ok)
+					usedSlots, ok := dest[1].(*int)
+					require.True(t, ok)
+					*maxSlots, *usedSlots = 10, 10
+				})})
+			},
+		},
+		{
+			wantID:      FindingIDReplicationRoleAttributeMissing,
+			wantMessage: `source role "pgstream_user" lacks the REPLICATION attribute; run ALTER ROLE pgstream_user REPLICATION as a superuser`,
+			build: func(t *testing.T) Finding {
+				return singleFinding(t, &ReplicationRoleAttrCheck{Source: queryRowSource(t, func(t *testing.T, dest []any) {
+					roleName, ok := dest[0].(*string)
+					require.True(t, ok)
+					hasReplication, ok := dest[1].(*bool)
+					require.True(t, ok)
+					*roleName, *hasReplication = "pgstream_user", false
+				})})
+			},
+		},
+		{
+			wantID:      FindingIDSnapshotConnectionHeadroomInsufficient,
+			wantMessage: "snapshot needs 16 concurrent connections (snapshot_workers × table_workers) but source has only 7 available (max_connections=100, superuser_reserved_connections=3, 90 in use); lower snapshot_workers/table_workers, raise max_connections (requires restart), or reduce existing connections",
+			build: func(t *testing.T) Finding {
+				return singleFinding(t, &SnapshotConnectionsCheck{Source: sourceWithConnLimits(t, 100, 3, 90), Demand: 16})
+			},
+		},
+		{
+			wantID:      FindingIDSourceMultipleInstances,
+			wantMessage: "source appears to be load-balanced across multiple Postgres instances: an exported snapshot was not visible on 3 of 8 probe connections. Parallel data snapshotting requires every connection to reach the same instance — point the source at a single-instance / writer endpoint (Aurora/RDS reader endpoints and instance-spanning poolers are unsupported for snapshots).",
+			build: func(t *testing.T) Finding {
+				return singleFinding(t, &SourceSnapshotInstanceCheck{
+					Probe:  func(context.Context, int) (int, error) { return 3, nil },
+					Probes: 8,
+				})
+			},
+		},
+		{
+			wantID:      FindingIDTargetVersionOlderThanSource,
+			wantMessage: "source is PostgreSQL 18.4, target is PostgreSQL 17.4; restoring a dump from a newer server into an older one is unsupported and may fail. Use a target running PostgreSQL 18 or newer.",
+			build: func(t *testing.T) Finding {
+				return singleFinding(t, &PostgresVersionCheck{Source: versionConn(t, 18), Target: versionConn(t, 17)})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.wantID, func(t *testing.T) {
+			t.Parallel()
+
+			finding := tc.build(t)
+			require.Equal(t, tc.wantID, finding.ID)
+			require.Equal(t, tc.wantMessage, finding.Message)
+		})
+	}
+}
+
+// singleFinding runs a check and returns the one finding it is expected to
+// report.
+func singleFinding(t *testing.T, check Check) Finding {
+	t.Helper()
+
+	findings, err := check.Run(context.Background())
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	return findings[0]
+}
+
+// queryRowSource returns an AcquireFunc whose Querier answers every QueryRow by
+// letting fill populate the scan destinations, for the checks that read a
+// single row of settings.
+func queryRowSource(t *testing.T, fill func(t *testing.T, dest []any)) postgres.AcquireFunc {
+	return func(context.Context) (postgres.Querier, error) {
+		return &mocks.Querier{
+			QueryRowFn: func(_ context.Context, dest []any, _ string, _ ...any) error {
+				fill(t, dest)
+				return nil
+			},
+		}, nil
+	}
+}
+
+// declaredFindingIDs returns every finding id constant declared in
+// finding_ids.go, keyed by constant name.
+func declaredFindingIDs(t *testing.T) map[string]string {
+	t.Helper()
+
+	file, err := parser.ParseFile(token.NewFileSet(), "finding_ids.go", nil, 0)
+	require.NoError(t, err)
+
+	ids := map[string]string{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			require.True(t, ok)
+			require.Len(t, value.Values, 1)
+			lit, ok := value.Values[0].(*ast.BasicLit)
+			require.True(t, ok, "a finding id constant is not a string literal")
+			id, err := strconv.Unquote(lit.Value)
+			require.NoError(t, err)
+			ids[value.Names[0].Name] = id
+		}
+	}
+	return ids
+}
+
+// findingLiterals returns every non-empty Finding composite literal in the
+// package's non-test sources. An empty literal is the "no finding" sentinel a
+// helper returns beside a false result, so it is skipped.
+func findingLiterals(t *testing.T) []*ast.CompositeLit {
+	t.Helper()
+
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	var literals []*ast.CompositeLit
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), name, nil, 0)
+		require.NoError(t, err)
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok || len(lit.Elts) == 0 {
+				return true
+			}
+			switch typ := lit.Type.(type) {
+			case *ast.Ident:
+				if typ.Name == "Finding" {
+					literals = append(literals, lit)
+				}
+			case *ast.ArrayType:
+				elem, ok := typ.Elt.(*ast.Ident)
+				if !ok || elem.Name != "Finding" {
+					return true
+				}
+				for _, elt := range lit.Elts {
+					inner, ok := elt.(*ast.CompositeLit)
+					if ok && inner.Type == nil && len(inner.Elts) > 0 {
+						literals = append(literals, inner)
+					}
+				}
+			}
+			return true
+		})
+	}
+	return literals
+}
+
+// literalText returns the text of a string literal expression, and the empty
+// string for anything else. A composed expression (fmt.Sprintf, concatenation)
+// therefore reads as non-empty, which is what the completeness test needs.
+func literalText(expr ast.Expr) string {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "composed"
+	}
+	text, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "composed"
+	}
+	return text
+}

--- a/pkg/stream/preflight/preflight.go
+++ b/pkg/stream/preflight/preflight.go
@@ -22,7 +22,16 @@ const (
 
 // Finding describes a single issue detected by a Check. Every finding is an
 // error — a check that finds nothing wrong returns no findings at all.
+//
+// ID and Title identify the kind of problem, not the instance of it. Neither
+// carries data read from the database under test, so a consumer can count
+// findings by ID and show Title as a heading for a kind it has never seen.
+// Detail carries the specifics: the tables, the version, the setting value.
+// Message is the single line the CLI prints.
 type Finding struct {
+	ID      string `json:"id"`
+	Title   string `json:"title"`
+	Detail  string `json:"detail"`
 	Message string `json:"message"`
 }
 

--- a/pkg/stream/preflight/preflight_test.go
+++ b/pkg/stream/preflight/preflight_test.go
@@ -245,8 +245,13 @@ func TestReport_JSONMarshal(t *testing.T) {
 	report := Report{
 		Results: []CheckResult{
 			{
-				Name:     "a",
-				Findings: []Finding{{Message: "broken"}},
+				Name: "a",
+				Findings: []Finding{{
+					ID:      "wal_level_not_logical",
+					Title:   "The source wal_level is not logical",
+					Detail:  "The source runs with wal_level=\"replica\".",
+					Message: "broken",
+				}},
 			},
 			{
 				Name: "b",
@@ -259,7 +264,11 @@ func TestReport_JSONMarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := `{"results":[` +
-		`{"name":"a","findings":[{"message":"broken"}]},` +
+		`{"name":"a","findings":[{` +
+		`"id":"wal_level_not_logical",` +
+		`"title":"The source wal_level is not logical",` +
+		`"detail":"The source runs with wal_level=\"replica\".",` +
+		`"message":"broken"}]},` +
 		`{"name":"b","findings":null,"error":"boom"}` +
 		`]}`
 	require.JSONEq(t, expected, string(data))

--- a/pkg/stream/preflight/replica_identity.go
+++ b/pkg/stream/preflight/replica_identity.go
@@ -69,8 +69,8 @@ func (c *ReplicaIdentityCheck) Run(ctx context.Context) ([]Finding, error) {
 		if !c.Selection.IsTableInScope(t.Schema, t.Name) {
 			continue
 		}
-		if msg := assessReplicaIdentity(t); msg != "" {
-			findings = append(findings, Finding{Message: msg})
+		if finding, found := assessReplicaIdentity(t); found {
+			findings = append(findings, finding)
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -87,27 +87,47 @@ type replicaIdentityRow struct {
 	ReplidentOK  bool // only meaningful when Relreplident == 'i'
 }
 
-// assessReplicaIdentity returns a remediation message if the table's REPLICA
-// IDENTITY is insufficient for UPDATE/DELETE replication, or "" if it's OK.
+// assessReplicaIdentity returns a finding if the table's REPLICA IDENTITY is
+// insufficient for UPDATE/DELETE replication, and reports false if it's OK.
 // Kept pure for cheap unit testing.
-func assessReplicaIdentity(t replicaIdentityRow) string {
+func assessReplicaIdentity(t replicaIdentityRow) (Finding, bool) {
 	tbl := postgres.QuoteIdentifier(t.Schema) + "." + postgres.QuoteIdentifier(t.Name)
 	switch t.Relreplident {
 	case "f":
-		return ""
+		return Finding{}, false
 	case "d":
 		if t.HasPK {
-			return ""
+			return Finding{}, false
 		}
-		return fmt.Sprintf("%s: REPLICA IDENTITY=default but no PRIMARY KEY; UPDATE/DELETE WAL events will be skipped — add a PRIMARY KEY, set REPLICA IDENTITY FULL, or REPLICA IDENTITY USING INDEX <unique non-partial NOT-NULL index>", tbl)
+		return Finding{
+			ID:      FindingIDReplicaIdentityNoPrimaryKey,
+			Title:   "A table has replica identity default and no primary key",
+			Detail:  fmt.Sprintf("The table %s has REPLICA IDENTITY=default and no PRIMARY KEY, so Postgres skips its UPDATE and DELETE WAL events. Add a PRIMARY KEY, set REPLICA IDENTITY FULL, or set REPLICA IDENTITY USING INDEX with a unique, non-partial, NOT NULL index.", tbl),
+			Message: fmt.Sprintf("%s: REPLICA IDENTITY=default but no PRIMARY KEY; UPDATE/DELETE WAL events will be skipped — add a PRIMARY KEY, set REPLICA IDENTITY FULL, or REPLICA IDENTITY USING INDEX <unique non-partial NOT-NULL index>", tbl),
+		}, true
 	case "n":
-		return fmt.Sprintf("%s: REPLICA IDENTITY=nothing; UPDATE/DELETE WAL events will be skipped — set REPLICA IDENTITY DEFAULT / FULL / USING INDEX", tbl)
+		return Finding{
+			ID:      FindingIDReplicaIdentityNothing,
+			Title:   "A table has replica identity nothing",
+			Detail:  fmt.Sprintf("The table %s has REPLICA IDENTITY=nothing, so Postgres skips its UPDATE and DELETE WAL events. Set REPLICA IDENTITY DEFAULT, FULL, or USING INDEX.", tbl),
+			Message: fmt.Sprintf("%s: REPLICA IDENTITY=nothing; UPDATE/DELETE WAL events will be skipped — set REPLICA IDENTITY DEFAULT / FULL / USING INDEX", tbl),
+		}, true
 	case "i":
 		if t.ReplidentOK {
-			return ""
+			return Finding{}, false
 		}
-		return fmt.Sprintf("%s: REPLICA IDENTITY=index but the chosen index is invalid, non-unique, partial, or includes nullable columns — pick a different index or use REPLICA IDENTITY FULL", tbl)
+		return Finding{
+			ID:      FindingIDReplicaIdentityIndexUnusable,
+			Title:   "A table uses an unusable index as its replica identity",
+			Detail:  fmt.Sprintf("The table %s has REPLICA IDENTITY=index, but the index is invalid, non-unique, partial, or includes nullable columns. Select a different index, or use REPLICA IDENTITY FULL.", tbl),
+			Message: fmt.Sprintf("%s: REPLICA IDENTITY=index but the chosen index is invalid, non-unique, partial, or includes nullable columns — pick a different index or use REPLICA IDENTITY FULL", tbl),
+		}, true
 	default:
-		return fmt.Sprintf("%s: unknown REPLICA IDENTITY=%q on this Postgres version", tbl, t.Relreplident)
+		return Finding{
+			ID:      FindingIDReplicaIdentityUnknown,
+			Title:   "A table has an unknown replica identity",
+			Detail:  fmt.Sprintf("The table %s reports REPLICA IDENTITY=%q, which this Postgres version does not define. Set REPLICA IDENTITY DEFAULT, FULL, or USING INDEX.", tbl, t.Relreplident),
+			Message: fmt.Sprintf("%s: unknown REPLICA IDENTITY=%q on this Postgres version", tbl, t.Relreplident),
+		}, true
 	}
 }

--- a/pkg/stream/preflight/replica_identity_test.go
+++ b/pkg/stream/preflight/replica_identity_test.go
@@ -21,7 +21,8 @@ func TestAssessReplicaIdentity(t *testing.T) {
 		name     string
 		row      replicaIdentityRow
 		wantHit  bool
-		wantSubs []string // substrings that must appear in the finding
+		wantID   string
+		wantSubs []string // substrings that must appear in the finding message
 	}{
 		{
 			name: "FULL is always OK",
@@ -35,12 +36,14 @@ func TestAssessReplicaIdentity(t *testing.T) {
 			name:     "default without PK is a finding",
 			row:      replicaIdentityRow{Schema: "public", Name: "audit_log", Relreplident: "d"},
 			wantHit:  true,
+			wantID:   FindingIDReplicaIdentityNoPrimaryKey,
 			wantSubs: []string{`"public"."audit_log"`, "REPLICA IDENTITY=default", "no PRIMARY KEY"},
 		},
 		{
 			name:     "nothing is a finding regardless of PK",
 			row:      replicaIdentityRow{Schema: "public", Name: "events", Relreplident: "n", HasPK: true},
 			wantHit:  true,
+			wantID:   FindingIDReplicaIdentityNothing,
 			wantSubs: []string{`"public"."events"`, "REPLICA IDENTITY=nothing"},
 		},
 		{
@@ -51,12 +54,14 @@ func TestAssessReplicaIdentity(t *testing.T) {
 			name:     "index with an invalid index is a finding",
 			row:      replicaIdentityRow{Schema: "public", Name: "t", Relreplident: "i"},
 			wantHit:  true,
+			wantID:   FindingIDReplicaIdentityIndexUnusable,
 			wantSubs: []string{`"public"."t"`, "REPLICA IDENTITY=index"},
 		},
 		{
 			name:     "unknown relreplident value is a finding",
 			row:      replicaIdentityRow{Schema: "public", Name: "t", Relreplident: "z"},
 			wantHit:  true,
+			wantID:   FindingIDReplicaIdentityUnknown,
 			wantSubs: []string{"unknown REPLICA IDENTITY"},
 		},
 	}
@@ -64,13 +69,17 @@ func TestAssessReplicaIdentity(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := assessReplicaIdentity(tc.row)
+			got, found := assessReplicaIdentity(tc.row)
+			require.Equal(t, tc.wantHit, found)
 			if !tc.wantHit {
-				require.Empty(t, got)
+				require.Equal(t, Finding{}, got)
 				return
 			}
+			require.Equal(t, tc.wantID, got.ID)
+			require.NotEmpty(t, got.Title)
+			require.NotEmpty(t, got.Detail)
 			for _, sub := range tc.wantSubs {
-				require.Contains(t, got, sub)
+				require.Contains(t, got.Message, sub)
 			}
 		})
 	}

--- a/pkg/stream/preflight/replication.go
+++ b/pkg/stream/preflight/replication.go
@@ -36,6 +36,9 @@ func (c *WALLevelCheck) Run(ctx context.Context) ([]Finding, error) {
 	}
 	if level != "logical" {
 		return []Finding{{
+			ID:      FindingIDWALLevelNotLogical,
+			Title:   "The source wal_level is not logical",
+			Detail:  fmt.Sprintf("The source runs with wal_level=%q. Logical replication requires wal_level=logical. Set it in postgresql.conf and restart the server.", level),
 			Message: fmt.Sprintf("wal_level=%q on source; set wal_level=logical in postgresql.conf and restart for logical replication", level),
 		}}, nil
 	}
@@ -95,6 +98,11 @@ func (c *WAL2JSONCheck) Run(ctx context.Context) ([]Finding, error) {
 	switch {
 	case isWAL2JSONMissing(probeErr), isWAL2JSONNotAllowed(probeErr):
 		return []Finding{{
+			ID:    FindingIDWAL2JSONUnavailable,
+			Title: "The wal2json output plugin is not available on the source",
+			Detail: "Install the wal2json package. On postgres 17.11+, also add wal2json to output_plugin_libraries " +
+				"(it defaults to \"pgoutput, test_decoding\") and reload the server. The server reads that allowlist " +
+				"before it loads the library, so it refuses an installed wal2json while the allowlist omits it.",
 			Message: "wal2json output plugin not available on source; install the wal2json package, and on postgres 17.11+ add wal2json to output_plugin_libraries (it defaults to \"pgoutput, test_decoding\") and reload the server — that allowlist is checked before the library is loaded, so an installed wal2json is still refused while it is missing from it",
 		}}, nil
 	case isProbePreconditionUnmet(probeErr):
@@ -197,6 +205,9 @@ func (c *ReplicationSlotHeadroomCheck) Run(ctx context.Context) ([]Finding, erro
 	}
 	if usedSlots >= maxSlots {
 		return []Finding{{
+			ID:      FindingIDReplicationSlotHeadroomExhausted,
+			Title:   "The source has no free replication slot",
+			Detail:  fmt.Sprintf("The source uses %d of %d replication slots. Raise max_replication_slots (requires a restart) or drop unused slots.", usedSlots, maxSlots),
 			Message: fmt.Sprintf("no replication slot headroom: %d/%d slots in use; raise max_replication_slots (requires restart) or drop unused slots", usedSlots, maxSlots),
 		}}, nil
 	}
@@ -224,6 +235,9 @@ func (c *ReplicationRoleAttrCheck) Run(ctx context.Context) ([]Finding, error) {
 	}
 	if !hasReplication {
 		return []Finding{{
+			ID:      FindingIDReplicationRoleAttributeMissing,
+			Title:   "The source role does not have the REPLICATION attribute",
+			Detail:  fmt.Sprintf("The source role %q does not have the REPLICATION attribute, which a logical replication slot requires. Run ALTER ROLE %s REPLICATION as a superuser.", roleName, roleName),
 			Message: fmt.Sprintf("source role %q lacks the REPLICATION attribute; run ALTER ROLE %s REPLICATION as a superuser", roleName, roleName),
 		}}, nil
 	}

--- a/pkg/stream/preflight/resources.go
+++ b/pkg/stream/preflight/resources.go
@@ -82,6 +82,9 @@ func (c *SnapshotConnectionsCheck) Run(ctx context.Context) ([]Finding, error) {
 	}
 	if int(c.Demand) > available {
 		return []Finding{{
+			ID:     FindingIDSnapshotConnectionHeadroomInsufficient,
+			Title:  "The source does not have enough free connections for the snapshot",
+			Detail: fmt.Sprintf("The snapshot needs %d concurrent connections (snapshot_workers × table_workers). The source has %d available (max_connections=%d, superuser_reserved_connections=%d, %d in use). Lower snapshot_workers or table_workers, raise max_connections (requires a restart), or close existing connections.", c.Demand, available, maxConns, reserved, used),
 			Message: fmt.Sprintf(
 				"snapshot needs %d concurrent connections (snapshot_workers × table_workers) but source has only %d available (max_connections=%d, superuser_reserved_connections=%d, %d in use); lower snapshot_workers/table_workers, raise max_connections (requires restart), or reduce existing connections",
 				c.Demand, available, maxConns, reserved, used,

--- a/pkg/stream/preflight/schema.go
+++ b/pkg/stream/preflight/schema.go
@@ -102,7 +102,7 @@ func (c *SchemaTypeCompatibilityCheck) Run(ctx context.Context) ([]Finding, erro
 		if _, ok := pgstreamSupportedTypes[row.TypeName]; ok {
 			continue
 		}
-		findings = append(findings, Finding{Message: unsupportedColumnTypeMessage(row)})
+		findings = append(findings, unsupportedColumnTypeFinding(row))
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating rows: %w", err)
@@ -139,16 +139,18 @@ func (r schemaColumnRow) isEnum() bool {
 	return r.TypeKind == "e" || r.ElemTypeKind == "e"
 }
 
-func unsupportedColumnTypeMessage(row schemaColumnRow) string {
+func unsupportedColumnTypeFinding(row schemaColumnRow) Finding {
 	col := postgres.QuoteIdentifier(row.Schema) + "." + postgres.QuoteIdentifier(row.Table) + "." + postgres.QuoteIdentifier(row.Column)
 	desc := fmt.Sprintf("type %q", row.TypeName)
 	if kind := typeKindLabel(row.TypeKind); kind != "" {
 		desc = fmt.Sprintf("%s %q", kind, row.TypeName)
 	}
-	return fmt.Sprintf(
-		"%s: %s unknown type; Cast the column to a supported type or exclude the table from the migration. To request support, open an issue in the repo: https://github.com/xataio/pgstream/issues/new",
-		col, desc,
-	)
+	return Finding{
+		ID:      FindingIDUnsupportedColumnType,
+		Title:   "A column uses a type pgstream does not support",
+		Detail:  fmt.Sprintf("The column %s uses the unknown %s. Cast the column to a supported type, or exclude the table from the migration. To request support, open an issue in the repo: https://github.com/xataio/pgstream/issues/new", col, desc),
+		Message: fmt.Sprintf("%s: %s unknown type; Cast the column to a supported type or exclude the table from the migration. To request support, open an issue in the repo: https://github.com/xataio/pgstream/issues/new", col, desc),
+	}
 }
 
 // PostgresRangeTypeCheck verifies that every in-scope range/multirange column
@@ -190,8 +192,8 @@ func (c *PostgresRangeTypeCheck) Run(ctx context.Context) ([]Finding, error) {
 		if !c.Selection.IsTableInScope(row.Schema, row.Table) {
 			continue
 		}
-		if msg := unsupportedRangeTypeMessage(row); msg != "" {
-			findings = append(findings, Finding{Message: msg})
+		if finding, found := unsupportedRangeTypeFinding(row); found {
+			findings = append(findings, finding)
 		}
 	}
 	if err := rows.Err(); err != nil {
@@ -200,20 +202,22 @@ func (c *PostgresRangeTypeCheck) Run(ctx context.Context) ([]Finding, error) {
 	return findings, nil
 }
 
-func unsupportedRangeTypeMessage(row schemaColumnRow) string {
+func unsupportedRangeTypeFinding(row schemaColumnRow) (Finding, bool) {
 	switch row.TypeKind {
 	case "r", "m": // range, multirange
 	default:
-		return ""
+		return Finding{}, false
 	}
 	if _, ok := supportedPostgresRangeTypes[row.TypeName]; ok {
-		return ""
+		return Finding{}, false
 	}
 	col := postgres.QuoteIdentifier(row.Schema) + "." + postgres.QuoteIdentifier(row.Table) + "." + postgres.QuoteIdentifier(row.Column)
-	return fmt.Sprintf(
-		"%s: %s %q unknown type; pgstream only encodes int4range, int8range, and tstzrange values. Cast the column to a supported type or exclude the table from the migration. To request support, open an issue in the repo: https://github.com/xataio/pgstream/issues/new",
-		col, typeKindLabel(row.TypeKind), row.TypeName,
-	)
+	return Finding{
+		ID:      FindingIDUnsupportedRangeType,
+		Title:   "A column uses a range type pgstream does not support",
+		Detail:  fmt.Sprintf("The column %s uses the unknown %s %q. pgstream encodes int4range, int8range, and tstzrange values only. Cast the column to a supported type, or exclude the table from the migration. To request support, open an issue in the repo: https://github.com/xataio/pgstream/issues/new", col, typeKindLabel(row.TypeKind), row.TypeName),
+		Message: fmt.Sprintf("%s: %s %q unknown type; pgstream only encodes int4range, int8range, and tstzrange values. Cast the column to a supported type or exclude the table from the migration. To request support, open an issue in the repo: https://github.com/xataio/pgstream/issues/new", col, typeKindLabel(row.TypeKind), row.TypeName),
+	}, true
 }
 
 // SchemaExtensionCompatibilityCheck verifies that every extension installed on
@@ -271,7 +275,7 @@ func (c *SchemaExtensionCompatibilityCheck) Run(ctx context.Context) ([]Finding,
 	if len(missing) == 0 {
 		return nil, nil
 	}
-	return []Finding{{Message: missingExtensionsMessage(missing)}}, nil
+	return []Finding{missingExtensionsFinding(missing)}, nil
 }
 
 // Details exposes every extension installed on the source as a string array
@@ -311,9 +315,9 @@ type missingExtension struct {
 	schema string
 }
 
-// missingExtensionsMessage renders a single remediation covering every source
+// missingExtensionsFinding renders a single finding covering every source
 // extension absent from the target.
-func missingExtensionsMessage(missing []missingExtension) string {
+func missingExtensionsFinding(missing []missingExtension) Finding {
 	names := make([]string, len(missing))
 	stmts := make([]string, len(missing))
 	for i, ext := range missing {
@@ -324,10 +328,12 @@ func missingExtensionsMessage(missing []missingExtension) string {
 	if len(missing) > 1 {
 		noun = "extensions"
 	}
-	return fmt.Sprintf(
-		"%d %s installed on source but missing on the target: %s; run the following on the target before migrating, or the schema will fail to apply: %s",
-		len(missing), noun, strings.Join(names, ", "), strings.Join(stmts, " "),
-	)
+	return Finding{
+		ID:      FindingIDTargetExtensionMissing,
+		Title:   "The target does not have an extension the source has",
+		Detail:  fmt.Sprintf("The source has %d %s the target does not have: %s. Run the following on the target before you migrate, or the schema fails to apply: %s", len(missing), noun, strings.Join(names, ", "), strings.Join(stmts, " ")),
+		Message: fmt.Sprintf("%d %s installed on source but missing on the target: %s; run the following on the target before migrating, or the schema will fail to apply: %s", len(missing), noun, strings.Join(names, ", "), strings.Join(stmts, " ")),
+	}
 }
 
 func typeKindLabel(typtype string) string {

--- a/pkg/stream/preflight/schema_test.go
+++ b/pkg/stream/preflight/schema_test.go
@@ -280,16 +280,16 @@ func TestTypeKindLabel(t *testing.T) {
 	require.Equal(t, "", typeKindLabel("b"))
 }
 
-func TestUnsupportedColumnTypeMessage_BaseTypeOmitsKindNoun(t *testing.T) {
+func TestUnsupportedColumnTypeFinding_BaseTypeOmitsKindNoun(t *testing.T) {
 	t.Parallel()
 
 	// A built-in system type pgx doesn't register (typtype 'b') should read as a
 	// bare type name, not be mislabelled as a "user-defined type".
-	msg := unsupportedColumnTypeMessage(schemaColumnRow{
+	finding := unsupportedColumnTypeFinding(schemaColumnRow{
 		Schema: "public", Table: "t", Column: "relid", TypeName: "regclass", TypeKind: "b",
 	})
-	require.Contains(t, msg, `"public"."t"."relid": type "regclass"`)
-	require.NotContains(t, msg, "user-defined type")
+	require.Contains(t, finding.Message, `"public"."t"."relid": type "regclass"`)
+	require.NotContains(t, finding.Message, "user-defined type")
 }
 
 func TestPostgresRangeTypeCheck_Run_SupportedRangesPass(t *testing.T) {
@@ -359,17 +359,28 @@ func TestPostgresRangeTypeCheck_Name(t *testing.T) {
 	require.Equal(t, "postgres_range_type_support", (&PostgresRangeTypeCheck{}).Name())
 }
 
-func TestUnsupportedRangeTypeMessage(t *testing.T) {
+func TestUnsupportedRangeTypeFinding(t *testing.T) {
 	t.Parallel()
 
 	// non-range types and supported ranges produce nothing
-	require.Empty(t, unsupportedRangeTypeMessage(schemaColumnRow{TypeName: "text", TypeKind: "b"}))
-	require.Empty(t, unsupportedRangeTypeMessage(schemaColumnRow{TypeName: "int4range", TypeKind: "r"}))
-	require.Empty(t, unsupportedRangeTypeMessage(schemaColumnRow{TypeName: "tstzrange", TypeKind: "r"}))
+	for _, row := range []schemaColumnRow{
+		{TypeName: "text", TypeKind: "b"},
+		{TypeName: "int4range", TypeKind: "r"},
+		{TypeName: "tstzrange", TypeKind: "r"},
+	} {
+		_, found := unsupportedRangeTypeFinding(row)
+		require.False(t, found)
+	}
 
 	// unsupported range/multirange types produce a finding
-	require.NotEmpty(t, unsupportedRangeTypeMessage(schemaColumnRow{TypeName: "numrange", TypeKind: "r"}))
-	require.NotEmpty(t, unsupportedRangeTypeMessage(schemaColumnRow{TypeName: "tstzmultirange", TypeKind: "m"}))
+	for _, row := range []schemaColumnRow{
+		{TypeName: "numrange", TypeKind: "r"},
+		{TypeName: "tstzmultirange", TypeKind: "m"},
+	} {
+		finding, found := unsupportedRangeTypeFinding(row)
+		require.True(t, found)
+		require.NotEmpty(t, finding.Message)
+	}
 }
 
 func TestSchemaExtensionCompatibilityCheck_Run_AllPresentOnTarget(t *testing.T) {

--- a/pkg/stream/preflight/snapshot_source_instance.go
+++ b/pkg/stream/preflight/snapshot_source_instance.go
@@ -30,14 +30,12 @@ func (c *SourceSnapshotInstanceCheck) Name() string {
 func (c *SourceSnapshotInstanceCheck) Run(ctx context.Context) ([]Finding, error) {
 	missing, err := c.Probe(ctx, c.Probes)
 	if missing > 0 {
-		return []Finding{{Message: fmt.Sprintf(
-			"source appears to be load-balanced across multiple Postgres instances: an exported "+
-				"snapshot was not visible on %d of %d probe connections. Parallel data snapshotting "+
-				"requires every connection to reach the same instance — point the source at a "+
-				"single-instance / writer endpoint (Aurora/RDS reader endpoints and instance-spanning "+
-				"poolers are unsupported for snapshots).",
-			missing, c.Probes,
-		)}}, nil
+		return []Finding{{
+			ID:      FindingIDSourceMultipleInstances,
+			Title:   "The source is load-balanced across multiple Postgres instances",
+			Detail:  fmt.Sprintf("An exported snapshot is not visible on %d of %d probe connections. "+"Parallel data snapshotting requires every connection to reach the same instance. "+"Point the source at a single-instance or writer endpoint. "+"Snapshots do not support Aurora/RDS reader endpoints or instance-spanning poolers.", missing, c.Probes),
+			Message: fmt.Sprintf("source appears to be load-balanced across multiple Postgres instances: an exported "+"snapshot was not visible on %d of %d probe connections. Parallel data snapshotting "+"requires every connection to reach the same instance — point the source at a "+"single-instance / writer endpoint (Aurora/RDS reader endpoints and instance-spanning "+"poolers are unsupported for snapshots).", missing, c.Probes),
+		}}, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("running snapshot instance probe: %w", err)

--- a/pkg/stream/preflight/version.go
+++ b/pkg/stream/preflight/version.go
@@ -79,6 +79,9 @@ func (c *PostgresVersionCheck) Run(ctx context.Context) ([]Finding, error) {
 
 	if c.targetVersion.major() < c.sourceVersion.major() {
 		return []Finding{{
+			ID:     FindingIDTargetVersionOlderThanSource,
+			Title:  "The target runs an older PostgreSQL major version than the source",
+			Detail: fmt.Sprintf("The source runs PostgreSQL %s and the target runs PostgreSQL %s. A restore of a dump from a newer server into an older one is unsupported and can fail. Use a target that runs PostgreSQL %d or newer.", c.sourceVersion, c.targetVersion, c.sourceVersion.major()),
 			Message: fmt.Sprintf(
 				"source is PostgreSQL %s, target is PostgreSQL %s; restoring a dump from a newer server into an older one is unsupported and may fail. Use a target running PostgreSQL %d or newer.",
 				c.sourceVersion, c.targetVersion, c.sourceVersion.major(),


### PR DESCRIPTION
#### Description

`preflight.Finding` carries one field, `Message`. That is enough for the CLI, which prints the message. It is not enough for a machine consumer.

Two problems show up when using it as a lib:

- A finding cannot be counted. The only identity a finding has is its message text, and messages carry the user's data.
- A finding cannot be rendered structurally.

This PR adds three fields to `Finding`:

```golang
type Finding struct {
      ID      string `json:"id"`      // a stable slug naming the kind of problem
      Title   string `json:"title"`   // one short line naming the problem
      Detail  string `json:"detail"`  // the specifics: the tables, the version, the setting
      Message string `json:"message"` // the line the CLI prints, unchanged
}
```

`Message` keeps its exact current text at every construction site, so the human output of pgstream check does not change. The JSON report got new fields.

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Add `ID`, `Title` and `Detail` to `Finding`, and to the `checkResultJSON`

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
