### PR TITLE
Add an array transformer that maps over array elements

### DIFF
--- a/pkg/transformers/array_transformer.go
+++ b/pkg/transformers/array_transformer.go
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// ArrayGenerator selects how the elements of the transformed array are drawn
+// from the elements of the source array.
+type ArrayGenerator string
+
+const (
+	// ArrayGeneratorMap transforms every source element in order, preserving
+	// the length of the array.
+	ArrayGeneratorMap ArrayGenerator = "map"
+	// ArrayGeneratorRandom emits between MinCount and MaxCount elements, each
+	// the transform of a source element chosen at random with replacement.
+	ArrayGeneratorRandom ArrayGenerator = "random"
+)
+
+// arrayShape records how the value reached the transformer, so that the
+// transformed value is emitted the same way. The replication path carries an
+// array as its postgres literal, the snapshot path as a decoded slice, and
+// the kafka, webhook and search targets serialise whichever they are given.
+type arrayShape int
+
+const (
+	shapeSlice arrayShape = iota
+	shapeString
+	shapeBytes
+)
+
+var (
+	ErrMultiDimensionalArray = errors.New("multi-dimensional arrays are not supported")
+	ErrInvalidArrayOptions   = errors.New("invalid array options")
+)
+
+// ArrayConfig describes an ArrayTransformer.
+type ArrayConfig struct {
+	ElementTransformer Transformer
+	ArrayOID           uint32
+	ElementTypeName    string
+	Column             string
+	Generator          ArrayGenerator
+	MinCount           int
+	MaxCount           int
+}
+
+// ArrayTransformer applies an element transformer to every element of a
+// one-dimensional postgres array.
+type ArrayTransformer struct {
+	inner           Transformer
+	arrayOID        uint32
+	elementTypeName string
+	column          string
+	generator       ArrayGenerator
+	minCount        int
+	maxCount        int
+	pgMap           *pgtype.Map
+	// injected by the tests, which cannot assert on a random draw
+	randIntN func(n int) int
+}
+
+func NewArrayTransformer(cfg ArrayConfig) (*ArrayTransformer, error) {
+	if cfg.ElementTransformer == nil {
+		return nil, fmt.Errorf("%w: no element transformer", ErrInvalidArrayOptions)
+	}
+
+	switch cfg.Generator {
+	case ArrayGeneratorMap:
+		if cfg.MinCount != 0 || cfg.MaxCount != 0 {
+			return nil, fmt.Errorf("%w: min_count and max_count only apply to the %q generator", ErrInvalidArrayOptions, ArrayGeneratorRandom)
+		}
+	case ArrayGeneratorRandom:
+		if cfg.MinCount < 0 || cfg.MaxCount < 0 {
+			return nil, fmt.Errorf("%w: min_count and max_count must not be negative", ErrInvalidArrayOptions)
+		}
+		if cfg.MinCount > cfg.MaxCount {
+			return nil, fmt.Errorf("%w: min_count %d is greater than max_count %d", ErrInvalidArrayOptions, cfg.MinCount, cfg.MaxCount)
+		}
+	default:
+		return nil, fmt.Errorf("%w: unknown generator %q, expected %q or %q", ErrInvalidArrayOptions, cfg.Generator, ArrayGeneratorMap, ArrayGeneratorRandom)
+	}
+
+	return &ArrayTransformer{
+		inner:           cfg.ElementTransformer,
+		arrayOID:        cfg.ArrayOID,
+		elementTypeName: cfg.ElementTypeName,
+		column:          cfg.Column,
+		generator:       cfg.Generator,
+		minCount:        cfg.MinCount,
+		maxCount:        cfg.MaxCount,
+		pgMap:           pgtype.NewMap(),
+		randIntN:        rand.IntN,
+	}, nil
+}
+
+func (t *ArrayTransformer) Transform(ctx context.Context, value Value) (any, error) {
+	elements, shape, err := t.decode(value.TransformValue)
+	if err != nil {
+		return nil, err
+	}
+
+	transformed, err := t.transformElements(ctx, elements, value)
+	if err != nil {
+		return nil, err
+	}
+
+	return t.encode(transformed, shape)
+}
+
+func (t *ArrayTransformer) decode(value any) ([]any, arrayShape, error) {
+	switch v := value.(type) {
+	case []any:
+		return v, shapeSlice, nil
+	case string:
+		elements, err := t.decodeLiteral([]byte(v))
+		return elements, shapeString, err
+	case []byte:
+		elements, err := t.decodeLiteral(v)
+		return elements, shapeBytes, err
+	default:
+		return nil, shapeSlice, fmt.Errorf("column %q: expected an array literal or a slice, got %T: %w", t.column, value, ErrUnsupportedValueType)
+	}
+}
+
+// decodeLiteral scans into pgtype.Array rather than into a slice, because
+// pgtype.Array preserves the dimensions pgx parsed. Scanning into a slice
+// flattens a nested literal into a single dimension and reports no error, so
+// the shape would be lost before the element wise transform sees it.
+func (t *ArrayTransformer) decodeLiteral(literal []byte) ([]any, error) {
+	var array pgtype.Array[any]
+	if err := t.pgMap.PlanScan(t.arrayOID, pgtype.TextFormatCode, &array).Scan(literal, &array); err != nil {
+		return nil, fmt.Errorf("column %q: decoding array literal: %w", t.column, err)
+	}
+	if len(array.Dims) > 1 {
+		return nil, fmt.Errorf("column %q: %w", t.column, ErrMultiDimensionalArray)
+	}
+	return array.Elements, nil
+}
+
+func (t *ArrayTransformer) encode(elements []any, shape arrayShape) (any, error) {
+	if shape == shapeSlice {
+		return elements, nil
+	}
+
+	literal, err := t.pgMap.Encode(t.arrayOID, pgtype.TextFormatCode, elements, nil)
+	if err != nil {
+		return nil, fmt.Errorf("column %q: encoding array literal: %w", t.column, err)
+	}
+	if shape == shapeBytes {
+		return literal, nil
+	}
+	return string(literal), nil
+}
+
+func (t *ArrayTransformer) transformElements(ctx context.Context, elements []any, value Value) ([]any, error) {
+	if t.generator == ArrayGeneratorRandom {
+		return t.resampleElements(ctx, elements, value)
+	}
+
+	transformed := make([]any, len(elements))
+	for i, element := range elements {
+		var err error
+		if transformed[i], err = t.transformElement(ctx, element, value); err != nil {
+			return nil, fmt.Errorf("column %q: element %d: %w", t.column, i, err)
+		}
+	}
+	return transformed, nil
+}
+
+// resampleElements emits a random number of elements, each the transform of a
+// source element chosen at random with replacement. Every invocation is handed
+// a value that was in the row, so the generator never invents one.
+func (t *ArrayTransformer) resampleElements(ctx context.Context, elements []any, value Value) ([]any, error) {
+	if len(elements) == 0 {
+		return []any{}, nil
+	}
+
+	count := t.minCount
+	if t.maxCount > t.minCount {
+		count += t.randIntN(t.maxCount - t.minCount + 1)
+	}
+
+	transformed := make([]any, count)
+	for i := range transformed {
+		var err error
+		if transformed[i], err = t.transformElement(ctx, elements[t.randIntN(len(elements))], value); err != nil {
+			return nil, fmt.Errorf("column %q: element %d: %w", t.column, i, err)
+		}
+	}
+	return transformed, nil
+}
+
+// transformElement keeps a NULL element NULL without calling the element
+// transformer, mirroring how the wal transformer skips a NULL column value. An
+// element transformer that returns nil produces a NULL element in place, so
+// the length of a mapped array is always preserved.
+func (t *ArrayTransformer) transformElement(ctx context.Context, element any, value Value) (any, error) {
+	if element == nil {
+		return nil, nil
+	}
+	return t.inner.Transform(ctx, Value{
+		TransformValue: element,
+		TransformType:  t.elementTypeName,
+		DynamicValues:  value.DynamicValues,
+	})
+}
+
+func (t *ArrayTransformer) CompatibleTypes() []SupportedDataType {
+	return t.inner.CompatibleTypes()
+}
+
+func (t *ArrayTransformer) Type() TransformerType { return t.inner.Type() }
+
+func (t *ArrayTransformer) IsDynamic() bool { return t.inner.IsDynamic() }
+
+// Uniqueness classifies the whole array transform, which is what validation
+// against a unique index needs. Mapping a length preserving, injective element
+// transform over an array is injective, so map inherits the element
+// transformer's classification verbatim.
+func (t *ArrayTransformer) Uniqueness() Uniqueness {
+	if t.generator == ArrayGeneratorRandom {
+		return UniquenessLossy
+	}
+	return UniquenessOf(t.inner)
+}
+
+func (t *ArrayTransformer) Close() error {
+	return t.inner.Close()
+}

--- a/pkg/transformers/array_transformer_test.go
+++ b/pkg/transformers/array_transformer_test.go
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+)
+
+// stubTransformer stands in for an element transformer. The mocks package
+// cannot be used here, since it imports this one.
+type stubTransformer struct {
+	transformFn func(Value) (any, error)
+	uniqueness  Uniqueness
+	dynamic     bool
+	closeErr    error
+}
+
+func (s *stubTransformer) Transform(_ context.Context, value Value) (any, error) {
+	return s.transformFn(value)
+}
+
+func (s *stubTransformer) CompatibleTypes() []SupportedDataType {
+	return []SupportedDataType{StringDataType}
+}
+func (s *stubTransformer) Type() TransformerType  { return TransformerType("stub") }
+func (s *stubTransformer) IsDynamic() bool        { return s.dynamic }
+func (s *stubTransformer) Uniqueness() Uniqueness { return s.uniqueness }
+func (s *stubTransformer) Close() error           { return s.closeErr }
+
+func upperTransformer() *stubTransformer {
+	return &stubTransformer{transformFn: func(value Value) (any, error) {
+		str, ok := value.TransformValue.(string)
+		if !ok {
+			return nil, fmt.Errorf("stub: got %T: %w", value.TransformValue, ErrUnsupportedValueType)
+		}
+		return strings.ToUpper(str), nil
+	}}
+}
+
+func newTestArrayTransformer(t *testing.T, cfg ArrayConfig) *ArrayTransformer {
+	t.Helper()
+	if cfg.Generator == "" {
+		cfg.Generator = ArrayGeneratorMap
+	}
+	if cfg.ArrayOID == 0 {
+		cfg.ArrayOID = pgtype.TextArrayOID
+		cfg.ElementTypeName = "text"
+	}
+	if cfg.Column == "" {
+		cfg.Column = "emails"
+	}
+	transformer, err := NewArrayTransformer(cfg)
+	require.NoError(t, err)
+	return transformer
+}
+
+func TestNewArrayTransformer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     ArrayConfig
+		wantErr error
+	}{
+		{
+			name: "ok - map",
+			cfg:  ArrayConfig{ElementTransformer: upperTransformer(), Generator: ArrayGeneratorMap},
+		},
+		{
+			name: "ok - random",
+			cfg:  ArrayConfig{ElementTransformer: upperTransformer(), Generator: ArrayGeneratorRandom, MinCount: 0, MaxCount: 3},
+		},
+		{
+			name:    "error - counts under map",
+			cfg:     ArrayConfig{ElementTransformer: upperTransformer(), Generator: ArrayGeneratorMap, MaxCount: 3},
+			wantErr: ErrInvalidArrayOptions,
+		},
+		{
+			name:    "error - min greater than max",
+			cfg:     ArrayConfig{ElementTransformer: upperTransformer(), Generator: ArrayGeneratorRandom, MinCount: 4, MaxCount: 3},
+			wantErr: ErrInvalidArrayOptions,
+		},
+		{
+			name:    "error - negative count",
+			cfg:     ArrayConfig{ElementTransformer: upperTransformer(), Generator: ArrayGeneratorRandom, MinCount: -1, MaxCount: 3},
+			wantErr: ErrInvalidArrayOptions,
+		},
+		{
+			name:    "error - unknown generator",
+			cfg:     ArrayConfig{ElementTransformer: upperTransformer(), Generator: ArrayGenerator("shuffle")},
+			wantErr: ErrInvalidArrayOptions,
+		},
+		{
+			name:    "error - no element transformer",
+			cfg:     ArrayConfig{Generator: ArrayGeneratorMap},
+			wantErr: ErrInvalidArrayOptions,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewArrayTransformer(tc.cfg)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestArrayTransformer_Transform_map(t *testing.T) {
+	t.Parallel()
+
+	errTest := errors.New("oh noes")
+
+	tests := []struct {
+		name        string
+		cfg         ArrayConfig
+		value       any
+		wantValue   any
+		wantErr     error
+		wantSeen    []any
+		checkValues bool
+	}{
+		{
+			name:      "literal in, literal out, quoting round trips",
+			cfg:       ArrayConfig{ElementTransformer: upperTransformer()},
+			value:     `{a,"b,c",NULL,"NULL","d\"e","f\\g"}`,
+			wantValue: `{A,"B,C",NULL,"NULL","D\"E","F\\G"}`,
+			// a NULL element is never handed to the element transformer, but
+			// the string "NULL" is
+			wantSeen:    []any{"a", "b,c", "NULL", `d"e`, `f\g`},
+			checkValues: true,
+		},
+		{
+			name:      "slice in, slice out",
+			cfg:       ArrayConfig{ElementTransformer: upperTransformer()},
+			value:     []any{"a", nil, "b"},
+			wantValue: []any{"A", nil, "B"},
+		},
+		{
+			name:      "bytes in, bytes out",
+			cfg:       ArrayConfig{ElementTransformer: upperTransformer()},
+			value:     []byte(`{a,b}`),
+			wantValue: []byte(`{A,B}`),
+		},
+		{
+			name:      "empty array",
+			cfg:       ArrayConfig{ElementTransformer: upperTransformer()},
+			value:     `{}`,
+			wantValue: `{}`,
+		},
+		{
+			name: "int4 elements are decoded to int32 on the literal path",
+			cfg: ArrayConfig{
+				ArrayOID:        pgtype.Int4ArrayOID,
+				ElementTypeName: "int4",
+				ElementTransformer: &stubTransformer{transformFn: func(value Value) (any, error) {
+					i, ok := value.TransformValue.(int32)
+					if !ok {
+						return nil, fmt.Errorf("stub: got %T: %w", value.TransformValue, ErrUnsupportedValueType)
+					}
+					return i * 2, nil
+				}},
+			},
+			value:     `{1,NULL,3}`,
+			wantValue: `{2,NULL,6}`,
+		},
+		{
+			name: "a nil result is a NULL element, and the length is preserved",
+			cfg: ArrayConfig{ElementTransformer: &stubTransformer{transformFn: func(value Value) (any, error) {
+				return nil, nil
+			}}},
+			value:     `{a,b,c}`,
+			wantValue: `{NULL,NULL,NULL}`,
+		},
+		{
+			name: "the first element error is the column error",
+			cfg: ArrayConfig{ElementTransformer: &stubTransformer{transformFn: func(value Value) (any, error) {
+				if value.TransformValue == "b" {
+					return nil, errTest
+				}
+				return value.TransformValue, nil
+			}}},
+			value:   `{a,b,c}`,
+			wantErr: errTest,
+		},
+		{
+			name:    "multi-dimensional literal",
+			cfg:     ArrayConfig{ElementTransformer: upperTransformer()},
+			value:   `{{a,b},{c,d}}`,
+			wantErr: ErrMultiDimensionalArray,
+		},
+		{
+			name:    "unsupported value type",
+			cfg:     ArrayConfig{ElementTransformer: upperTransformer()},
+			value:   42,
+			wantErr: ErrUnsupportedValueType,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var seen []any
+			if tc.checkValues {
+				inner := tc.cfg.ElementTransformer
+				tc.cfg.ElementTransformer = &stubTransformer{transformFn: func(value Value) (any, error) {
+					seen = append(seen, value.TransformValue)
+					return inner.Transform(context.Background(), value)
+				}}
+			}
+
+			transformer := newTestArrayTransformer(t, tc.cfg)
+			got, err := transformer.Transform(context.Background(), NewValue(tc.value, "text[]", nil))
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Contains(t, err.Error(), "emails")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantValue, got)
+			if tc.checkValues {
+				require.Equal(t, tc.wantSeen, seen)
+			}
+		})
+	}
+}
+
+func TestArrayTransformer_Transform_random(t *testing.T) {
+	t.Parallel()
+
+	t.Run("draws the count from the range and resamples the source", func(t *testing.T) {
+		t.Parallel()
+		transformer := newTestArrayTransformer(t, ArrayConfig{
+			ElementTransformer: upperTransformer(),
+			Generator:          ArrayGeneratorRandom,
+			MinCount:           2,
+			MaxCount:           5,
+		})
+		// the first draw picks the count within [0,max-min], the rest pick
+		// source indexes
+		draws := []int{2, 0, 0, 2, 2}
+		transformer.randIntN = func(n int) int {
+			draw := draws[0]
+			draws = draws[1:]
+			require.Less(t, draw, n)
+			return draw
+		}
+
+		got, err := transformer.Transform(context.Background(), NewValue(`{a,b,c}`, "text[]", nil))
+		require.NoError(t, err)
+		require.Equal(t, `{A,A,C,C}`, got)
+		require.Empty(t, draws)
+	})
+
+	t.Run("a NULL element is drawn as NULL without a redraw", func(t *testing.T) {
+		t.Parallel()
+		transformer := newTestArrayTransformer(t, ArrayConfig{
+			ElementTransformer: upperTransformer(),
+			Generator:          ArrayGeneratorRandom,
+			MinCount:           2,
+			MaxCount:           2,
+		})
+		transformer.randIntN = func(n int) int { return 1 }
+
+		got, err := transformer.Transform(context.Background(), NewValue(`{a,NULL}`, "text[]", nil))
+		require.NoError(t, err)
+		require.Equal(t, `{NULL,NULL}`, got)
+	})
+
+	t.Run("an empty source array stays empty", func(t *testing.T) {
+		t.Parallel()
+		transformer := newTestArrayTransformer(t, ArrayConfig{
+			ElementTransformer: &stubTransformer{transformFn: func(Value) (any, error) {
+				t.Fatal("the element transformer must not be called for an empty array")
+				return nil, nil
+			}},
+			Generator: ArrayGeneratorRandom,
+			MinCount:  1,
+			MaxCount:  3,
+		})
+
+		got, err := transformer.Transform(context.Background(), NewValue(`{}`, "text[]", nil))
+		require.NoError(t, err)
+		require.Equal(t, `{}`, got)
+	})
+
+	t.Run("a zero count emits an empty array", func(t *testing.T) {
+		t.Parallel()
+		transformer := newTestArrayTransformer(t, ArrayConfig{
+			ElementTransformer: upperTransformer(),
+			Generator:          ArrayGeneratorRandom,
+			MinCount:           0,
+			MaxCount:           0,
+		})
+
+		got, err := transformer.Transform(context.Background(), NewValue(`{a,b}`, "text[]", nil))
+		require.NoError(t, err)
+		require.Equal(t, `{}`, got)
+	})
+}
+
+func TestArrayTransformer_Uniqueness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		generator ArrayGenerator
+		inner     Uniqueness
+		want      Uniqueness
+	}{
+		{name: "map preserves a preserving element transformer", generator: ArrayGeneratorMap, inner: UniquenessPreserved, want: UniquenessPreserved},
+		{name: "map keeps a lossy element transformer lossy", generator: ArrayGeneratorMap, inner: UniquenessLossy, want: UniquenessLossy},
+		{name: "map resolves an unclassified element transformer", generator: ArrayGeneratorMap, inner: UniquenessUnspecified, want: UniquenessNotGuaranteed},
+		{name: "random is lossy over a preserving element transformer", generator: ArrayGeneratorRandom, inner: UniquenessPreserved, want: UniquenessLossy},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := ArrayConfig{
+				ElementTransformer: &stubTransformer{transformFn: func(Value) (any, error) { return nil, nil }, uniqueness: tc.inner},
+				Generator:          tc.generator,
+			}
+			if tc.generator == ArrayGeneratorRandom {
+				cfg.MaxCount = 3
+			}
+			transformer := newTestArrayTransformer(t, cfg)
+			require.Equal(t, tc.want, UniquenessOf(transformer))
+		})
+	}
+}
+
+func TestArrayTransformer_delegatesToTheElementTransformer(t *testing.T) {
+	t.Parallel()
+
+	errClose := errors.New("oh noes")
+	inner := &stubTransformer{
+		transformFn: func(Value) (any, error) { return nil, nil },
+		dynamic:     true,
+		closeErr:    errClose,
+	}
+	transformer := newTestArrayTransformer(t, ArrayConfig{ElementTransformer: inner})
+
+	require.Equal(t, inner.Type(), transformer.Type())
+	require.Equal(t, inner.CompatibleTypes(), transformer.CompatibleTypes())
+	require.True(t, transformer.IsDynamic())
+	require.ErrorIs(t, transformer.Close(), errClose)
+}
+
+func TestArrayTransformer_sharesDynamicValuesWithEveryElement(t *testing.T) {
+	t.Parallel()
+
+	dynamicValues := map[string]any{"country": "ES"}
+	var seen []map[string]any
+	transformer := newTestArrayTransformer(t, ArrayConfig{
+		ElementTransformer: &stubTransformer{transformFn: func(value Value) (any, error) {
+			seen = append(seen, value.DynamicValues)
+			require.Equal(t, "text", value.TransformType)
+			return value.TransformValue, nil
+		}},
+	})
+
+	_, err := transformer.Transform(context.Background(), NewValue(`{a,b}`, "text[]", dynamicValues))
+	require.NoError(t, err)
+	require.Equal(t, []map[string]any{dynamicValues, dynamicValues}, seen)
+}


### PR DESCRIPTION
#### Description

Adds `ArrayTransformer`, a `Transformer` that wraps another transformer and applies it to every element of a one-dimensional PostgreSQL array.

This is the second PR for array column support. It adds the type and its tests only. So this PR changes no behaviour. The follow-up PR adds the `array_options` configuration surface and wires the wrapper into the transformation rules parser.

##### Related Issue(s)

- Related to #1163

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Add `ArrayTransformer` and `ArrayConfig`, with two generators: `map` applies the transformer to each source element in order and preserves the length; `random` emits between `MinCount` and `MaxCount` elements, each the transform of a source element drawn at random with replacement, so the generator never invents a value that was not in the row.
- Decode and encode through the pgx type map rather than by splitting the literal. An element therefore reaches the transformer as the value of its element type on both paths — an `int4[]` element arrives as `int32`, not `"1"` — a NULL element is distinguishable from the string `"NULL"`, and quoting and escaping stay pgx's concern.
- Emit the same shape that arrived: a literal for a literal, a `[]any` for a `[]any`. The Kafka, webhook and search payloads for an array column are unchanged.

#### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
