### PR TITLE
Parse range literals for binary COPY in bulk ingest

### DIFF
--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter.go
@@ -25,6 +25,12 @@ const (
 	onConflictDoNothing
 )
 
+const (
+	int4rangeType = "int4range"
+	int8rangeType = "int8range"
+	tstzrangeType = "tstzrange"
+)
+
 var (
 	errUnsupportedOnConflictAction = errors.New("unsupported on conflict action")
 	errUnableToBuildQuery          = errors.New("unable to build query, no primary keys of previous values available")
@@ -318,10 +324,20 @@ func (a *dmlAdapter) filterRowColumnsForAction(cols []wal.Column, schemaInfo sch
 func (a *dmlAdapter) updateValueForCopy(value any, colType string, isEnum bool) any {
 	// For COPY, we might need to update the value for some data types,
 	// so that it will be able to be encoded into binary format correctly.
+
+	// A transformer can turn a range into its postgres literal. pgx has no
+	// binary encode plan from a string to a range, so parse it back into a
+	// typed range first.
+	if strVal, ok := value.(string); ok {
+		if typed, ok := a.parseRangeLiteral(colType, strVal); ok {
+			return typed
+		}
+	}
+
 	switch colType {
 	case "date", "timestamp", "timestamptz":
 		return getInfinityValueForDateTime(value, colType)
-	case "tstzrange":
+	case tstzrangeType:
 		return getTypedTSTZRange(value)
 	case "tsvector":
 		if b, ok := value.([]byte); ok {
@@ -355,6 +371,36 @@ func (a *dmlAdapter) updateValueForCopy(value any, colType string, isEnum bool) 
 	}
 
 	return value
+}
+
+// parseRangeLiteral scans a postgres range literal into the typed range pgx
+// can encode in binary format for the column type. It reports false for a
+// column that is not a range, or a literal that does not parse.
+func (a *dmlAdapter) parseRangeLiteral(colType, literal string) (any, bool) {
+	switch colType {
+	case int4rangeType:
+		return scanRangeLiteral[int32](a.pgTypeMap, pgtype.Int4rangeOID, literal)
+	case int8rangeType:
+		return scanRangeLiteral[int64](a.pgTypeMap, pgtype.Int8rangeOID, literal)
+	case "numrange":
+		return scanRangeLiteral[pgtype.Numeric](a.pgTypeMap, pgtype.NumrangeOID, literal)
+	case "daterange":
+		return scanRangeLiteral[pgtype.Date](a.pgTypeMap, pgtype.DaterangeOID, literal)
+	case "tsrange":
+		return scanRangeLiteral[pgtype.Timestamp](a.pgTypeMap, pgtype.TsrangeOID, literal)
+	case tstzrangeType:
+		return scanRangeLiteral[time.Time](a.pgTypeMap, pgtype.TstzrangeOID, literal)
+	default:
+		return nil, false
+	}
+}
+
+func scanRangeLiteral[T any](typeMap *pgtype.Map, oid uint32, literal string) (any, bool) {
+	var r pgtype.Range[T]
+	if err := typeMap.Scan(oid, pgtype.TextFormatCode, []byte(literal), &r); err != nil {
+		return nil, false
+	}
+	return r, true
 }
 
 func quotedTableName(schemaName, tableName string) string {
@@ -419,11 +465,11 @@ func getTypedTSTZRange(value any) any {
 
 func getTypedRangeValue(colType string, value any) any {
 	switch colType {
-	case "int4range":
+	case int4rangeType:
 		return getTypedInt4Range(value)
-	case "int8range":
+	case int8rangeType:
 		return getTypedInt8Range(value)
-	case "tstzrange":
+	case tstzrangeType:
 		return getTypedTSTZRange(value)
 	default:
 		return value

--- a/pkg/wal/processor/postgres/postgres_wal_dml_adapter_test.go
+++ b/pkg/wal/processor/postgres/postgres_wal_dml_adapter_test.go
@@ -992,6 +992,36 @@ func Test_updateValueForCopy_enumArray(t *testing.T) {
 	require.Equal(t, "{happy,sad}", a.updateValueForCopy("{happy,sad}", "mood[]", true))
 }
 
+func Test_updateValueForCopy_rangeLiteral(t *testing.T) {
+	t.Parallel()
+
+	a := newTestDMLAdapterForCopy(t)
+
+	// a range literal produced by a transformer is parsed into the typed
+	// range pgx's binary COPY encoder can handle
+	require.Equal(t,
+		pgtype.Range[int32]{Lower: 1, Upper: 10, LowerType: pgtype.Inclusive, UpperType: pgtype.Exclusive, Valid: true},
+		a.updateValueForCopy("[1,10)", "int4range", false))
+	require.Equal(t,
+		pgtype.Range[int64]{Lower: 5, LowerType: pgtype.Exclusive, UpperType: pgtype.Unbounded, Valid: true},
+		a.updateValueForCopy("(5,)", "int8range", false))
+	require.Equal(t,
+		pgtype.Range[pgtype.Date]{
+			Lower:     pgtype.Date{Time: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), Valid: true},
+			Upper:     pgtype.Date{Time: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC), Valid: true},
+			LowerType: pgtype.Inclusive, UpperType: pgtype.Exclusive, Valid: true,
+		},
+		a.updateValueForCopy("[2024-01-01,2024-02-01)", "daterange", false))
+	require.Equal(t,
+		pgtype.Range[int32]{LowerType: pgtype.Empty, UpperType: pgtype.Empty, Valid: true},
+		a.updateValueForCopy("empty", "int4range", false))
+
+	// a literal that does not parse is left for pgx to report
+	require.Equal(t, "not a range", a.updateValueForCopy("not a range", "int4range", false))
+	// a text column is never touched
+	require.Equal(t, "[1,10)", a.updateValueForCopy("[1,10)", "text", false))
+}
+
 func Test_newDMLAdapter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
#### Description

Bulk ingest writes snapshot rows with pgx's binary-format COPY. When a transformer turns a range column into its Postgres literal, for example `[1,10)` from a `template` or `literal_string` rule, pgx has no encode plan from a string to a range and the batch fails:

```
copy from: ERROR: COPY from stdin failed: unable to encode "[1,10)" into binary format for int4range (OID 3904): cannot find encode plan
```

The batch writer is unaffected, because it sends the literal as a query parameter and Postgres parses it. This PR makes bulk ingest handle the same input by scanning the literal into the typed range pgx can encode, the same way array literals are already parsed back into Go slices in the COPY value path.

##### Related Issue(s)

- Related to #1178

#### Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

#### Changes Made

- Add `parseRangeLiteral` to the DML adapter's COPY value path. A string value on an `int4range`, `int8range`, `numrange`, `daterange`, `tsrange` or `tstzrange` column is scanned by OID into the matching `pgtype.Range[T]`
- Leave a literal that does not parse untouched, so pgx reports the error as before
- Extract the range type names that now appear three times into constants, to satisfy `goconst`

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
