### PR TITLE
Warn and fail early on array column rule surprises

### DIFF
--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -136,8 +136,9 @@ The `random` generator never invents a value. Each new element is the transform 
 
 ### Limitations
 
-- **Multi-dimensional arrays are not supported.** PostgreSQL does not record the number of dimensions in the column type, so pgstream cannot reject these rules at startup. On the replication path a multi-dimensional value is a per-row error, which the `on_error` policy handles.
-- **`literal_string` writes into each element.** On an array column, `literal_string` writes its literal into every element instead of into the column as a whole.
+- **Multi-dimensional arrays are not supported.** pgstream rejects a rule at startup when the column is declared with more than one dimension. PostgreSQL does not enforce the declared number of dimensions, so a column declared as one-dimensional can still hold a multi-dimensional value. On the replication path this value is a per-row error, which the `on_error` policy handles. On the snapshot path pgstream cannot detect it, because the source driver returns the elements already flattened, and it writes a one-dimensional array to the target.
+- **`literal_string` and `pg_anonymizer` write into each element.** On an array column these transformers write into every element instead of into the column as a whole. This is different from the behaviour before pgstream supported array columns. `pgstream validate rules` reports a warning for each of these rules.
+- **`pg_anonymizer` sends one query for each element.** A wide array multiplies the queries that pgstream sends to the source database for the row. `pgstream validate rules` reports a warning for each rule that uses this transformer on an array column.
 - **Dynamic parameters are not paired element by element.** A `dynamic_parameters` sibling that is itself an array falls back to the parameter default.
 
 ### Uniqueness

--- a/pkg/transformers/mocks/mock_transformer.go
+++ b/pkg/transformers/mocks/mock_transformer.go
@@ -13,6 +13,7 @@ type Transformer struct {
 	IsDynamicFn       func() bool
 	CompatibleTypesFn func() []transformers.SupportedDataType
 	UniquenessFn      func() transformers.Uniqueness
+	TypeFn            func() transformers.TransformerType
 }
 
 func (m *Transformer) Transform(_ context.Context, val transformers.Value) (any, error) {
@@ -24,6 +25,9 @@ func (m *Transformer) CompatibleTypes() []transformers.SupportedDataType {
 }
 
 func (m *Transformer) Type() transformers.TransformerType {
+	if m.TypeFn != nil {
+		return m.TypeFn()
+	}
 	return transformers.TransformerType("mock")
 }
 

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
@@ -42,7 +42,15 @@ func WithUniquenessEnforcement() ParserOption {
 
 const (
 	fieldDescriptionsQuery = "SELECT * FROM %s LIMIT 0"
-	schemaTablesQuery      = "SELECT tablename FROM pg_tables WHERE schemaname=$1"
+	// attndims records the dimensions a column was declared with. Postgres
+	// does not enforce it, so this catches a text[][] declaration and not a
+	// multi-dimensional value stored in a text[] column, which the transformer
+	// still rejects per row on the replication path.
+	multiDimensionalColumnsQuery = `SELECT a.attname FROM pg_attribute a
+	JOIN pg_class c ON c.oid = a.attrelid
+	JOIN pg_namespace n ON n.oid = c.relnamespace
+	WHERE n.nspname = $1 AND c.relname = $2 AND a.attnum > 0 AND NOT a.attisdropped AND a.attndims > 1`
+	schemaTablesQuery = "SELECT tablename FROM pg_tables WHERE schemaname=$1"
 	// expression columns have attnum 0 and no pg_attribute row, so the LEFT
 	// JOIN yields a NULL attname rather than dropping the index entirely.
 	// indkey also carries INCLUDE columns, which do not enforce uniqueness;
@@ -129,6 +137,11 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 			return nil, err
 		}
 
+		multiDimensionalColumns, err := v.getMultiDimensionalColumns(ctx, table.Schema, table.Table)
+		if err != nil {
+			return nil, err
+		}
+
 		// map column names to their pg type OID and modifier
 		mappedColumnTypes := make(map[string]columnType, len(fieldDescriptions))
 		for _, desc := range fieldDescriptions {
@@ -155,6 +168,10 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 				if cfg.Parameters["postgres_url"] == nil {
 					cfg.Parameters["postgres_url"] = v.connURL
 				}
+			}
+
+			if _, multiDimensional := multiDimensionalColumns[colName]; multiDimensional {
+				return nil, fmt.Errorf("%s: column '%s' in table %q.%q: %w", tableRulePosition(tableIdx), colName, table.Schema, table.Table, transformers.ErrMultiDimensionalArray)
 			}
 
 			// build the transformer
@@ -185,6 +202,10 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 			// an array column holds the wrapper rather than the transformer
 			// the rule names, so that uniqueness validation and the transform
 			// itself both see the whole array transform
+			if resolved.isArray {
+				v.warnings = append(v.warnings, arrayColumnWarnings(tableIdx, table.Schema, table.Table, colName, dataTypeName, transformer)...)
+			}
+
 			transformer, err = wrapArrayTransformer(transformer, transformerRules.ArrayOptions, colName, colType.oid, resolved)
 			if err != nil {
 				return nil, columnRuleError(tableIdx, table.Schema, table.Table, colName, err)
@@ -374,7 +395,9 @@ func (v *PostgresTransformerParser) getFieldDescriptions(ctx context.Context, sc
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("reading columns for table %q.%q: %w", schema, table, err)
 	}
-	return rows.FieldDescriptions(), nil
+	// the descriptions belong to the connection and are overwritten by the
+	// next query on it, so the caller gets a copy it can keep
+	return slices.Clone(rows.FieldDescriptions()), nil
 }
 
 func (v *PostgresTransformerParser) getAllSchemaTables(ctx context.Context, schema string) ([]string, error) {
@@ -531,4 +554,50 @@ func numericParamMagnitude(value any) (float64, error) {
 	default:
 		return 0, fmt.Errorf("got %T, want a number", value)
 	}
+}
+
+// getMultiDimensionalColumns returns the columns of a table that were declared
+// with more than one dimension. Only one dimensional arrays are transformed
+// per element, and rejecting these keeps the run from starting rather than
+// failing row by row.
+func (v *PostgresTransformerParser) getMultiDimensionalColumns(ctx context.Context, schema, table string) (map[string]struct{}, error) {
+	rows, err := v.conn.Query(ctx, multiDimensionalColumnsQuery, schema, table)
+	if err != nil {
+		return nil, fmt.Errorf("querying column dimensions for table %q.%q: %w", schema, table, err)
+	}
+	defer rows.Close()
+
+	columns := map[string]struct{}{}
+	for rows.Next() {
+		var columnName string
+		if err := rows.Scan(&columnName); err != nil {
+			return nil, fmt.Errorf("scanning column dimensions for table %q.%q: %w", schema, table, err)
+		}
+		columns[columnName] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading column dimensions for table %q.%q: %w", schema, table, err)
+	}
+	return columns, nil
+}
+
+// arrayColumnWarnings reports the two ways a rule on an array column behaves
+// differently from what its configuration suggests, both of which are silent
+// otherwise.
+func arrayColumnWarnings(tableIdx int, schema, table, column, dataTypeName string, transformer transformers.Transformer) []string {
+	position := fmt.Sprintf("%s: column '%s' in table %q.%q (%s)", tableRulePosition(tableIdx), column, schema, table, dataTypeName)
+
+	var warnings []string
+	if slices.Contains(transformer.CompatibleTypes(), transformers.AllDataTypes) {
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: transformer %q applies to each element of the array, not to the column value as a whole",
+			position, transformer.Type()))
+	}
+
+	if transformer.Type() == transformers.PGAnonymizer {
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: transformer %q queries the source database once for each element, so a wide array multiplies the queries for the row",
+			position, transformer.Type()))
+	}
+	return warnings
 }

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
@@ -28,6 +28,12 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 		return &pgmocks.Querier{
 			QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
 				switch query {
+				case multiDimensionalColumnsQuery:
+					return &pgmocks.Rows{
+						CloseFn: func() {},
+						NextFn:  func(i uint) bool { return false },
+						ErrFn:   func() error { return nil },
+					}, nil
 				case "SELECT * FROM \"public\".\"test\" LIMIT 0":
 					return &pgmocks.Rows{
 						FieldDescriptionsFn: func() []pgconn.FieldDescription {
@@ -544,6 +550,12 @@ func TestPostgresTransformerParser_uniqueIndexValidation(t *testing.T) {
 		return &pgmocks.Querier{
 			QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
 				switch query {
+				case multiDimensionalColumnsQuery:
+					return &pgmocks.Rows{
+						CloseFn: func() {},
+						NextFn:  func(i uint) bool { return false },
+						ErrFn:   func() error { return nil },
+					}, nil
 				case "SELECT * FROM \"public\".\"test\" LIMIT 0":
 					return &pgmocks.Rows{
 						FieldDescriptionsFn: func() []pgconn.FieldDescription {
@@ -854,6 +866,12 @@ func TestPostgresTransformerParser_connectionInjection(t *testing.T) {
 		return &pgmocks.Querier{
 			QueryFn: func(_ context.Context, _ uint, query string, _ ...any) (pglib.Rows, error) {
 				switch query {
+				case multiDimensionalColumnsQuery:
+					return &pgmocks.Rows{
+						CloseFn: func() {},
+						NextFn:  func(i uint) bool { return false },
+						ErrFn:   func() error { return nil },
+					}, nil
 				case "SELECT * FROM \"public\".\"test\" LIMIT 0":
 					return &pgmocks.Rows{
 						FieldDescriptionsFn: func() []pgconn.FieldDescription {
@@ -960,6 +978,12 @@ func TestPostgresTransformerParser_ParseAndValidate_arrayColumns(t *testing.T) {
 		return &pgmocks.Querier{
 			QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
 				switch query {
+				case multiDimensionalColumnsQuery:
+					return &pgmocks.Rows{
+						CloseFn: func() {},
+						NextFn:  func(i uint) bool { return false },
+						ErrFn:   func() error { return nil },
+					}, nil
 				case "SELECT * FROM \"public\".\"test\" LIMIT 0":
 					return &pgmocks.Rows{
 						FieldDescriptionsFn: func() []pgconn.FieldDescription {
@@ -1194,6 +1218,120 @@ func TestPostgresTransformerParser_ParseAndValidate_arrayColumns(t *testing.T) {
 				// so that validation classifies the whole array transform
 				require.IsType(t, &transformers.ArrayTransformer{}, columnTransformers[column])
 				require.Equal(t, wantUniqueness, transformers.UniquenessOf(columnTransformers[column]))
+			}
+		})
+	}
+}
+
+// a column declared with more than one dimension cannot be transformed per
+// element, so the run must not start rather than fail on every row
+func TestPostgresTransformerParser_multiDimensionalColumnRejected(t *testing.T) {
+	t.Parallel()
+
+	querier := &pgmocks.Querier{
+		QueryFn: func(_ context.Context, _ uint, query string, _ ...any) (pglib.Rows, error) {
+			switch query {
+			case multiDimensionalColumnsQuery:
+				return &pgmocks.Rows{
+					CloseFn: func() {},
+					NextFn:  func(i uint) bool { return i == 1 },
+					ScanFn: func(i uint, dest ...any) error {
+						require.Len(t, dest, 1)
+						columnName, ok := dest[0].(*string)
+						require.True(t, ok)
+						*columnName = "grid"
+						return nil
+					},
+					ErrFn: func() error { return nil },
+				}, nil
+			case "SELECT * FROM \"public\".\"test\" LIMIT 0":
+				return &pgmocks.Rows{
+					FieldDescriptionsFn: func() []pgconn.FieldDescription {
+						return []pgconn.FieldDescription{{Name: "grid", DataTypeOID: pgtype.TextArrayOID}}
+					},
+					CloseFn: func() {},
+					ErrFn:   func() error { return nil },
+				}, nil
+			case uniqueIndexQuery:
+				return &pgmocks.Rows{
+					CloseFn: func() {},
+					NextFn:  func(i uint) bool { return false },
+					ErrFn:   func() error { return nil },
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected query: %s", query)
+			}
+		},
+	}
+
+	parser := PostgresTransformerParser{
+		conn:           querier,
+		builder:        builder.NewTransformerBuilder(),
+		pgtypeMap:      pglib.NewMapper(querier),
+		requiredTables: []string{"public.test"},
+	}
+
+	_, err := parser.ParseAndValidate(context.Background(), Rules{
+		ValidationMode: "relaxed",
+		Transformers: []TableRules{
+			{
+				Schema:      "public",
+				Table:       "test",
+				ColumnRules: map[string]TransformerRules{"grid": {Name: "email"}},
+			},
+		},
+	})
+	require.ErrorIs(t, err, transformers.ErrMultiDimensionalArray)
+	require.ErrorContains(t, err, "table_transformers[0]")
+}
+
+// the two behaviours of an array column rule that its configuration does not
+// show
+func Test_arrayColumnWarnings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		transformerType  transformers.TransformerType
+		compatibleTypes  []transformers.SupportedDataType
+		wantWarningCount int
+		wantContains     []string
+	}{
+		{
+			name:             "an all types transformer applies per element",
+			transformerType:  transformers.LiteralString,
+			compatibleTypes:  []transformers.SupportedDataType{transformers.AllDataTypes},
+			wantWarningCount: 1,
+			wantContains:     []string{"each element", "table_transformers[3]", "'emails'"},
+		},
+		{
+			name:             "pg_anonymizer queries once per element",
+			transformerType:  transformers.PGAnonymizer,
+			compatibleTypes:  []transformers.SupportedDataType{transformers.AllDataTypes},
+			wantWarningCount: 2,
+			wantContains:     []string{"each element", "once for each element"},
+		},
+		{
+			name:             "a typed transformer warns about nothing",
+			transformerType:  transformers.TransformerType("email"),
+			compatibleTypes:  []transformers.SupportedDataType{transformers.StringDataType},
+			wantWarningCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			transformer := &transformermocks.Transformer{
+				TypeFn:            func() transformers.TransformerType { return tc.transformerType },
+				CompatibleTypesFn: func() []transformers.SupportedDataType { return tc.compatibleTypes },
+			}
+
+			warnings := arrayColumnWarnings(3, "public", "test", "emails", "_text", transformer)
+			require.Len(t, warnings, tc.wantWarningCount)
+			for _, want := range tc.wantContains {
+				require.Contains(t, strings.Join(warnings, "\n"), want)
 			}
 		})
 	}


### PR DESCRIPTION
#### Description

Three unreported problems are addressed and reported:

- A transformer that declares `AllDataTypes` (`literal_string`, `pg_anonymizer`) applies per element on an array column. For a configuration written before array columns were supported
- `pg_anonymizer` sends one query to the source for each element, so a wide array multiplies the queries for every row
- A column declared with more than one dimension was accepted, then failed row by row on the replication path

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- `ParseAndValidate` reports a warning for each of the first two cases. Both surface in `pgstream validate rules` and in the run log, and name the rule position, schema, table, column and type.

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
