### PR TITLE
Resolve enum types and return choice labels as strings

### DIFF
--- a/internal/postgres/pg_mapper.go
+++ b/internal/postgres/pg_mapper.go
@@ -29,12 +29,26 @@ type Mapper struct {
 	// the pgx map does not know. A nil value caches the answer that the OID
 	// does not name an array, so a scalar user defined type is queried once.
 	elementOIDMap *synclib.Map[uint32, *ElementType]
+	// enumOIDMap caches whether an OID resolves to an enum, and if so its
+	// labels. A nil value is a cached negative answer, which most OIDs are.
+	enumOIDMap *synclib.Map[uint32, *EnumType]
 }
 
 // ElementType identifies the element type of a postgres array type.
 type ElementType struct {
 	OID  uint32
 	Name string
+}
+
+// EnumType describes a column type that names a user-defined enum, either
+// directly or through a domain over one.
+type EnumType struct {
+	// Name is the enum's own type name, which is not always the column's type
+	// name: a domain resolves to the enum underneath it.
+	Name string
+	// Labels are the enum's values, in their declared sort order. They are
+	// shared with every caller for this OID and must not be modified.
+	Labels []string
 }
 
 // NewMapper creates a new Mapper instance with the given database querier.
@@ -46,6 +60,7 @@ func NewMapper(conn Querier) *Mapper {
 		pgMap:         pgtype.NewMap(),
 		customOIDMap:  synclib.NewMap[uint32, string](),
 		elementOIDMap: synclib.NewMap[uint32, *ElementType](),
+		enumOIDMap:    synclib.NewMap[uint32, *EnumType](),
 	}
 }
 
@@ -111,4 +126,45 @@ func (m *Mapper) queryElementType(ctx context.Context, oid uint32) (*ElementType
 	elementType := &ElementType{OID: elementOID, Name: elementName}
 	m.elementOIDMap.Set(oid, elementType)
 	return elementType, nil
+}
+
+// enumTypeQuery resolves an OID to the enum it names, together with the enum's
+// labels in their declared order. It returns no row for anything else.
+//
+// Postgres reports a domain column's base type in the row description, so a
+// domain over an enum arrives here as the enum itself. An array of an enum has
+// its own OID, whose typtype is 'b', so callers resolve the element type first.
+const enumTypeQuery = `SELECT t.typname, array_agg(e.enumlabel ORDER BY e.enumsortorder)
+	FROM pg_type t
+	JOIN pg_enum e ON e.enumtypid = t.oid
+	WHERE t.oid = $1 AND t.typtype = 'e'
+	GROUP BY t.typname`
+
+// EnumForOID returns the enum the given OID names, or nil when it names none.
+// Built-in types are answered from the pgx type map without a query, since no
+// enum can have a built-in OID.
+//
+// The returned value is shared with every other caller for that OID and must
+// not be modified; clone Labels before handing them to anything that might.
+// Note: This method may acquire a database connection if the OID is not cached.
+func (m *Mapper) EnumForOID(ctx context.Context, oid uint32) (*EnumType, error) {
+	if _, isBuiltIn := m.pgMap.TypeForOID(oid); isBuiltIn {
+		return nil, nil
+	}
+	if enum, found := m.enumOIDMap.Get(oid); found {
+		return enum, nil
+	}
+
+	var enum EnumType
+	err := m.querier.QueryRow(ctx, []any{&enum.Name, &enum.Labels}, enumTypeQuery, oid)
+	switch {
+	case err == nil:
+		m.enumOIDMap.Set(oid, &enum)
+		return &enum, nil
+	case errors.Is(err, ErrNoRows):
+		m.enumOIDMap.Set(oid, nil)
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("selecting enum for OID %d: %w", oid, err)
+	}
 }

--- a/internal/postgres/pg_mapper.go
+++ b/internal/postgres/pg_mapper.go
@@ -131,9 +131,14 @@ func (m *Mapper) queryElementType(ctx context.Context, oid uint32) (*ElementType
 // enumTypeQuery resolves an OID to the enum it names, together with the enum's
 // labels in their declared order. It returns no row for anything else.
 //
-// Postgres reports a domain column's base type in the row description, so a
-// domain over an enum arrives here as the enum itself. An array of an enum has
-// its own OID, whose typtype is 'b', so callers resolve the element type first.
+// Filtering on typtype = 'e' alone is enough for a domain over an enum, because
+// postgres reports the domain's base type in the row description rather than
+// the domain's own OID. TestMapper_EnumForOID_Integration pins that on every
+// supported major, since the rest of this package resolves typbasetype from the
+// catalog explicitly and the difference is easy to miss.
+//
+// An array of an enum has its own OID, whose typtype is 'b', so it names no
+// enum here and a caller resolves the element type first.
 const enumTypeQuery = `SELECT t.typname, array_agg(e.enumlabel ORDER BY e.enumsortorder)
 	FROM pg_type t
 	JOIN pg_enum e ON e.enumtypid = t.oid

--- a/internal/postgres/pg_mapper_integration_test.go
+++ b/internal/postgres/pg_mapper_integration_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package postgres
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xataio/pgstream/internal/testcontainers"
+)
+
+// EnumForOID filters on typtype='e' alone, which is only correct if postgres
+// reports a domain's base type in the row description rather than the domain's
+// own OID. Everything else in this package resolves typbasetype from the
+// catalog explicitly, so the assumption is checked here against a real server
+// instead of being asserted in a comment.
+func TestMapper_EnumForOID_Integration(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx := context.Background()
+
+	for _, image := range []testcontainers.PostgresImage{testcontainers.Postgres14, testcontainers.Postgres17} {
+		t.Run(string(image), func(t *testing.T) {
+			assertEnumForOID(t, ctx, image)
+		})
+	}
+}
+
+func assertEnumForOID(t *testing.T, ctx context.Context, image testcontainers.PostgresImage) {
+	t.Helper()
+
+	var pgURL string
+	cleanup, err := testcontainers.SetupPostgresContainer(ctx, &pgURL, image)
+	require.NoError(t, err)
+	defer cleanup()
+
+	conn, err := NewConn(ctx, pgURL)
+	require.NoError(t, err)
+	defer conn.Close(ctx)
+
+	_, err = conn.Exec(ctx, `
+		CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+		CREATE DOMAIN mood_domain AS mood;
+		CREATE DOMAIN text_domain AS text;
+		CREATE TABLE feelings (
+			id     bigint,
+			mood   mood,
+			backup mood_domain,
+			moods  mood[],
+			note   text,
+			label  text_domain
+		)`)
+	require.NoError(t, err)
+
+	// the OIDs the parser sees, taken the same way getFieldDescriptions and
+	// the snapshot row adapter take them
+	rows, err := conn.Query(ctx, "SELECT * FROM feelings LIMIT 0")
+	require.NoError(t, err)
+	oidByColumn := map[string]uint32{}
+	for _, desc := range rows.FieldDescriptions() {
+		oidByColumn[string(desc.Name)] = desc.DataTypeOID
+	}
+	rows.Close()
+	require.Len(t, oidByColumn, 6)
+
+	labels := []string{"sad", "ok", "happy"}
+
+	tests := []struct {
+		column   string
+		wantEnum *EnumType
+	}{
+		{column: "mood", wantEnum: &EnumType{Name: "mood", Labels: labels}},
+		{
+			// the assumption under test: the row description carries mood's
+			// OID, not mood_domain's, so no typbasetype lookup is needed
+			column:   "backup",
+			wantEnum: &EnumType{Name: "mood", Labels: labels},
+		},
+		{
+			// an array has its own OID, so it names no enum here; a caller
+			// that wants the element enum resolves the element type first
+			column:   "moods",
+			wantEnum: nil,
+		},
+		{column: "note", wantEnum: nil},
+		{column: "label", wantEnum: nil},
+		{column: "id", wantEnum: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.column, func(t *testing.T) {
+			mapper := NewMapper(conn)
+
+			enum, err := mapper.EnumForOID(ctx, oidByColumn[tc.column])
+			require.NoError(t, err)
+			require.Equal(t, tc.wantEnum, enum)
+		})
+	}
+}

--- a/internal/postgres/pg_mapper_test.go
+++ b/internal/postgres/pg_mapper_test.go
@@ -206,3 +206,116 @@ func TestMapper_ElementTypeForOID(t *testing.T) {
 		})
 	}
 }
+
+func TestMapper_EnumForOID(t *testing.T) {
+	t.Parallel()
+
+	errTest := errors.New("oh noes")
+
+	// each querier counts its calls, so the cache can be asserted on rather
+	// than only its contents
+	newQuerier := func(name string, labels []string, err error, calls *int) Querier {
+		return &mockQuerier{
+			queryRowFn: func(ctx context.Context, dest []any, query string, args ...any) error {
+				*calls++
+				if err != nil {
+					return err
+				}
+				require.Equal(t, enumTypeQuery, query)
+				require.Len(t, dest, 2)
+				gotName, ok := dest[0].(*string)
+				require.True(t, ok)
+				*gotName = name
+				gotLabels, ok := dest[1].(*[]string)
+				require.True(t, ok)
+				*gotLabels = labels
+				return nil
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		// querier is built per case so the call count can be shared with it
+		newQuerier func(calls *int) Querier
+		oid        uint32
+
+		wantEnum  *EnumType
+		wantCache map[uint32]*EnumType
+		wantCalls int
+		wantErr   error
+	}{
+		{
+			name: "built-in type is answered without a query",
+			newQuerier: func(calls *int) Querier {
+				return &mockQuerier{queryRowFn: func(ctx context.Context, dest []any, query string, args ...any) error {
+					*calls++
+					t.Errorf("unexpected query %q for a built-in OID", query)
+					return nil
+				}}
+			},
+			oid: 23, // int4
+
+			wantEnum:  nil,
+			wantCache: map[uint32]*EnumType{},
+			wantCalls: 0,
+		},
+		{
+			name: "enum resolved, then served from the cache",
+			newQuerier: func(calls *int) Querier {
+				return newQuerier("mood", []string{"sad", "ok", "happy"}, nil, calls)
+			},
+			oid: 16385,
+
+			wantEnum: &EnumType{Name: "mood", Labels: []string{"sad", "ok", "happy"}},
+			wantCache: map[uint32]*EnumType{
+				16385: {Name: "mood", Labels: []string{"sad", "ok", "happy"}},
+			},
+			wantCalls: 1,
+		},
+		{
+			name: "a custom type that is no enum caches the negative answer",
+			newQuerier: func(calls *int) Querier {
+				return newQuerier("", nil, ErrNoRows, calls)
+			},
+			oid: 1234,
+
+			wantEnum:  nil,
+			wantCache: map[uint32]*EnumType{1234: nil},
+			wantCalls: 1,
+		},
+		{
+			name: "an error is not cached, so the next call retries",
+			newQuerier: func(calls *int) Querier {
+				return newQuerier("", nil, errTest, calls)
+			},
+			oid: 1234,
+
+			wantEnum:  nil,
+			wantCache: map[uint32]*EnumType{},
+			wantCalls: 2,
+			wantErr:   errTest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			calls := 0
+			m := NewMapper(tc.newQuerier(&calls))
+
+			enum, err := m.EnumForOID(context.Background(), tc.oid)
+			require.ErrorIs(t, err, tc.wantErr)
+			require.Equal(t, tc.wantEnum, enum)
+
+			// a second lookup must not re-query unless the first failed
+			enumAgain, errAgain := m.EnumForOID(context.Background(), tc.oid)
+			require.ErrorIs(t, errAgain, tc.wantErr)
+			require.Equal(t, tc.wantEnum, enumAgain)
+
+			require.Equal(t, tc.wantCalls, calls)
+			require.Equal(t, tc.wantCache, m.enumOIDMap.GetMap())
+		})
+	}
+}

--- a/pkg/transformers/greenmask/greenmask_choice_transformer.go
+++ b/pkg/transformers/greenmask/greenmask_choice_transformer.go
@@ -38,6 +38,7 @@ var (
 	choiceCompatibleTypes = []transformers.SupportedDataType{
 		transformers.StringDataType,
 		transformers.ByteArrayDataType,
+		transformers.EnumDataType,
 	}
 )
 
@@ -70,11 +71,19 @@ func NewChoiceTransformer(params transformers.ParameterValues) (*ChoiceTransform
 
 func (t *ChoiceTransformer) Transform(_ context.Context, value transformers.Value) (any, error) {
 	var toTransform []byte
+	// a choice is a label, not opaque bytes, so give it back as the same kind
+	// of value it arrived as. An enum column only accepts the string form:
+	// bound as bytes, the chosen label reaches postgres hex encoded and is
+	// rejected with "invalid input value for enum"
+	wasString := false
 	switch val := value.TransformValue.(type) {
 	case []byte:
 		toTransform = val
 	case string:
 		toTransform = []byte(val)
+		wasString = true
+	// greenmask's own value shape, which none of pgstream's decoders produce,
+	// so it cannot carry an enum label and keeps returning bytes
 	case *toolkit.RawValue:
 		toTransform = val.Data
 	default:
@@ -85,6 +94,9 @@ func (t *ChoiceTransformer) Transform(_ context.Context, value transformers.Valu
 		return nil, err
 	}
 
+	if wasString {
+		return string(ret.Data), nil
+	}
 	return ret.Data, nil
 }
 

--- a/pkg/transformers/greenmask/greenmask_choice_transformer_test.go
+++ b/pkg/transformers/greenmask/greenmask_choice_transformer_test.go
@@ -92,6 +92,15 @@ func TestChoiceTransformer_Transform(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name:  "ok - transform an enum label deterministically",
+			input: "sad",
+			params: transformers.ParameterValues{
+				"generator": deterministic,
+				"choices":   []string{"sad", "ok", "happy"},
+			},
+			wantErr: nil,
+		},
+		{
 			name:  "error - invalid input type",
 			input: 1,
 			params: transformers.ParameterValues{
@@ -113,11 +122,23 @@ func TestChoiceTransformer_Transform(t *testing.T) {
 				return
 			}
 
-			// check if the result is in the choices
+			// the chosen label comes back as the same kind of value it went
+			// in as, so an enum column receives a label rather than its hex
+			// encoding
 			require.NotNil(t, got)
-			val, ok := got.([]byte)
-			require.True(t, ok)
-			require.Contains(t, tt.params["choices"], string(val))
+			var val string
+			switch out := got.(type) {
+			case string:
+				require.IsType(t, "", tt.input, "a string input must produce a string")
+				val = out
+			case []byte:
+				_, inputWasString := tt.input.(string)
+				require.False(t, inputWasString, "a non string input must produce bytes")
+				val = string(out)
+			default:
+				t.Fatalf("unexpected transform output type %T", got)
+			}
+			require.Contains(t, tt.params["choices"], val)
 
 			// if deterministic, check if we get the same result again
 			if mustGetGeneratorType(t, tt.params) == deterministic {

--- a/pkg/transformers/transformer.go
+++ b/pkg/transformers/transformer.go
@@ -109,6 +109,7 @@ const (
 	AllDataTypes           SupportedDataType = "all"
 	CitextDataType         SupportedDataType = "citext"
 	HstoreDataType         SupportedDataType = "hstore"
+	EnumDataType           SupportedDataType = "enum"
 )
 
 const (

--- a/transformers-definition.json
+++ b/transformers-definition.json
@@ -150,7 +150,8 @@
       "name": "greenmask_choice",
       "supported_types": [
         "string",
-        "byte_array"
+        "byte_array",
+        "enum"
       ],
       "uniqueness": "lossy",
       "parameters": [


### PR DESCRIPTION
#### Description

`Mapper.EnumForOID` resolves an OID to the enum it names and returns the enum's labels in their declared order. Postgres reports a domain's base type in the row description, so a domain over an enum arrives already resolved. An array of an enum has its own OID and matches nothing here, so a caller resolves the element type first. Results are cached, a nil value being a cached negative, which most
OIDs are.

`greenmask_choice` returned the chosen value as a byte array whatever the input was. A label bound as bytes reaches postgres hex encoded, so an enum column rejects it with `invalid input value for enum`. It now returns a string when the input was a string, which is what the sibling `greenmask_string` transformer already did.

Follow-up PR is coming with the proper wiring.

#### Type of Change

Please select the relevant option(s):

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- `greenmask_choice` returns a `string` when its input was a string. A `[]byte` input still returns bytes, and `*toolkit.RawValue`, which none of pgstream's decoders produce, is unchanged.
- `EnumDataType`, for a transformer to declare. `greenmask_choice` declares it.

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
