### PR TITLE
Decode array elements with a catalog aware type map

### DIFF
--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -123,7 +123,7 @@ column_transformers:
 | `map`     | Applies the transformer to each source element, in order. The array keeps its length. This is the default.                               |
 | `random`  | Emits between `min_count` and `max_count` elements. Each element is the transform of a source element selected at random, with repeats.  |
 
-`min_count` and `max_count` are required with the `random` generator. They must be non-negative, and `min_count` must not be greater than `max_count`. They are not valid with the `map` generator. pgstream rejects the rules at startup if these conditions are not met, and names the schema, table and column.
+`min_count` and `max_count` are required with the `random` generator. They must be non-negative, `min_count` must not be greater than `max_count`, and `max_count` must not be greater than 10000. The limit protects against a mistyped value, which pgstream would otherwise apply to every row. These parameters are not valid with the `map` generator. pgstream rejects the rules at startup if these conditions are not met, and names the schema, table and column.
 
 The `random` generator never invents a value. Each new element is the transform of a value that is in the row. An empty source array stays empty.
 

--- a/internal/postgres/pg_utils.go
+++ b/internal/postgres/pg_utils.go
@@ -290,7 +290,10 @@ func (rawJSONTextCodec) FormatSupported(format int16) bool {
 // the connection's type map to rawJSONTextCodec, so their values decode to raw
 // text (string). See WithRawJSONDecoding.
 func registerRawJSONDecoding(conn *pgx.Conn) {
-	typeMap := conn.TypeMap()
+	registerRawJSONDecodingOnMap(conn.TypeMap())
+}
+
+func registerRawJSONDecodingOnMap(typeMap *pgtype.Map) {
 	jsonType := &pgtype.Type{Name: "json", OID: pgtype.JSONOID, Codec: rawJSONTextCodec{}}
 	jsonbType := &pgtype.Type{Name: "jsonb", OID: pgtype.JSONBOID, Codec: rawJSONTextCodec{}}
 	typeMap.RegisterType(jsonType)
@@ -538,4 +541,43 @@ func applyTCPKeepalive(conn net.Conn) error {
 		return nil
 	}
 	return tcp.SetKeepAliveConfig(keepAliveConfig())
+}
+
+// NewArrayTypeMap returns a type map that can decode and encode values of
+// arrayOID in the text format.
+//
+// A transformer that runs on array elements cannot use a bare pgtype.Map: that
+// map only knows the built-in OIDs, so a user-defined array type - an enum
+// array, citext[], hstore[], a domain over an array - fails to scan at run
+// time even though the rule validated. Such an element type is registered with
+// the text codec, which is what the server sends in the text format anyway,
+// and the array type is registered around it.
+//
+// json and jsonb keep the raw text decoding that connections use, so an
+// element reaches the transformer as raw text on both the replication and the
+// snapshot path, and a JSON null stays distinguishable from SQL NULL.
+//
+// It returns an error when the array type still cannot be resolved, so that an
+// unusable rule fails when it is built rather than on every row.
+func NewArrayTypeMap(arrayOID, elementOID uint32, elementTypeName string) (*pgtype.Map, error) {
+	typeMap := pgtype.NewMap()
+	registerRawJSONDecodingOnMap(typeMap)
+
+	if _, found := typeMap.TypeForOID(arrayOID); !found {
+		elementType, found := typeMap.TypeForOID(elementOID)
+		if !found {
+			elementType = &pgtype.Type{Name: elementTypeName, OID: elementOID, Codec: pgtype.TextCodec{}}
+			typeMap.RegisterType(elementType)
+		}
+		typeMap.RegisterType(&pgtype.Type{
+			Name:  "_" + elementTypeName,
+			OID:   arrayOID,
+			Codec: &pgtype.ArrayCodec{ElementType: elementType},
+		})
+	}
+
+	if _, found := typeMap.TypeForOID(arrayOID); !found {
+		return nil, fmt.Errorf("no codec for array type OID %d with element %s (OID %d)", arrayOID, elementTypeName, elementOID)
+	}
+	return typeMap, nil
 }

--- a/pkg/transformers/array_transformer.go
+++ b/pkg/transformers/array_transformer.go
@@ -9,7 +9,16 @@ import (
 	"math/rand/v2"
 
 	"github.com/jackc/pgx/v5/pgtype"
+
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/pkg/transformers/internal/pool"
 )
+
+// maxArrayElementCount bounds the output length of the random generator. It
+// guards against a mistyped max_count, which would otherwise allocate and
+// transform that many elements for every row, once per element for a
+// transformer that queries the source.
+const maxArrayElementCount = 10_000
 
 // ArrayGenerator selects how the elements of the transformed array are drawn
 // from the elements of the source array.
@@ -45,6 +54,7 @@ var (
 type ArrayConfig struct {
 	ElementTransformer Transformer
 	ArrayOID           uint32
+	ElementOID         uint32
 	ElementTypeName    string
 	Column             string
 	Generator          ArrayGenerator
@@ -62,7 +72,10 @@ type ArrayTransformer struct {
 	generator       ArrayGenerator
 	minCount        int
 	maxCount        int
-	pgMap           *pgtype.Map
+	// pgtype.Map memoizes its encode plans without synchronisation, and one
+	// transformer is shared by every snapshot worker, so each concurrent
+	// caller takes its own instance rather than sharing one.
+	pgMapPool *pool.Pool[*pgtype.Map]
 	// injected by the tests, which cannot assert on a random draw
 	randIntN func(n int) int
 }
@@ -84,8 +97,22 @@ func NewArrayTransformer(cfg ArrayConfig) (*ArrayTransformer, error) {
 		if cfg.MinCount > cfg.MaxCount {
 			return nil, fmt.Errorf("%w: min_count %d is greater than max_count %d", ErrInvalidArrayOptions, cfg.MinCount, cfg.MaxCount)
 		}
+		if cfg.MaxCount > maxArrayElementCount {
+			return nil, fmt.Errorf("%w: max_count %d is above the limit of %d", ErrInvalidArrayOptions, cfg.MaxCount, maxArrayElementCount)
+		}
 	default:
 		return nil, fmt.Errorf("%w: unknown generator %q, expected %q or %q", ErrInvalidArrayOptions, cfg.Generator, ArrayGeneratorMap, ArrayGeneratorRandom)
+	}
+
+	// the parser accepts a rule on a user-defined array type on the strength
+	// of a catalog lookup, so the transformer has to be able to decode that
+	// type too. Building the map here means an unusable rule fails while it is
+	// built rather than on every row.
+	pgMapPool, err := pool.New(func() (*pgtype.Map, error) {
+		return pglib.NewArrayTypeMap(cfg.ArrayOID, cfg.ElementOID, cfg.ElementTypeName)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: column %q: %w", ErrInvalidArrayOptions, cfg.Column, err)
 	}
 
 	return &ArrayTransformer{
@@ -96,7 +123,7 @@ func NewArrayTransformer(cfg ArrayConfig) (*ArrayTransformer, error) {
 		generator:       cfg.Generator,
 		minCount:        cfg.MinCount,
 		maxCount:        cfg.MaxCount,
-		pgMap:           pgtype.NewMap(),
+		pgMapPool:       pgMapPool,
 		randIntN:        rand.IntN,
 	}, nil
 }
@@ -135,8 +162,14 @@ func (t *ArrayTransformer) decode(value any) ([]any, arrayShape, error) {
 // flattens a nested literal into a single dimension and reports no error, so
 // the shape would be lost before the element wise transform sees it.
 func (t *ArrayTransformer) decodeLiteral(literal []byte) ([]any, error) {
+	pgMap, err := t.pgMapPool.Acquire()
+	if err != nil {
+		return nil, fmt.Errorf("column %q: acquiring a type map: %w", t.column, err)
+	}
+	defer t.pgMapPool.Release(pgMap)
+
 	var array pgtype.Array[any]
-	if err := t.pgMap.PlanScan(t.arrayOID, pgtype.TextFormatCode, &array).Scan(literal, &array); err != nil {
+	if err := pgMap.PlanScan(t.arrayOID, pgtype.TextFormatCode, &array).Scan(literal, &array); err != nil {
 		return nil, fmt.Errorf("column %q: decoding array literal: %w", t.column, err)
 	}
 	if len(array.Dims) > 1 {
@@ -150,7 +183,13 @@ func (t *ArrayTransformer) encode(elements []any, shape arrayShape) (any, error)
 		return elements, nil
 	}
 
-	literal, err := t.pgMap.Encode(t.arrayOID, pgtype.TextFormatCode, elements, nil)
+	pgMap, err := t.pgMapPool.Acquire()
+	if err != nil {
+		return nil, fmt.Errorf("column %q: acquiring a type map: %w", t.column, err)
+	}
+	defer t.pgMapPool.Release(pgMap)
+
+	literal, err := pgMap.Encode(t.arrayOID, pgtype.TextFormatCode, elements, nil)
 	if err != nil {
 		return nil, fmt.Errorf("column %q: encoding array literal: %w", t.column, err)
 	}

--- a/pkg/transformers/array_transformer_test.go
+++ b/pkg/transformers/array_transformer_test.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -95,6 +97,11 @@ func TestNewArrayTransformer(t *testing.T) {
 		{
 			name:    "error - unknown generator",
 			cfg:     ArrayConfig{ElementTransformer: upperTransformer(), Generator: ArrayGenerator("shuffle")},
+			wantErr: ErrInvalidArrayOptions,
+		},
+		{
+			name:    "error - max_count above the limit",
+			cfg:     ArrayConfig{ElementTransformer: upperTransformer(), Generator: ArrayGeneratorRandom, MinCount: 1, MaxCount: maxArrayElementCount + 1},
 			wantErr: ErrInvalidArrayOptions,
 		},
 		{
@@ -371,4 +378,102 @@ func TestArrayTransformer_sharesDynamicValuesWithEveryElement(t *testing.T) {
 	_, err := transformer.Transform(context.Background(), NewValue(`{a,b}`, "text[]", dynamicValues))
 	require.NoError(t, err)
 	require.Equal(t, []map[string]any{dynamicValues, dynamicValues}, seen)
+}
+
+// statelessUpperTransformer records nothing, so a concurrent test measures the
+// array transformer rather than the recording stub.
+type statelessUpperTransformer struct{ stubTransformer }
+
+func (s *statelessUpperTransformer) Transform(_ context.Context, value Value) (any, error) {
+	str, ok := value.TransformValue.(string)
+	if !ok {
+		return nil, fmt.Errorf("%w: got %T", ErrUnsupportedValueType, value.TransformValue)
+	}
+	return strings.ToUpper(str), nil
+}
+
+// The parser accepts a rule on a user-defined array type on the strength of a
+// catalog lookup. A type map that only knows the built-in OIDs cannot decode
+// one, so such a rule used to validate and then fail on every row.
+func TestArrayTransformer_userDefinedElementType(t *testing.T) {
+	t.Parallel()
+
+	const moodArrayOID, moodOID = 60001, 60000
+
+	transformer, err := NewArrayTransformer(ArrayConfig{
+		ElementTransformer: upperTransformer(),
+		ArrayOID:           moodArrayOID,
+		ElementOID:         moodOID,
+		ElementTypeName:    "mood",
+		Generator:          ArrayGeneratorMap,
+		Column:             "moods",
+	})
+	require.NoError(t, err)
+
+	got, err := transformer.Transform(context.Background(), NewValue("{happy,sad}", "mood[]", nil))
+	require.NoError(t, err)
+	require.Equal(t, "{HAPPY,SAD}", got)
+}
+
+// json and jsonb reach the element transformer as raw text, in the same way
+// they do on a pgstream connection, so a large integer keeps its digits and a
+// JSON null stays distinct from SQL NULL.
+func TestArrayTransformer_jsonElementsStayRawText(t *testing.T) {
+	t.Parallel()
+
+	inner := upperTransformer()
+	var seen []any
+	inner.transformFn = func(value Value) (any, error) {
+		seen = append(seen, value.TransformValue)
+		return value.TransformValue, nil
+	}
+
+	transformer, err := NewArrayTransformer(ArrayConfig{
+		ElementTransformer: inner,
+		ArrayOID:           pgtype.JSONBArrayOID,
+		ElementOID:         pgtype.JSONBOID,
+		ElementTypeName:    "jsonb",
+		Generator:          ArrayGeneratorMap,
+		Column:             "payloads",
+	})
+	require.NoError(t, err)
+
+	const literal = `{"{\"a\": 12345678901234567890}","null"}`
+	got, err := transformer.Transform(context.Background(), NewValue(literal, "jsonb[]", nil))
+	require.NoError(t, err)
+
+	// raw text, not a map[string]any that re-marshalling would round to
+	// 12345678901234567000, and the JSON null is still an element
+	require.Equal(t, []any{`{"a": 12345678901234567890}`, "null"}, seen)
+	require.Equal(t, literal, got)
+}
+
+// One transformer instance is shared by every snapshot worker, and pgtype.Map
+// memoizes its encode plans without synchronisation.
+func TestArrayTransformer_concurrentTransform(t *testing.T) {
+	t.Parallel()
+
+	transformer, err := NewArrayTransformer(ArrayConfig{
+		ElementTransformer: &statelessUpperTransformer{},
+		ArrayOID:           pgtype.TextArrayOID,
+		ElementOID:         pgtype.TextOID,
+		ElementTypeName:    "text",
+		Generator:          ArrayGeneratorMap,
+		Column:             "tags",
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 50 {
+				got, err := transformer.Transform(context.Background(), NewValue("{alice,bob}", "text[]", nil))
+				assert.NoError(t, err)
+				assert.Equal(t, "{ALICE,BOB}", got)
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
@@ -248,6 +248,7 @@ func wrapArrayTransformer(t transformers.Transformer, opts *ArrayOptions, colNam
 	}
 	cfg.ElementTransformer = t
 	cfg.ArrayOID = arrayOID
+	cfg.ElementOID = resolved.oid
 	cfg.ElementTypeName = resolved.name
 	cfg.Column = colName
 	return transformers.NewArrayTransformer(cfg)


### PR DESCRIPTION
#### Description

`ArrayTransformer` builds its own type map with `pgtype.NewMap()`, which knows only the built-in OIDs. The parser, meanwhile, resolves an element type through the catalog (`ElementTypeForOID`, #1181), so a rule on a user-defined array type (`citext[]`, `hstore[]`), a domain over an array. It is accepted during validation. However, at run time every row then fails to scan:

```
cannot scan unknown type (OID 60001) in text format into *[]interface {}
```

Under the default `on_error: null` that nulls the whole column for 100% of rows, logging one DATALOSS line per row while the run reports success.
The column the user asked to anonymise is silently emptied. Under `pass-through` the original values reach the target instead. Either way `pgstream validate rules` says the configuration is fine.

Additional problems:

- It lacks the `rawJSONTextCodec` pgstream installs on every connection, so `jsonb[]` elements are unmarshalled and re-marshalled. A 20-digit integer comes back rounded, and a JSON `null` becomes SQL `NULL`.
- One map is shared by every snapshot worker, although `pgtype.Map` memoizes its encode plans without synchronisation.

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- `max_count` is capped to 10000

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
