### PR TITLE
Add context to transformer validation errors

### DIFF
--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
@@ -148,7 +148,7 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 			// build the transformer
 			transformer, err := v.builder.New(cfg)
 			if err != nil {
-				return nil, err
+				return nil, columnRuleError(table.Schema, table.Table, colName, err)
 			}
 
 			// get the data type so that we can later validate if it's compatible with the configured transformer
@@ -166,7 +166,7 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 			}
 
 			if err := validateNumericRange(cfg, colType); err != nil {
-				return nil, fmt.Errorf("column '%s' in table %q.%q: %w", colName, table.Schema, table.Table, err)
+				return nil, columnRuleError(table.Schema, table.Table, colName, err)
 			}
 
 			// add the transformer to the map
@@ -309,10 +309,13 @@ func (v *PostgresTransformerParser) getFieldDescriptions(ctx context.Context, sc
 	query := fmt.Sprintf(fieldDescriptionsQuery, pglib.QuoteQualifiedIdentifier(schema, table))
 	rows, err := v.conn.Query(ctx, query)
 	if err != nil {
-		return nil, fmt.Errorf("querying table rows: %w", err)
+		return nil, fmt.Errorf("querying columns for table %q.%q: %w", schema, table, err)
 	}
 	defer rows.Close()
-	return rows.FieldDescriptions(), rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading columns for table %q.%q: %w", schema, table, err)
+	}
+	return rows.FieldDescriptions(), nil
 }
 
 func (v *PostgresTransformerParser) getAllSchemaTables(ctx context.Context, schema string) ([]string, error) {

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
@@ -111,7 +111,7 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 	}
 	var uniquenessErrs []string
 	transformerMap := NewTransformerMap()
-	for _, table := range rules.Transformers {
+	for tableIdx, table := range rules.Transformers {
 		fieldDescriptions, err := v.getFieldDescriptions(context.Background(), table.Schema, table.Table)
 		if err != nil {
 			return nil, err
@@ -123,7 +123,7 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 			if _, found := table.ColumnRules[string(desc.Name)]; !found {
 				// column is not configured in rules, error out if strict validation mode is enabled
 				if table.ValidationMode == validationModeStrict {
-					return nil, fmt.Errorf("column %s of table %q.%q has no transformer configured", desc.Name, table.Schema, table.Table)
+					return nil, fmt.Errorf("%s: column %s of table %q.%q has no transformer configured", tableRulePosition(tableIdx), desc.Name, table.Schema, table.Table)
 				}
 				continue
 			}
@@ -148,25 +148,25 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 			// build the transformer
 			transformer, err := v.builder.New(cfg)
 			if err != nil {
-				return nil, columnRuleError(table.Schema, table.Table, colName, err)
+				return nil, columnRuleError(tableIdx, table.Schema, table.Table, colName, err)
 			}
 
 			// get the data type so that we can later validate if it's compatible with the configured transformer
 			colType, found := mappedColumnTypes[colName]
 			if !found {
 				// validate that the column in the rules is present in the table
-				return nil, fmt.Errorf("column %s not found in table %q.%q", colName, table.Schema, table.Table)
+				return nil, fmt.Errorf("%s: column %s not found in table %q.%q", tableRulePosition(tableIdx), colName, table.Schema, table.Table)
 			}
 
 			dataTypeName, err := v.pgtypeMap.TypeForOID(ctx, colType.oid)
 
 			// validate that the transformer is compatible with the column type
 			if err != nil || !pgTypeCompatibleWithTransformerType(transformer.CompatibleTypes(), colType.oid, dataTypeName) {
-				return nil, fmt.Errorf("transformer '%s' specified for column '%s' in table %q.%q does not support pg data type: %s with OID: %d", transformer.Type(), colName, table.Schema, table.Table, dataTypeName, colType.oid)
+				return nil, fmt.Errorf("%s: transformer '%s' specified for column '%s' in table %q.%q does not support pg data type: %s with OID: %d", tableRulePosition(tableIdx), transformer.Type(), colName, table.Schema, table.Table, dataTypeName, colType.oid)
 			}
 
 			if err := validateNumericRange(cfg, colType); err != nil {
-				return nil, columnRuleError(table.Schema, table.Table, colName, err)
+				return nil, columnRuleError(tableIdx, table.Schema, table.Table, colName, err)
 			}
 
 			// add the transformer to the map

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
@@ -284,7 +284,7 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 			},
 			validator: testPGValidator,
 
-			wantErr: fmt.Errorf("column id of table %s has no transformer configured", testSchemaTable),
+			wantErr: fmt.Errorf("table_transformers[0]: column id of table %s has no transformer configured", testSchemaTable),
 		},
 		{
 			name: "error - invalid column type",
@@ -304,7 +304,7 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 				},
 			},
 			validator: testPGValidator,
-			wantErr:   errors.New("transformer 'string' specified for column 'id' in table \"public\".\"test\" does not support pg data type: int8 with OID: 20"),
+			wantErr:   errors.New("table_transformers[0]: transformer 'string' specified for column 'id' in table \"public\".\"test\" does not support pg data type: int8 with OID: 20"),
 		},
 		{
 			name: "error - unknown custom column type",
@@ -326,7 +326,7 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 				pgtypeMap:      pglib.NewMapper(testQuerierWithUnknownTypeErr),
 				requiredTables: []string{"public.test"},
 			},
-			wantErr: errors.New("transformer 'neosync_email' specified for column 'email' in table \"public\".\"test\" does not support pg data type: unknown with OID: 1234"),
+			wantErr: errors.New("table_transformers[0]: transformer 'neosync_email' specified for column 'email' in table \"public\".\"test\" does not support pg data type: unknown with OID: 1234"),
 		},
 		{
 			name: "error - column not found in table",
@@ -346,7 +346,7 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 				},
 			},
 			validator: testPGValidator,
-			wantErr:   fmt.Errorf("column %s not found in table %s", "unknown_column", testSchemaTable),
+			wantErr:   fmt.Errorf("table_transformers[0]: column %s not found in table %s", "unknown_column", testSchemaTable),
 		},
 		{
 			name: "error - required table not present in rules",
@@ -474,7 +474,7 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 			if tc.wantErr != nil || tc.wantErrContains != "" {
 				require.Error(t, err)
 				if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
-					require.Equal(t, err.Error(), tc.wantErr.Error())
+					require.Equal(t, tc.wantErr.Error(), err.Error())
 				}
 				if tc.wantErrContains != "" {
 					require.ErrorContains(t, err, tc.wantErrContains)

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
@@ -124,6 +124,7 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 		validator        PostgresTransformerParser
 
 		wantErr                   error
+		wantErrContains           string
 		wantActiveTransformersFor []string
 		wantNoopTransformersFor   []string
 	}{
@@ -414,16 +415,69 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 			},
 			wantErr: fmt.Errorf("getting required tables list: wildcard schema must be used with wildcard table, got: \"test\""),
 		},
+		{
+			name: "error - transformer fails to build",
+			transformerRules: []TableRules{
+				{
+					Schema: publicSchema,
+					Table:  "test",
+					ColumnRules: map[string]TransformerRules{
+						"name": {
+							Name:       string(transformers.Template),
+							Parameters: map[string]any{"template": `{{ literal_string "x" }}`},
+						},
+					},
+				},
+			},
+			validator:       testPGValidator,
+			wantErrContains: `column 'name' in table "public"."test": template_transformer: error parsing template`,
+		},
+		{
+			name: "error - unsupported transformer",
+			transformerRules: []TableRules{
+				{
+					Schema: publicSchema,
+					Table:  "test",
+					ColumnRules: map[string]TransformerRules{
+						"name": {Name: "not_a_transformer"},
+					},
+				},
+			},
+			validator:       testPGValidator,
+			wantErr:         transformers.ErrUnsupportedTransformer,
+			wantErrContains: `column 'name' in table "public"."test": unsupported transformer config`,
+		},
+		{
+			name: "error - table columns cannot be queried",
+			transformerRules: []TableRules{
+				{
+					Schema: publicSchema,
+					Table:  "missing",
+					ColumnRules: map[string]TransformerRules{
+						"name": {Name: "string"},
+					},
+				},
+			},
+			validator: PostgresTransformerParser{
+				conn:      testQuerier(),
+				builder:   builder.NewTransformerBuilder(),
+				pgtypeMap: pglib.NewMapper(testQuerier()),
+			},
+			wantErrContains: `querying columns for table "public"."missing"`,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			transformerMap, err := tc.validator.ParseAndValidate(context.Background(), Rules{Transformers: tc.transformerRules, ValidationMode: validationModeStrict})
-			if tc.wantErr != nil {
+			if tc.wantErr != nil || tc.wantErrContains != "" {
 				require.Error(t, err)
-				if !errors.Is(err, tc.wantErr) {
+				if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
 					require.Equal(t, err.Error(), tc.wantErr.Error())
+				}
+				if tc.wantErrContains != "" {
+					require.ErrorContains(t, err, tc.wantErrContains)
 				}
 				return
 			}

--- a/pkg/wal/processor/transformer/wal_transformer_parser.go
+++ b/pkg/wal/processor/transformer/wal_transformer_parser.go
@@ -4,6 +4,7 @@ package transformer
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/xataio/pgstream/pkg/transformers"
 )
@@ -34,12 +35,18 @@ func (p *transformerParser) parse(_ context.Context, rules Rules) (*TransformerM
 
 			transformer, err := p.builder.New(cfg)
 			if err != nil {
-				return nil, err
+				return nil, columnRuleError(table.Schema, table.Table, colName, err)
 			}
 			transformerMap.AddActiveTransformer(table.Schema, table.Table, colName, transformer)
 		}
 	}
 	return transformerMap, nil
+}
+
+// columnRuleError attributes err to the column rule that produced it, using the
+// phrasing every check in the rule parsers shares.
+func columnRuleError(schema, table, column string, err error) error {
+	return fmt.Errorf("column '%s' in table %q.%q: %w", column, schema, table, err)
 }
 
 func transformerRulesToConfig(rules TransformerRules) *transformers.Config {

--- a/pkg/wal/processor/transformer/wal_transformer_parser.go
+++ b/pkg/wal/processor/transformer/wal_transformer_parser.go
@@ -21,7 +21,7 @@ func newTransformerParser(b transformerBuilder) *transformerParser {
 
 func (p *transformerParser) parse(_ context.Context, rules Rules) (*TransformerMap, error) {
 	transformerMap := NewTransformerMap()
-	for _, table := range rules.Transformers {
+	for tableIdx, table := range rules.Transformers {
 		if table.ValidationMode == validationModeStrict {
 			return nil, errValidatorRequiredForStrictMode
 		}
@@ -35,7 +35,7 @@ func (p *transformerParser) parse(_ context.Context, rules Rules) (*TransformerM
 
 			transformer, err := p.builder.New(cfg)
 			if err != nil {
-				return nil, columnRuleError(table.Schema, table.Table, colName, err)
+				return nil, columnRuleError(tableIdx, table.Schema, table.Table, colName, err)
 			}
 			transformerMap.AddActiveTransformer(table.Schema, table.Table, colName, transformer)
 		}
@@ -45,8 +45,16 @@ func (p *transformerParser) parse(_ context.Context, rules Rules) (*TransformerM
 
 // columnRuleError attributes err to the column rule that produced it, using the
 // phrasing every check in the rule parsers shares.
-func columnRuleError(schema, table, column string, err error) error {
-	return fmt.Errorf("column '%s' in table %q.%q: %w", column, schema, table, err)
+func columnRuleError(tableIdx int, schema, table, column string, err error) error {
+	return fmt.Errorf("%s: column '%s' in table %q.%q: %w", tableRulePosition(tableIdx), column, schema, table, err)
+}
+
+// tableRulePosition names the entry of the table_transformers list that a rule
+// belongs to. The list is a slice all the way from the config file, so the
+// index matches the position the user wrote, and reads back as a yq path:
+// yq '.transformations.table_transformers[2]' config.yaml
+func tableRulePosition(tableIdx int) string {
+	return fmt.Sprintf("table_transformers[%d]", tableIdx)
 }
 
 func transformerRulesToConfig(rules TransformerRules) *transformers.Config {

--- a/pkg/wal/processor/transformer/wal_transformer_parser_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_parser_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/xataio/pgstream/pkg/transformers"
+	"github.com/xataio/pgstream/pkg/transformers/builder"
 	transformermocks "github.com/xataio/pgstream/pkg/transformers/mocks"
 )
 
@@ -35,6 +36,7 @@ func TestTransformerParser_parse(t *testing.T) {
 
 		wantTransformerMap *TransformerMap
 		wantErr            error
+		wantErrMsg         string
 	}{
 		{
 			name: "ok",
@@ -87,6 +89,7 @@ func TestTransformerParser_parse(t *testing.T) {
 
 			wantTransformerMap: nil,
 			wantErr:            transformers.ErrUnsupportedTransformer,
+			wantErrMsg:         `column 'column_1' in table "test_schema"."test_table": unsupported transformer config`,
 		},
 	}
 
@@ -98,7 +101,33 @@ func TestTransformerParser_parse(t *testing.T) {
 
 			transformerMap, err := tp.parse(context.Background(), Rules{Transformers: tc.rules})
 			require.ErrorIs(t, err, tc.wantErr)
+			if tc.wantErrMsg != "" {
+				require.EqualError(t, err, tc.wantErrMsg)
+			}
 			require.Equal(t, tc.wantTransformerMap, transformerMap)
 		})
 	}
+}
+
+func TestTransformerParser_parse_transformerBuildErrorContext(t *testing.T) {
+	t.Parallel()
+
+	rules := Rules{
+		Transformers: []TableRules{
+			{
+				Schema: "test_schema",
+				Table:  "test_table",
+				ColumnRules: map[string]TransformerRules{
+					"name": {
+						Name:       string(transformers.Template),
+						Parameters: map[string]any{"template": `{{ literal_string "x" }}`},
+					},
+				},
+			},
+		},
+	}
+
+	tp := newTransformerParser(builder.NewTransformerBuilder())
+	_, err := tp.parse(context.Background(), rules)
+	require.ErrorContains(t, err, `column 'name' in table "test_schema"."test_table": template_transformer: error parsing template`)
 }

--- a/pkg/wal/processor/transformer/wal_transformer_parser_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_parser_test.go
@@ -89,7 +89,43 @@ func TestTransformerParser_parse(t *testing.T) {
 
 			wantTransformerMap: nil,
 			wantErr:            transformers.ErrUnsupportedTransformer,
-			wantErrMsg:         `column 'column_1' in table "test_schema"."test_table": unsupported transformer config`,
+			wantErrMsg:         `table_transformers[0]: column 'column_1' in table "test_schema"."test_table": unsupported transformer config`,
+		},
+		{
+			name: "error - invalid transformer rules in a later table entry",
+			rules: []TableRules{
+				{
+					Schema: testSchema,
+					Table:  testTable,
+					ColumnRules: map[string]TransformerRules{
+						"column_1": {
+							Name: "string",
+						},
+					},
+				},
+				{
+					Schema: testSchema,
+					Table:  "other_table",
+					ColumnRules: map[string]TransformerRules{
+						"column_1": {
+							Name: "string",
+						},
+					},
+				},
+				{
+					Schema: testSchema,
+					Table:  "broken_table",
+					ColumnRules: map[string]TransformerRules{
+						"column_1": {
+							Name: "invalid",
+						},
+					},
+				},
+			},
+
+			wantTransformerMap: nil,
+			wantErr:            transformers.ErrUnsupportedTransformer,
+			wantErrMsg:         `table_transformers[2]: column 'column_1' in table "test_schema"."broken_table": unsupported transformer config`,
 		},
 	}
 


### PR DESCRIPTION
#### Description

Previously, `pgstream validate rules` reported a failing transformer without saying which rule produced it.

#### Example transformer config

```yaml
transformations:
  validation_mode: relaxed
  table_transformers:
    - schema: public
      table: users
      column_transformers:
        first_name:
          name: greenmask_firstname
        email:
          name: neosync_email
          parameters:
            preserve_domain: true

    - schema: public
      table: orders
      column_transformers:
        customer_ref:
          name: greenmask_string
          parameters:
            min_length: 8
            max_length: 8

    - schema: public
      table: test
      column_transformers:
        name:
          name: template
          parameters:
            template: '{{ literal_string "redacted" }}'
```

The failing rule is `table_transformers[2]`, column `name`.

**Before**

```
% pgstream validate rules --log-level debug -c pgstream.config.yml
using config file: pgstream.config.yml
WARNING  pgstream validation check identified issues: template_transformer: error parsing template: template: :5: function "literal_string" not defined
Transformation rules status:
 - Valid: false
 - Errors: [template_transformer: error parsing template: template: :5: function "literal_string" not defined]
 ```

**After**

```
% pgstream validate rules --log-level debug -c pgstream.config.yml
using config file: pgstream.config.yml
 WARNING  pgstream validation check identified issues: table_transformers[2]: column 'name' in table "public"."test": template_transformer: error parsing template: template: :5: function "literal_string" not defined
Transformation rules status:
 - Valid: false
 - Errors: [table_transformers[2]: column 'name' in table "public"."test": template_transformer: error parsing template: template: :5: function "literal_string" not defined]
```

##### Related Issue(s)

- Fixes #1164

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
