### PR TITLE
Stop retrying data exceptions and name the column

### DIFF
--- a/internal/postgres/errors.go
+++ b/internal/postgres/errors.go
@@ -225,7 +225,7 @@ func MapError(err error) error {
 		// Class 22 — Data Exception
 		if strings.HasPrefix(pgErr.Code, "22") {
 			return &ErrDataException{
-				Details: pgErr.Message,
+				Details: withErrorContext(pgErr),
 			}
 		}
 		// Class 23 — Integrity Constraint Violation
@@ -254,6 +254,13 @@ func MapError(err error) error {
 	}
 
 	return err
+}
+
+func withErrorContext(pgErr *pgconn.PgError) string {
+	if pgErr.Where == "" {
+		return pgErr.Message
+	}
+	return fmt.Sprintf("%s (%s)", pgErr.Message, pgErr.Where)
 }
 
 func encodingErrDetails(msg string) string {

--- a/internal/postgres/errors_test.go
+++ b/internal/postgres/errors_test.go
@@ -29,6 +29,48 @@ func TestMapError_realPgxEncodeError(t *testing.T) {
 		"pgx encoding failures must map to ErrValueEncoding so the batch writer drops only the failing query")
 }
 
+// TestMapError_dataExceptionKeepsContext pins the postgres CONTEXT line to the
+// mapped error. During COPY the message names only the type that rejected the
+// value, so without the context a length overflow on one column reads as if
+// every column of that type were at fault, see issue #1170.
+func TestMapError_dataExceptionKeepsContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		err         *pgconn.PgError
+		wantDetails string
+	}{
+		{
+			name: "with context",
+			err: &pgconn.PgError{
+				Code:    "22001",
+				Message: "value too long for type character varying(50)",
+				Where:   "COPY ledger_line, line 1, column code",
+			},
+			wantDetails: "value too long for type character varying(50) (COPY ledger_line, line 1, column code)",
+		},
+		{
+			name: "without context",
+			err: &pgconn.PgError{
+				Code:    "22001",
+				Message: "value too long for type character varying(50)",
+			},
+			wantDetails: "value too long for type character varying(50)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var errDataException *ErrDataException
+			require.ErrorAs(t, MapError(tt.err), &errDataException)
+			require.Equal(t, tt.wantDetails, errDataException.Details)
+		})
+	}
+}
+
 func TestMapError(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/postgres/retrier/pg_querier_retrier.go
+++ b/internal/postgres/retrier/pg_querier_retrier.go
@@ -163,6 +163,7 @@ func (q *Querier) isRetriableError(err error) bool {
 	programLimitExceeded := &postgres.ErrProgramLimitExceeded{}
 	featureNotSupported := &postgres.ErrFeatureNotSupported{}
 	valueEncoding := &postgres.ErrValueEncoding{}
+	dataException := &postgres.ErrDataException{}
 	switch {
 	case errors.As(mappedErr, &permissionDenied),
 		errors.As(mappedErr, &constraintViolation),
@@ -172,7 +173,8 @@ func (q *Querier) isRetriableError(err error) bool {
 		errors.As(mappedErr, &doesNotExist),
 		errors.As(mappedErr, &programLimitExceeded),
 		errors.As(mappedErr, &featureNotSupported),
-		errors.As(mappedErr, &valueEncoding):
+		errors.As(mappedErr, &valueEncoding),
+		errors.As(mappedErr, &dataException):
 		return false
 	}
 

--- a/internal/postgres/retrier/pg_querier_retrier_test.go
+++ b/internal/postgres/retrier/pg_querier_retrier_test.go
@@ -564,6 +564,24 @@ func TestQuerier_isRetriableError(t *testing.T) {
 			wantIsRetriable: false,
 		},
 		{
+			// a value the target column cannot store fails the same way every
+			// time it is replayed. The default policy has no attempt or
+			// elapsed-time bound, so retrying here loops until the process is
+			// killed instead of reporting which column rejected the value.
+			name: "string too long for the target column",
+			err: &pgconn.PgError{
+				Code:    "22001",
+				Message: "value too long for type character varying(50)",
+				Where:   "COPY ledger_line, line 1, column code",
+			},
+			wantIsRetriable: false,
+		},
+		{
+			name:            "wrapped data exception",
+			err:             fmt.Errorf("copy from: %w", &postgres.ErrDataException{}),
+			wantIsRetriable: false,
+		},
+		{
 			// isRetriableError maps through MapError, so a raw pgx encoding
 			// failure must be recognized even before anything types it. The
 			// default policy has no attempt or elapsed-time bound, so treating


### PR DESCRIPTION
#### Description

A snapshot with transformation rules stalls forever instead of failing. The bulk ingest writer logs the following line:

```
data exception: value too long for type character varying(50)
```

This line is logged repeatedly with a growing retry delay, and the run never completes and never errors out. Because the message names only the *type*, the failure reads as if a `TEXT` column were being limited to 50 characters.

Two issues:

- The error could not be attributed to a column. Postgres sends the problematic table and column in the `CONTEXT` line (`COPY ledger_line, line 1, column code`), exposed by pgconn as `PgError.Where`. `MapError` kept only `PgError.Message` and dropped it.
- The error was retried forever. `isRetriableError` did not list `ErrDataException` among the permanent errors. A class 22 error is raised by the row values themselves and fails identically on every replay. However, the default retry policy has no attempt or elapsed-time bound, so the copy looped until the process was killed.

##### Related Issue(s)

- Fixes #1170

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- `internal/postgres/errors.go`:new `withErrorContext` helper appends the Postgres `CONTEXT` line to `ErrDataException.Details` when the server sends one
- `internal/postgres/retrier/pg_querier_retrier.go`: `ErrDataException` added to the non-retryable set

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
