### PR TITLE
Apply transformation rules to array columns

### DIFF
--- a/cmd/config/config_yaml.go
+++ b/cmd/config/config_yaml.go
@@ -349,10 +349,20 @@ type TableTransformersConfig struct {
 }
 
 type ColumnTransformersConfig struct {
-	Name                string         `mapstructure:"name" yaml:"name"`
-	Parameters          map[string]any `mapstructure:"parameters" yaml:"parameters"`
-	DynamicParameters   map[string]any `mapstructure:"dynamic_parameters" yaml:"dynamic_parameters"`
-	AllowUniquenessLoss bool           `mapstructure:"allow_uniqueness_loss" yaml:"allow_uniqueness_loss"`
+	Name                string              `mapstructure:"name" yaml:"name"`
+	Parameters          map[string]any      `mapstructure:"parameters" yaml:"parameters"`
+	DynamicParameters   map[string]any      `mapstructure:"dynamic_parameters" yaml:"dynamic_parameters"`
+	AllowUniquenessLoss bool                `mapstructure:"allow_uniqueness_loss" yaml:"allow_uniqueness_loss"`
+	ArrayOptions        *ArrayOptionsConfig `mapstructure:"array_options" yaml:"array_options"`
+}
+
+// ArrayOptionsConfig configures how an array column's elements are produced.
+// The counts are pointers so that a count set to zero is distinguishable from
+// a count left out, which the transformation rules validate differently.
+type ArrayOptionsConfig struct {
+	Generator string `mapstructure:"generator" yaml:"generator"`
+	MinCount  *int   `mapstructure:"min_count" yaml:"min_count"`
+	MaxCount  *int   `mapstructure:"max_count" yaml:"max_count"`
 }
 
 // postgres source modes
@@ -926,6 +936,7 @@ func (c TransformationsConfig) parseTransformationConfig() (*transformer.Config,
 				Parameters:          cr.Parameters,
 				DynamicParameters:   cr.DynamicParameters,
 				AllowUniquenessLoss: cr.AllowUniquenessLoss,
+				ArrayOptions:        cr.ArrayOptions.toTransformerRules(),
 			}
 		}
 		rules = append(rules, transformer.TableRules{
@@ -1056,4 +1067,15 @@ func (bc *BatchConfig) parseBatchConfig() batch.Config {
 	}
 
 	return cfg
+}
+
+func (c *ArrayOptionsConfig) toTransformerRules() *transformer.ArrayOptions {
+	if c == nil {
+		return nil
+	}
+	return &transformer.ArrayOptions{
+		Generator: c.Generator,
+		MinCount:  c.MinCount,
+		MaxCount:  c.MaxCount,
+	}
 }

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
@@ -61,6 +61,10 @@ const (
 	publicSchema        = "public"
 	wildcard            = "*"
 	numericTypmodOffset = 4
+	// extension types the compatibility switch resolves by name, since their
+	// OIDs are assigned per database
+	citextTypeName = "citext"
+	hstoreTypeName = "hstore"
 )
 
 var (
@@ -76,6 +80,14 @@ var (
 type columnType struct {
 	oid      uint32
 	modifier int32
+}
+
+// resolvedType is the scalar type a column's values carry: the column's own
+// type, or, when the column is an array, the type its elements carry.
+type resolvedType struct {
+	columnType
+	name    string
+	isArray bool
 }
 
 func NewPostgresTransformerParser(ctx context.Context, pgURL string, builder transformerBuilder, requiredTables []string, opts ...ParserOption) (*PostgresTransformerParser, error) {
@@ -158,14 +170,23 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 				return nil, fmt.Errorf("%s: column %s not found in table %q.%q", tableRulePosition(tableIdx), colName, table.Schema, table.Table)
 			}
 
-			dataTypeName, err := v.pgtypeMap.TypeForOID(ctx, colType.oid)
+			dataTypeName, nameErr := v.pgtypeMap.TypeForOID(ctx, colType.oid)
+			resolved, err := v.resolveColumnType(ctx, colType)
 
 			// validate that the transformer is compatible with the column type
-			if err != nil || !pgTypeCompatibleWithTransformerType(transformer.CompatibleTypes(), colType.oid, dataTypeName) {
+			if nameErr != nil || err != nil || !pgTypeCompatibleWithTransformerType(transformer.CompatibleTypes(), resolved.oid, resolved.name) {
 				return nil, fmt.Errorf("%s: transformer '%s' specified for column '%s' in table %q.%q does not support pg data type: %s with OID: %d", tableRulePosition(tableIdx), transformer.Type(), colName, table.Schema, table.Table, dataTypeName, colType.oid)
 			}
 
-			if err := validateNumericRange(cfg, colType); err != nil {
+			if err := validateNumericRange(cfg, resolved.columnType); err != nil {
+				return nil, columnRuleError(tableIdx, table.Schema, table.Table, colName, err)
+			}
+
+			// an array column holds the wrapper rather than the transformer
+			// the rule names, so that uniqueness validation and the transform
+			// itself both see the whole array transform
+			transformer, err = wrapArrayTransformer(transformer, transformerRules.ArrayOptions, colName, colType.oid, resolved)
+			if err != nil {
 				return nil, columnRuleError(tableIdx, table.Schema, table.Table, colName, err)
 			}
 
@@ -193,6 +214,43 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 	}
 
 	return transformerMap, nil
+}
+
+func (v *PostgresTransformerParser) resolveColumnType(ctx context.Context, colType columnType) (resolvedType, error) {
+	name, err := v.pgtypeMap.TypeForOID(ctx, colType.oid)
+	if err != nil {
+		return resolvedType{columnType: colType, name: name}, err
+	}
+
+	element, err := v.pgtypeMap.ElementTypeForOID(ctx, colType.oid)
+	if err != nil || element == nil {
+		return resolvedType{columnType: colType, name: name}, err
+	}
+
+	// postgres records the precision of a numeric(10,2)[] column where it
+	// records a numeric(10,2) column's, so the modifier follows the element
+	resolved, err := v.resolveColumnType(ctx, columnType{oid: element.OID, modifier: colType.modifier})
+	resolved.isArray = true
+	return resolved, err
+}
+
+func wrapArrayTransformer(t transformers.Transformer, opts *ArrayOptions, colName string, arrayOID uint32, resolved resolvedType) (transformers.Transformer, error) {
+	if !resolved.isArray {
+		if opts != nil {
+			return nil, errArrayOptionsOnScalarColumn
+		}
+		return t, nil
+	}
+
+	cfg, err := opts.toArrayConfig()
+	if err != nil {
+		return nil, err
+	}
+	cfg.ElementTransformer = t
+	cfg.ArrayOID = arrayOID
+	cfg.ElementTypeName = resolved.name
+	cfg.Column = colName
+	return transformers.NewArrayTransformer(cfg)
 }
 
 func allowUniquenessLossColumns(table TableRules) map[string]bool {
@@ -409,9 +467,9 @@ func pgTypeCompatibleWithTransformerType(compatibleTypes []transformers.Supporte
 	default:
 		// handle extension/custom supported types
 		switch pgTypeName {
-		case "citext":
+		case citextTypeName:
 			return slices.Contains(compatibleTypes, transformers.CitextDataType)
-		case "hstore":
+		case hstoreTypeName:
 			return slices.Contains(compatibleTypes, transformers.HstoreDataType)
 		default:
 			return false

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
@@ -23,7 +23,6 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 	t.Parallel()
 
 	citextOID := uint32(1234)
-	citextTypeName := "citext"
 	testSchemaTable := "\"public\".\"test\""
 	testQuerier := func() *pgmocks.Querier {
 		return &pgmocks.Querier{
@@ -87,6 +86,11 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 				}
 			},
 			QueryRowFn: func(ctx context.Context, dest []any, query string, args ...any) error {
+				// the element type query only matches a true array type, and
+				// the fake OIDs in this test are all scalar
+				if strings.Contains(query, "a.typcategory = 'A'") {
+					return pglib.ErrNoRows
+				}
 				switch query {
 				case "SELECT typname FROM pg_type WHERE oid = $1":
 					require.Equal(t, 1, len(args))
@@ -919,6 +923,258 @@ func TestPostgresTransformerParser_connectionInjection(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.Equal(t, tc.wantPostgresURL, gotURL)
+		})
+	}
+}
+
+func TestPostgresTransformerParser_ParseAndValidate_arrayColumns(t *testing.T) {
+	t.Parallel()
+
+	const (
+		citextOID      = uint32(1234)
+		citextArrayOID = uint32(2345)
+		fpeKeyHex      = "000102030405060708090a0b0c0d0e0f"
+	)
+
+	testQuerier := func(indexRows []string) *pgmocks.Querier {
+		return &pgmocks.Querier{
+			QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
+				switch query {
+				case "SELECT * FROM \"public\".\"test\" LIMIT 0":
+					return &pgmocks.Rows{
+						FieldDescriptionsFn: func() []pgconn.FieldDescription {
+							return []pgconn.FieldDescription{
+								{Name: "name", DataTypeOID: pgtype.TextOID},
+								{Name: "emails", DataTypeOID: pgtype.TextArrayOID},
+								{Name: "tags", DataTypeOID: citextArrayOID},
+								{Name: "scores", DataTypeOID: pgtype.Int4ArrayOID},
+							}
+						},
+						CloseFn: func() {},
+						ErrFn:   func() error { return nil },
+					}, nil
+				case uniqueIndexQuery:
+					return &pgmocks.Rows{
+						CloseFn: func() {},
+						NextFn:  func(i uint) bool { return int(i) <= len(indexRows) },
+						ScanFn: func(i uint, dest ...any) error {
+							require.Len(t, dest, 3)
+							indexName, ok := dest[0].(*string)
+							require.True(t, ok)
+							primary, ok := dest[1].(*bool)
+							require.True(t, ok)
+							columnName, ok := dest[2].(**string)
+							require.True(t, ok)
+							column := indexRows[i-1]
+							*indexName, *primary, *columnName = "test_emails_key", false, &column
+							return nil
+						},
+						ErrFn: func() error { return nil },
+					}, nil
+				default:
+					return nil, fmt.Errorf("unexpected query: %s", query)
+				}
+			},
+			QueryRowFn: func(ctx context.Context, dest []any, query string, args ...any) error {
+				if strings.Contains(query, "a.typcategory = 'A'") {
+					if args[0] != citextArrayOID {
+						return pglib.ErrNoRows
+					}
+					require.Len(t, dest, 2)
+					elementOID, ok := dest[0].(*uint32)
+					require.True(t, ok)
+					elementName, ok := dest[1].(*string)
+					require.True(t, ok)
+					*elementOID, *elementName = citextOID, citextTypeName
+					return nil
+				}
+
+				require.Len(t, dest, 1)
+				typeName, ok := dest[0].(*string)
+				require.True(t, ok)
+				switch args[0] {
+				case citextOID:
+					*typeName = citextTypeName
+				case citextArrayOID:
+					*typeName = "_" + citextTypeName
+				default:
+					return fmt.Errorf("unexpected OID: %v", args[0])
+				}
+				return nil
+			},
+		}
+	}
+
+	intPtr := func(i int) *int { return &i }
+
+	tests := []struct {
+		name        string
+		columnRules map[string]TransformerRules
+		indexRows   []string
+		enforce     bool
+
+		wantUniqueness map[string]transformers.Uniqueness
+		wantErr        error
+		wantErrMsg     string
+	}{
+		{
+			name: "ok - a rule without array options maps over the elements",
+			columnRules: map[string]TransformerRules{
+				"emails": {Name: "fpe_ff1", Parameters: map[string]any{"key_hex": fpeKeyHex}},
+			},
+			// the map generator inherits the element transformer's guarantee
+			wantUniqueness: map[string]transformers.Uniqueness{"emails": transformers.UniquenessPreserved},
+		},
+		{
+			name: "ok - the random generator is lossy whatever it wraps",
+			columnRules: map[string]TransformerRules{
+				"emails": {
+					Name:         "fpe_ff1",
+					Parameters:   map[string]any{"key_hex": fpeKeyHex},
+					ArrayOptions: &ArrayOptions{Generator: "random", MinCount: intPtr(0), MaxCount: intPtr(12)},
+				},
+			},
+			wantUniqueness: map[string]transformers.Uniqueness{"emails": transformers.UniquenessLossy},
+		},
+		{
+			name: "ok - compatibility recurses into the element type",
+			columnRules: map[string]TransformerRules{
+				// email accepts citext, so it accepts citext[]
+				"tags": {Name: "email"},
+				// greenmask_integer accepts int4, so it accepts int4[]
+				"scores": {Name: "greenmask_integer", Parameters: map[string]any{"min_value": 1, "max_value": 100}},
+			},
+		},
+		{
+			name: "error - the element type is not compatible",
+			columnRules: map[string]TransformerRules{
+				"scores": {Name: "email"},
+			},
+			wantErrMsg: "transformer 'email' specified for column 'scores' in table \"public\".\"test\" does not support pg data type: _int4 with OID: 1007",
+		},
+		{
+			name: "error - array options on a scalar column",
+			columnRules: map[string]TransformerRules{
+				"name": {Name: "string", ArrayOptions: &ArrayOptions{Generator: "map"}},
+			},
+			wantErr: errArrayOptionsOnScalarColumn,
+		},
+		{
+			name: "error - counts under the map generator",
+			columnRules: map[string]TransformerRules{
+				"emails": {Name: "string", ArrayOptions: &ArrayOptions{MinCount: intPtr(1), MaxCount: intPtr(2)}},
+			},
+			wantErr: errArrayCountsNotAllowed,
+		},
+		{
+			name: "error - counts missing under the random generator",
+			columnRules: map[string]TransformerRules{
+				"emails": {Name: "string", ArrayOptions: &ArrayOptions{Generator: "random", MinCount: intPtr(1)}},
+			},
+			wantErr: errArrayCountsRequired,
+		},
+		{
+			name: "error - min count greater than max count",
+			columnRules: map[string]TransformerRules{
+				"emails": {Name: "string", ArrayOptions: &ArrayOptions{Generator: "random", MinCount: intPtr(4), MaxCount: intPtr(2)}},
+			},
+			wantErr:    transformers.ErrInvalidArrayOptions,
+			wantErrMsg: "column 'emails' in table \"public\".\"test\"",
+		},
+		{
+			name: "error - negative count",
+			columnRules: map[string]TransformerRules{
+				"emails": {Name: "string", ArrayOptions: &ArrayOptions{Generator: "random", MinCount: intPtr(-1), MaxCount: intPtr(2)}},
+			},
+			wantErr: transformers.ErrInvalidArrayOptions,
+		},
+		{
+			name: "error - unknown generator",
+			columnRules: map[string]TransformerRules{
+				"emails": {Name: "string", ArrayOptions: &ArrayOptions{Generator: "shuffle"}},
+			},
+			wantErr: transformers.ErrInvalidArrayOptions,
+		},
+		{
+			name: "ok - a mapped uniqueness preserving rule clears a unique index",
+			columnRules: map[string]TransformerRules{
+				"emails": {Name: "fpe_ff1", Parameters: map[string]any{"key_hex": fpeKeyHex}},
+			},
+			indexRows: []string{"emails"},
+			enforce:   true,
+		},
+		{
+			name: "error - a resampled rule breaks a unique index",
+			columnRules: map[string]TransformerRules{
+				"emails": {
+					Name:         "fpe_ff1",
+					Parameters:   map[string]any{"key_hex": fpeKeyHex},
+					ArrayOptions: &ArrayOptions{Generator: "random", MinCount: intPtr(0), MaxCount: intPtr(2)},
+				},
+			},
+			indexRows:  []string{"emails"},
+			enforce:    true,
+			wantErr:    ErrUniquenessNotPreserved,
+			wantErrMsg: `unique index "test_emails_key" (emails) is covered by a transformer that maps distinct values to the same output ("emails" uses "fpe_ff1")`,
+		},
+		{
+			name: "ok - allow_uniqueness_loss silences the resampled rule",
+			columnRules: map[string]TransformerRules{
+				"emails": {
+					Name:                "fpe_ff1",
+					Parameters:          map[string]any{"key_hex": fpeKeyHex},
+					AllowUniquenessLoss: true,
+					ArrayOptions:        &ArrayOptions{Generator: "random", MinCount: intPtr(0), MaxCount: intPtr(2)},
+				},
+			},
+			indexRows: []string{"emails"},
+			enforce:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parser := PostgresTransformerParser{
+				conn:              testQuerier(tc.indexRows),
+				builder:           builder.NewTransformerBuilder(),
+				pgtypeMap:         pglib.NewMapper(testQuerier(tc.indexRows)),
+				enforceUniqueness: tc.enforce,
+			}
+
+			transformerMap, err := parser.ParseAndValidate(context.Background(), Rules{
+				ValidationMode: validationModeRelaxed,
+				Transformers: []TableRules{
+					{
+						Schema:         "public",
+						Table:          "test",
+						ValidationMode: validationModeRelaxed,
+						ColumnRules:    tc.columnRules,
+					},
+				},
+			})
+
+			if tc.wantErr != nil || tc.wantErrMsg != "" {
+				require.Error(t, err)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, err, tc.wantErr)
+				}
+				if tc.wantErrMsg != "" {
+					require.Contains(t, err.Error(), tc.wantErrMsg)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			columnTransformers, found := transformerMap.GetActiveColumnTransformers("public", "test")
+			require.True(t, found)
+			for column, wantUniqueness := range tc.wantUniqueness {
+				// the map must hold the wrapper, not the element transformer,
+				// so that validation classifies the whole array transform
+				require.IsType(t, &transformers.ArrayTransformer{}, columnTransformers[column])
+				require.Equal(t, wantUniqueness, transformers.UniquenessOf(columnTransformers[column]))
+			}
 		})
 	}
 }

--- a/pkg/wal/processor/transformer/wal_transformer_parser.go
+++ b/pkg/wal/processor/transformer/wal_transformer_parser.go
@@ -27,6 +27,12 @@ func (p *transformerParser) parse(_ context.Context, rules Rules) (*TransformerM
 		}
 
 		for colName, transformerRules := range table.ColumnRules {
+			// without a connection there are no OIDs, so this parser cannot
+			// know whether a column is an array
+			if transformerRules.ArrayOptions != nil {
+				return nil, columnRuleError(tableIdx, table.Schema, table.Table, colName, errArrayOptionsRequirePostgres)
+			}
+
 			cfg := transformerRulesToConfig(transformerRules)
 			if cfg.Name == "" || cfg.Name == "noop" {
 				transformerMap.AddNoopTransformer(table.Schema, table.Table, colName)

--- a/pkg/wal/processor/transformer/wal_transformer_parser_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_parser_test.go
@@ -39,6 +39,22 @@ func TestTransformerParser_parse(t *testing.T) {
 		wantErrMsg         string
 	}{
 		{
+			name: "error - array options require a postgres connection",
+			rules: []TableRules{
+				{
+					Schema: testSchema,
+					Table:  testTable,
+					ColumnRules: map[string]TransformerRules{
+						"column_1": {
+							Name:         "string",
+							ArrayOptions: &ArrayOptions{Generator: "map"},
+						},
+					},
+				},
+			},
+			wantErr: errArrayOptionsRequirePostgres,
+		},
+		{
 			name: "ok",
 			rules: []TableRules{
 				{

--- a/pkg/wal/processor/transformer/wal_transformer_rules.go
+++ b/pkg/wal/processor/transformer/wal_transformer_rules.go
@@ -2,6 +2,12 @@
 
 package transformer
 
+import (
+	"errors"
+
+	"github.com/xataio/pgstream/pkg/transformers"
+)
+
 type Rules struct {
 	Transformers   []TableRules `yaml:"transformations"`
 	ValidationMode string       `yaml:"validation_mode"`
@@ -19,4 +25,42 @@ type TransformerRules struct {
 	Parameters          map[string]any `yaml:"parameters"`
 	DynamicParameters   map[string]any `yaml:"dynamic_parameters"`
 	AllowUniquenessLoss bool           `yaml:"allow_uniqueness_loss"`
+	ArrayOptions        *ArrayOptions  `yaml:"array_options"` // optional
+}
+
+type ArrayOptions struct {
+	Generator string `yaml:"generator"`
+	MinCount  *int   `yaml:"min_count"`
+	MaxCount  *int   `yaml:"max_count"`
+}
+
+var (
+	errArrayOptionsOnScalarColumn  = errors.New("array_options is only valid on an array column")
+	errArrayCountsRequired         = errors.New(`min_count and max_count are required when array_options.generator is "random"`)
+	errArrayCountsNotAllowed       = errors.New(`min_count and max_count are only valid when array_options.generator is "random"`)
+	errArrayOptionsRequirePostgres = errors.New("array_options requires a source postgres connection, which resolves the column type")
+)
+
+func (o *ArrayOptions) toArrayConfig() (transformers.ArrayConfig, error) {
+	cfg := transformers.ArrayConfig{Generator: transformers.ArrayGeneratorMap}
+	if o == nil {
+		return cfg, nil
+	}
+	if o.Generator != "" {
+		cfg.Generator = transformers.ArrayGenerator(o.Generator)
+	}
+
+	switch cfg.Generator {
+	case transformers.ArrayGeneratorMap:
+		if o.MinCount != nil || o.MaxCount != nil {
+			return cfg, errArrayCountsNotAllowed
+		}
+	case transformers.ArrayGeneratorRandom:
+		if o.MinCount == nil || o.MaxCount == nil {
+			return cfg, errArrayCountsRequired
+		}
+		cfg.MinCount, cfg.MaxCount = *o.MinCount, *o.MaxCount
+	}
+	// an unknown generator is rejected by the array transformer itself
+	return cfg, nil
 }


### PR DESCRIPTION
### Description

This PR applies a transformation rule on an array column to each element, instead of rejecting the rule at validation time. Today a rule on a `varchar(500)[]` column fails compatibility against every transformer that declares its types, with `does not support pg data type: _varchar with OID: 1015`. The rejection happens at rules-validation time, so it blocks the whole run: a table with a single array column cannot be transformed at all, even for its other columns.

This is the third PR for array column support.

##### Related Issue(s)

- Related to #1163

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Add an optional `array_options` block to a column rule, with `generator`, `min_count` and `max_count`, plumbed through `cmd/config`
- Wrap the transformer a rule names in an `ArrayTransformer` when the column is an array
- Reject rules that cannot mean anything, naming the table rule, schema, table and column: `array_options` on a scalar column, counts under `map`, counts missing under `random`, and a `min_count` above a `max_count`.
- Reject `array_options` in the connection-less parser, which has no OIDs and so cannot know whether a column is an array. This matches the existing requirement that enum support needs a source connection.

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary


#### Additional Notes

<!-- Any context or special instructions for reviewers -->
