### PR TITLE
Allow any column type in template transformer

### DIFF
--- a/pkg/transformers/template_transformer.go
+++ b/pkg/transformers/template_transformer.go
@@ -18,8 +18,7 @@ type TemplateTransformer struct {
 var (
 	errTemplateMustBeProvided = errors.New("template_transformer: template parameter must be provided")
 	templateCompatibleTypes   = []SupportedDataType{
-		StringDataType,
-		ByteArrayDataType,
+		AllDataTypes,
 	}
 	templateParams = []Parameter{
 		{

--- a/pkg/transformers/template_transformer_test.go
+++ b/pkg/transformers/template_transformer_test.go
@@ -98,6 +98,15 @@ func TestTemplateTransformer_Transform(t *testing.T) {
 			wantErr:    nil,
 		},
 		{
+			name:  "ok - integer value",
+			value: int32(42),
+			params: ParameterValues{
+				"template": "{{ .GetValue }}",
+			},
+			wantOutput: "42",
+			wantErr:    nil,
+		},
+		{
 			name:  "incompatible types for comparison",
 			value: 1,
 			params: ParameterValues{

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
@@ -291,6 +291,26 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 			wantErr: fmt.Errorf("table_transformers[0]: column id of table %s has no transformer configured", testSchemaTable),
 		},
 		{
+			name: "ok - template on a non string column",
+			transformerRules: []TableRules{
+				{
+					Schema:         "public",
+					Table:          "test",
+					ValidationMode: "relaxed",
+					ColumnRules: map[string]TransformerRules{
+						"id": {
+							Name:       string(transformers.Template),
+							Parameters: map[string]any{"template": "{{ .GetValue }}"},
+						},
+					},
+				},
+			},
+			validator: testPGValidator,
+
+			wantActiveTransformersFor: []string{"id"},
+			wantErr:                   nil,
+		},
+		{
 			name: "error - invalid column type",
 			transformerRules: []TableRules{
 				{

--- a/transformers-definition.json
+++ b/transformers-definition.json
@@ -1078,8 +1078,7 @@
     {
       "name": "template",
       "supported_types": [
-        "string",
-        "byte_array"
+        "all"
       ],
       "uniqueness": "not_guaranteed",
       "parameters": [


### PR DESCRIPTION
#### Description

The template transformer declared only `string` and `byte_array` as compatible types, so `pgstream validate` rejected it on any other column:

```
transformer 'template' specified for column 'lu_title_id' in table "public"."person" does not support pg data type: int4 with OID: 23
```

The documentation already says the transformer works on any Postgres type as long as the template output has the right syntax for the column. This PR makes the declaration match the docs. The transformer now declares `all`, the same way `literal_string` and `pg_anonymizer` do, and `transformers-definition.json` is regenerated.

Rendering of non-text snapshot values (numeric, uuid, date and friends arrive as pgx Go types during a snapshot) is handled in a follow-up PR stacked on this one.

##### Related Issue(s)

- Fixes #1178

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- Declare `AllDataTypes` as the template transformer's compatible type set
- Add a parser test that reproduces the exact validation error from the issue on an `int8` column and passes after the change
- Add a transformer unit test that renders an integer value through `{{ .GetValue }}`

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
