### PR TITLE
Support enum columns in greenmask_choice

### DIFF
--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -325,14 +325,34 @@ transformations:
 
 **Uniqueness:** `lossy`. Any table with more rows than choices produces duplicates. Cannot be used on a column covered by a unique index. See [Uniqueness and unique indexes](#uniqueness-and-unique-indexes).
 
-| Supported PostgreSQL types          |
-| ----------------------------------- |
-| `text`, `varchar`, `char`, `bpchar` |
+| Supported PostgreSQL types                                                  |
+| --------------------------------------------------------------------------- |
+| `text`, `varchar`, `char`, `bpchar`, user-defined enum, and arrays of these |
 
-| Parameter | Type     | Default | Required | Values               |
-| --------- | -------- | ------- | -------- | -------------------- |
-| generator | string   | random  | No       | random,deterministic |
-| choices   | string[] | N/A     | Yes      | N/A                  |
+`choices` is optional for an enum column. If you do not set it, pgstream uses the labels of the enum. If you set it, pgstream compares each value with those labels. A wrong value stops the run at startup, not at each insert.
+
+A domain over an enum resolves to the enum. An array of an enum resolves to the enum too, so an array column receives the same choices and transforms each element.
+
+`greenmask_choice` is the only type-specific transformer for an enum column. It is the only one that you can limit to the values of the enum. `literal_string` and `pg_anonymizer` accept all types. They also apply to an enum column. For `literal_string`, use a literal that is a valid label.
+
+The default choices have three limits:
+
+- **A source Postgres URL is necessary.** Without it, pgstream does not validate the rules against a catalog. A rule without `choices` then stops the run at startup with the message `greenmask_choice: choices must not be empty`. Set `choices` for a pipeline that has no Postgres source, for example a pipeline with a Kafka source.
+- **pgstream reads the labels one time, at startup.** If you add or rename a label on the source, pgstream uses the new label only after a restart. Before the restart, a replicated `ALTER TYPE ... RENAME VALUE` makes pgstream write a label that the target refuses. At startup, pgstream writes the labels in use to the log for each column with default choices.
+- **The default is the full set of labels.** pgstream does not read a `CHECK` constraint on a domain or on a table. It does not apply such a constraint. Set `choices` for a column with a `CHECK` constraint.
+
+⚠️ The transformer can select the label that the source row already contains. It selects from all the choices and does not remove the source value from the set. With `generator: random`, approximately 1 row in N keeps its source value, where N is the number of choices. With `generator: deterministic`, each label maps to one fixed label, so a label that maps to itself keeps its value in every row. The transformers that select from a fixed dictionary, for example `greenmask_firstname`, operate in the same way.
+
+⚠️ Use `generator: random` for an enum column. The `deterministic` generator maps each label to one fixed label and uses no secret key. The target contains all labels of the enum. A person who reads the target can find the source label of each value. pgstream writes a warning to the log when a rule uses `deterministic` with default enum choices.
+
+ℹ️ The transformer writes the value as a string. This is a change for the Kafka, webhook, Elasticsearch and OpenSearch targets. Before this change, `greenmask_choice` wrote a byte array, and these targets encoded that byte array as base64 in JSON. Update the consumers that decode base64. A search index also contains base64 in the documents from before this change.
+
+| Parameter | Type     | Default                       | Required                   | Values               |
+| --------- | -------- | ----------------------------- | -------------------------- | -------------------- |
+| generator | string   | random                        | No                         | random,deterministic |
+| choices   | string[] | the enum's labels, if an enum | Yes, unless an enum column | N/A                  |
+
+`transformers-definition.json` shows `choices` as always required. This file describes the transformer, not the column that you configure it on.
 
 **Example Configuration:**
 
@@ -347,6 +367,9 @@ transformations:
           parameters:
             generator: random
             choices: ["pending", "shipped", "delivered", "cancelled"]
+        # an enum column does not need choices; pgstream uses the enum labels
+        mood:
+          name: greenmask_choice
 ```
 
 **Input-Output Examples:**
@@ -453,11 +476,12 @@ transformations:
 | Supported PostgreSQL types            |
 | ------------------------------------- |
 | `real`, `double precision`, `numeric` |
-⚠️ On a `numeric` column `min_value` and `max_value` are **required**. Their defaults span the whole `float32` range, which produces the same out-of-range constant for every row .
 
-A `numeric` value is converted to a `float64` before it seeds the generator, and the generated value is a `float64` too, so a `numeric` column is anonymized within float64's range: values beyond it are clamped, and values beyond float64's significand are rounded. Only the seed is affected, since the original is discarded.
+⚠️ Set `min_value` and `max_value` for a `numeric` column. These parameters are required there. The default range covers all `float32` values. With the default range, the transformer writes the same constant value in each row.
 
-On a `numeric(p,s)` column the configured range is checked against the column when the rules are validated, so a range that cannot fit fails the run. An unconstrained `numeric` accepts any value, so nothing is checked there beyond the bounds being set.
+The transformer converts the `numeric` value to a `float64` and uses that `float64` as the seed for the generator. The output is also a `float64`. If the source value has more digits than a `float64` holds, the transformer rounds it. If the source value is outside the `float64` range, the transformer uses the largest `float64` value. These changes apply to the seed only, because the transformer discards the source value.
+
+pgstream compares the range with the column when it validates the rules. If the range does not fit a `numeric(p,s)` column, the run stops. A `numeric` column without a precision holds any value. For such a column, pgstream checks only that you set both bounds.
 
 | Parameter | Type   | Default                                       | Required | Values               |
 | --------- | ------ | --------------------------------------------- | -------- | -------------------- |

--- a/pkg/stream/integration/snapshot_pg_integration_test.go
+++ b/pkg/stream/integration/snapshot_pg_integration_test.go
@@ -13,6 +13,8 @@ import (
 	pglib "github.com/xataio/pgstream/internal/postgres"
 	"github.com/xataio/pgstream/internal/testcontainers"
 	"github.com/xataio/pgstream/pkg/stream"
+	"github.com/xataio/pgstream/pkg/transformers"
+	"github.com/xataio/pgstream/pkg/transformers/greenmask"
 	"github.com/xataio/pgstream/pkg/wal/processor/transformer"
 )
 
@@ -1175,6 +1177,182 @@ func Test_SnapshotToPostgres_NumericColumnTransformer(t *testing.T) {
 	t.Run("batch writer", func(t *testing.T) {
 		run(t, "batch")
 	})
+}
+
+// Test_SnapshotToPostgres_EnumColumnTransformer verifies that a user-defined
+// enum column can be transformed end to end. An enum's OID is assigned by the
+// database, so it reaches no case of the transformer type compatibility map
+// and every rule on such a column used to be rejected. greenmask_choice picks
+// from the enum's own labels, which default from the catalog when the rule
+// does not list them.
+func Test_SnapshotToPostgres_EnumColumnTransformer(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	var snapshotPGURL string
+	pgcleanup, err := testcontainers.SetupPostgresContainer(context.Background(), &snapshotPGURL, testcontainers.Postgres14, "config/postgresql.conf")
+	require.NoError(t, err)
+	defer pgcleanup()
+
+	// each subtest gets its own context, so a timeout in one cannot cancel
+	// the context the next one still needs
+	run := func(t *testing.T, suffix string, columnRules map[string]transformer.TransformerRules, want []enumRow, opts ...option) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		testTable := fmt.Sprintf("enum_transformer_%s", suffix)
+		// distinct from the enum types Test_SnapshotToPostgres_EnumColumn
+		// creates: the target database is shared by every test in the package,
+		// and a name collision leaves whichever restores second inserting
+		// labels the other test's enum does not have
+		enumType := fmt.Sprintf("choice_mood_%s", suffix)
+
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+			`CREATE TYPE %s AS ENUM ('sad', 'ok', 'happy')`, enumType))
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+			`CREATE DOMAIN %s_d AS %s`, enumType, enumType))
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+			`CREATE TABLE %s(
+				id      INTEGER PRIMARY KEY,
+				mood    %s NOT NULL,
+				backup  %s_d
+			)`, testTable, enumType, enumType))
+		execQueryWithURL(t, ctx, snapshotPGURL, fmt.Sprintf(
+			`INSERT INTO %s(id, mood, backup) VALUES
+				(1, 'sad', 'happy'),
+				(2, 'ok', NULL),
+				(3, 'happy', 'sad')`,
+			testTable))
+
+		cfg := &stream.Config{
+			Listener: testPostgresListenerCfgWithSnapshot(snapshotPGURL, targetPGURL, []string{testTable}),
+			Processor: testPostgresProcessorCfg(append(opts, withTransformerRules([]transformer.TableRules{{
+				Schema:      "public",
+				Table:       testTable,
+				ColumnRules: columnRules,
+			}}))...),
+		}
+		initStream(t, ctx, snapshotPGURL)
+		runSnapshot(t, ctx, cfg)
+
+		targetConn, err := pglib.NewConn(ctx, targetPGURL)
+		require.NoError(t, err)
+		defer targetConn.Close(ctx)
+
+		timer := time.NewTimer(20 * time.Second)
+		defer timer.Stop()
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		query := fmt.Sprintf("SELECT id, mood::text, backup::text FROM %s ORDER BY id", testTable)
+		fetch := func() ([]enumRow, error) {
+			rows, err := targetConn.Query(ctx, query)
+			if err != nil {
+				return nil, err
+			}
+			defer rows.Close()
+			out := []enumRow{}
+			for rows.Next() {
+				var r enumRow
+				if err := rows.Scan(&r.id, &r.mood, &r.backup); err != nil {
+					return nil, err
+				}
+				out = append(out, r)
+			}
+			return out, rows.Err()
+		}
+
+		// poll only for arrival, then assert once on the test's own goroutine
+		var got []enumRow
+		for got == nil {
+			select {
+			case <-timer.C:
+				t.Fatal("timeout waiting for postgres snapshot sync of transformed enum columns")
+			case <-ticker.C:
+				rows, err := fetch()
+				if err == nil && len(rows) == 3 {
+					got = rows
+				}
+			}
+		}
+
+		// nullness is asserted per row: a transformer error nulls the column
+		// under the default on_error policy, so a nil backup would otherwise
+		// pass as "not a label"
+		require.Equal(t, want, got)
+	}
+
+	// no choices configured: they default to the enum's labels, for the enum
+	// column and for the domain over it alike. The generator is deterministic
+	// so the mapping is fixed, which is what makes the outcome assertable at
+	// all; a random generator could only be checked for membership.
+	defaultedRules := map[string]transformer.TransformerRules{
+		"mood":   {Name: "greenmask_choice", Parameters: map[string]any{"generator": "deterministic"}},
+		"backup": {Name: "greenmask_choice", Parameters: map[string]any{"generator": "deterministic"}},
+	}
+	// an explicit subset of one: every transformed value has to be that label,
+	// which no untransformed source row would satisfy
+	explicitRules := map[string]transformer.TransformerRules{
+		"mood": {
+			Name:       "greenmask_choice",
+			Parameters: map[string]any{"choices": []any{"ok"}, "generator": "deterministic"},
+		},
+	}
+
+	t.Run("bulk ingest", func(t *testing.T) {
+		run(t, "bulk", defaultedRules, deterministicEnumRows(t), withBulkIngestionEnabled())
+	})
+	t.Run("batch writer", func(t *testing.T) {
+		run(t, "batch", defaultedRules, deterministicEnumRows(t))
+	})
+	t.Run("explicit choices", func(t *testing.T) {
+		// mood is forced to "ok" for every row; backup carries no rule, so it
+		// must survive untouched, which also pins pass-through of an unruled
+		// enum column
+		happy, sad := "happy", "sad"
+		run(t, "explicit", explicitRules, []enumRow{
+			{id: 1, mood: "ok", backup: &happy},
+			{id: 2, mood: "ok", backup: nil},
+			{id: 3, mood: "ok", backup: &sad},
+		})
+	})
+}
+
+type enumRow struct {
+	id     int
+	mood   string
+	backup *string
+}
+
+// deterministicEnumRows computes what the defaulted-choices rules must produce,
+// by running the very transformer the parser builds. Asserting membership in
+// the label set instead would pass even if the transformer were skipped, since
+// the source values are themselves labels.
+func deterministicEnumRows(t *testing.T) []enumRow {
+	t.Helper()
+
+	tr, err := greenmask.NewChoiceTransformer(transformers.ParameterValues{
+		"generator": "deterministic",
+		"choices":   []string{"sad", "ok", "happy"},
+	})
+	require.NoError(t, err)
+
+	transform := func(in string) string {
+		out, err := tr.Transform(context.Background(), transformers.NewValue(in, "mood", nil))
+		require.NoError(t, err)
+		label, ok := out.(string)
+		require.True(t, ok, "expected a string label, got %T", out)
+		return label
+	}
+
+	backup1 := transform("happy")
+	backup3 := transform("sad")
+	return []enumRow{
+		{id: 1, mood: transform("sad"), backup: &backup1},
+		{id: 2, mood: transform("ok"), backup: nil},
+		{id: 3, mood: transform("happy"), backup: &backup3},
+	}
 }
 
 // Test_SnapshotToPostgres_IdentityAndGeneratedColumns verifies that identity

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -261,7 +261,7 @@ func addProcessorModifiers(ctx context.Context, config *Config, logger loglib.Lo
 		pgURL := config.SourcePostgresURL()
 		if pgURL != "" {
 			var parser transformer.ParseFn
-			parserOpts := []transformer.ParserOption{}
+			parserOpts := []transformer.ParserOption{transformer.WithParserLogger(logger)}
 			// only a postgres target enforces the source's unique indexes
 			if config.Processor.Postgres != nil {
 				parserOpts = append(parserOpts, transformer.WithUniquenessEnforcement())

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	pglib "github.com/xataio/pgstream/internal/postgres"
+	loglib "github.com/xataio/pgstream/pkg/log"
 	"github.com/xataio/pgstream/pkg/transformers"
 	"golang.org/x/exp/slices"
 )
@@ -27,6 +28,7 @@ type PostgresTransformerParser struct {
 	// only a postgres target actually enforces a unique index; elsewhere the
 	// same findings are reported but must not block the pipeline
 	enforceUniqueness bool
+	logger            loglib.Logger
 }
 
 type ParserOption func(*PostgresTransformerParser)
@@ -37,6 +39,16 @@ type ParserOption func(*PostgresTransformerParser)
 func WithUniquenessEnforcement() ParserOption {
 	return func(v *PostgresTransformerParser) {
 		v.enforceUniqueness = true
+	}
+}
+
+// WithParserLogger sets the logger rules validation reports through. It is
+// named apart from WithLogger, which configures the transformer processor.
+func WithParserLogger(l loglib.Logger) ParserOption {
+	return func(v *PostgresTransformerParser) {
+		v.logger = loglib.NewLogger(l).WithFields(loglib.Fields{
+			loglib.ModuleField: "postgres_transformer_parser",
+		})
 	}
 }
 
@@ -73,6 +85,7 @@ const (
 	// OIDs are assigned per database
 	citextTypeName = "citext"
 	hstoreTypeName = "hstore"
+	choicesParam   = "choices"
 )
 
 var (
@@ -80,6 +93,9 @@ var (
 	// ErrNumericRange is returned when a transformer configured on a numeric
 	// column can generate values the column cannot store.
 	ErrNumericRange = errors.New("transformer range does not fit the numeric column")
+	// ErrInvalidEnumChoice is returned when a greenmask_choice rule on an enum
+	// column lists a value the enum does not have.
+	ErrInvalidEnumChoice = errors.New("choice is not a valid enum label")
 )
 
 // columnType is what rules validation needs to know about a column's type: the
@@ -96,6 +112,9 @@ type resolvedType struct {
 	columnType
 	name    string
 	isArray bool
+	// enum is set when the resolved type names a user-defined enum, which an
+	// array column inherits from its element type.
+	enum *pglib.EnumType
 }
 
 func NewPostgresTransformerParser(ctx context.Context, pgURL string, builder transformerBuilder, requiredTables []string, opts ...ParserOption) (*PostgresTransformerParser, error) {
@@ -109,6 +128,7 @@ func NewPostgresTransformerParser(ctx context.Context, pgURL string, builder tra
 		builder:        builder,
 		pgtypeMap:      pglib.NewMapper(pool),
 		requiredTables: requiredTables,
+		logger:         loglib.NewNoopLogger(),
 	}
 	for _, opt := range opts {
 		opt(parser)
@@ -158,10 +178,12 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 		for colName, transformerRules := range table.ColumnRules {
 			cfg := transformerRulesToConfig(transformerRules)
 
-			switch cfg.Name {
-			case "", "noop":
+			if cfg.Name == "" || cfg.Name == "noop" {
 				transformerMap.AddNoopTransformer(table.Schema, table.Table, colName)
 				continue
+			}
+
+			switch cfg.Name {
 			case transformers.PGAnonymizer, transformers.LookupChoice:
 				// these transformers require a connection pool, set
 				// the source PG URL if not provided
@@ -174,12 +196,6 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 				return nil, fmt.Errorf("%s: column '%s' in table %q.%q: %w", tableRulePosition(tableIdx), colName, table.Schema, table.Table, transformers.ErrMultiDimensionalArray)
 			}
 
-			// build the transformer
-			transformer, err := v.builder.New(cfg)
-			if err != nil {
-				return nil, columnRuleError(tableIdx, table.Schema, table.Table, colName, err)
-			}
-
 			// get the data type so that we can later validate if it's compatible with the configured transformer
 			colType, found := mappedColumnTypes[colName]
 			if !found {
@@ -188,10 +204,37 @@ func (v *PostgresTransformerParser) ParseAndValidate(ctx context.Context, rules 
 			}
 
 			dataTypeName, nameErr := v.pgtypeMap.TypeForOID(ctx, colType.oid)
-			resolved, err := v.resolveColumnType(ctx, colType)
+			resolved, resolveErr := v.resolveColumnType(ctx, colType)
+			if nameErr == nil && resolveErr == nil {
+				// the element type for an array column, so an array of an enum
+				// reaches its labels the same way a scalar enum column does
+				enum, enumErr := v.pgtypeMap.EnumForOID(ctx, resolved.oid)
+				if enumErr != nil {
+					return nil, columnRuleError(tableIdx, table.Schema, table.Table, colName, fmt.Errorf("resolving enum type: %w", enumErr))
+				}
+				resolved.enum = enum
+			}
+
+			// an enum column supplies the choices its transformer is built
+			// with, so this has to happen before the builder runs
+			if cfg.Name == transformers.GreenmaskChoice {
+				defaulted, err := v.applyEnumChoices(cfg, resolved.enum)
+				if err != nil {
+					return nil, columnRuleError(tableIdx, table.Schema, table.Table, colName, err)
+				}
+				if defaulted {
+					v.reportDefaultedChoices(table.Schema, table.Table, colName, cfg, resolved.enum)
+				}
+			}
+
+			// build the transformer
+			transformer, err := v.builder.New(cfg)
+			if err != nil {
+				return nil, columnRuleError(tableIdx, table.Schema, table.Table, colName, err)
+			}
 
 			// validate that the transformer is compatible with the column type
-			if nameErr != nil || err != nil || !pgTypeCompatibleWithTransformerType(transformer.CompatibleTypes(), resolved.oid, resolved.name) {
+			if nameErr != nil || resolveErr != nil || !pgTypeCompatibleWithTransformerType(transformer.CompatibleTypes(), resolved.oid, resolved.name, resolved.enum) {
 				return nil, fmt.Errorf("%s: transformer '%s' specified for column '%s' in table %q.%q does not support pg data type: %s with OID: %d", tableRulePosition(tableIdx), transformer.Type(), colName, table.Schema, table.Table, dataTypeName, colType.oid)
 			}
 
@@ -459,9 +502,16 @@ func parseTableName(qualifiedTableName string) (string, string, error) {
 	}
 }
 
-func pgTypeCompatibleWithTransformerType(compatibleTypes []transformers.SupportedDataType, pgTypeOID uint32, pgTypeName string) bool {
+func pgTypeCompatibleWithTransformerType(compatibleTypes []transformers.SupportedDataType, pgTypeOID uint32, pgTypeName string, enum *pglib.EnumType) bool {
 	if slices.Contains(compatibleTypes, transformers.AllDataTypes) {
 		return true
+	}
+	// an enum accepts only a transformer that can be constrained to its
+	// labels, and never through the OID switch below, since its OID is
+	// assigned by the database rather than fixed. An array column resolves to
+	// its element type, so an array of an enum arrives here as the enum
+	if enum != nil {
+		return slices.Contains(compatibleTypes, transformers.EnumDataType)
 	}
 	switch pgTypeOID {
 	case pgtype.TextOID, pgtype.VarcharOID, pgtype.BPCharOID:
@@ -600,4 +650,64 @@ func arrayColumnWarnings(tableIdx int, schema, table, column, dataTypeName strin
 			position, transformer.Type()))
 	}
 	return warnings
+}
+
+// applyEnumChoices reconciles a greenmask_choice rule with the column it is
+// configured on. On an enum column the labels are the natural choices, so a
+// rule that omits them gets them, and a rule that lists them is checked
+// against the enum now rather than failing per row against the target. It
+// reports whether the choices were defaulted.
+//
+// The labels are read once, here, so a label renamed on the source afterwards
+// is only picked up on restart. Constraints narrowing the column further, such
+// as a CHECK on a domain over the enum, are not visible in the row description
+// this resolves from and are not honoured; list the choices explicitly there.
+func (v *PostgresTransformerParser) applyEnumChoices(cfg *transformers.Config, enum *pglib.EnumType) (bool, error) {
+	if enum == nil {
+		return false, nil
+	}
+
+	choices, found, err := transformers.FindParameterArray[string](cfg.Parameters, choicesParam)
+	if err != nil {
+		return false, fmt.Errorf("%s must be an array of strings: %w", choicesParam, err)
+	}
+	if !found {
+		if cfg.Parameters == nil {
+			cfg.Parameters = transformers.ParameterValues{}
+		}
+		// cloned: the labels belong to the mapper's cache, which every column
+		// of this enum shares
+		cfg.Parameters[choicesParam] = slices.Clone(enum.Labels)
+		return true, nil
+	}
+
+	// an explicitly empty list is a mistake, most often a template that
+	// rendered nothing, so let the builder reject it rather than silently
+	// widening it to every label
+	for _, choice := range choices {
+		if !slices.Contains(enum.Labels, choice) {
+			return false, fmt.Errorf("%w: %q is not a label of enum %q (%s)",
+				ErrInvalidEnumChoice, choice, enum.Name, strings.Join(enum.Labels, ", "))
+		}
+	}
+	return false, nil
+}
+
+// reportDefaultedChoices records a choice set the operator never wrote. It is
+// the only trace of it: the labels live in memory, and a value the target
+// later rejects cannot otherwise be traced back to a rule.
+func (v *PostgresTransformerParser) reportDefaultedChoices(schema, table, column string, cfg *transformers.Config, enum *pglib.EnumType) {
+	v.logger.Info("defaulting greenmask_choice choices to the enum's labels", loglib.Fields{
+		"schema": schema, "table": table, "column": column,
+		"enum": enum.Name, "choices": enum.Labels,
+	})
+
+	// the deterministic generator maps each label to a fixed other label with
+	// no secret involved, and an enum publishes its whole label set to anyone
+	// who can read the target, so the mapping is trivially invertible
+	if generator, _ := cfg.Parameters["generator"].(string); generator == "deterministic" {
+		v.warnings = append(v.warnings, fmt.Sprintf(
+			"%s: column %q uses greenmask_choice with the deterministic generator over enum %q's own labels, which is reversible by anyone who can read the target; use generator: random to break the correspondence",
+			schemaTableKey(schema, table), column, enum.Name))
+	}
 }

--- a/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
+++ b/pkg/wal/processor/transformer/wal_postgres_transformer_parser_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	pglib "github.com/xataio/pgstream/internal/postgres"
 	pgmocks "github.com/xataio/pgstream/internal/postgres/mocks"
+	loglib "github.com/xataio/pgstream/pkg/log"
 	"github.com/xataio/pgstream/pkg/transformers"
 	"github.com/xataio/pgstream/pkg/transformers/builder"
 	transformermocks "github.com/xataio/pgstream/pkg/transformers/mocks"
@@ -93,8 +94,9 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 			},
 			QueryRowFn: func(ctx context.Context, dest []any, query string, args ...any) error {
 				// the element type query only matches a true array type, and
-				// the fake OIDs in this test are all scalar
-				if strings.Contains(query, "a.typcategory = 'A'") {
+				// the fake OIDs in this test are all scalar. No column of the
+				// mocked table is an enum either
+				if strings.Contains(query, "a.typcategory = 'A'") || enumTypeQueryMatch(query) {
 					return pglib.ErrNoRows
 				}
 				switch query {
@@ -115,6 +117,9 @@ func TestPostgresTransformerParser_ParseAndValidate(t *testing.T) {
 
 	testQuerierWithUnknownTypeErr := testQuerier()
 	testQuerierWithUnknownTypeErr.QueryRowFn = func(ctx context.Context, dest []any, query string, args ...any) error {
+		if enumTypeQueryMatch(query) {
+			return pglib.ErrNoRows
+		}
 		require.Equal(t, query, "SELECT typname FROM pg_type WHERE oid = $1")
 		require.Equal(t, 1, len(args))
 		require.Equal(t, citextOID, args[0])
@@ -705,13 +710,56 @@ func Test_pgTypeCompatibleWithTransformerType(t *testing.T) {
 	}
 	stringCompatible := []transformers.SupportedDataType{transformers.StringDataType}
 
+	enumCompatible := []transformers.SupportedDataType{
+		transformers.StringDataType,
+		transformers.EnumDataType,
+	}
+	mood := &pglib.EnumType{Name: "mood", Labels: []string{"sad", "ok", "happy"}}
+
 	tests := []struct {
 		name            string
 		compatibleTypes []transformers.SupportedDataType
 		oid             uint32
 		typeName        string
+		enum            *pglib.EnumType
 		want            bool
 	}{
+		{
+			name:            "enum with an enum compatible transformer",
+			compatibleTypes: enumCompatible,
+			oid:             16385,
+			typeName:        "mood",
+			enum:            mood,
+			want:            true,
+		},
+		{
+			name: "enum with a string transformer that cannot produce a label",
+			// a string transformer would emit a value the enum does not have,
+			// which the target rejects row by row
+			compatibleTypes: []transformers.SupportedDataType{transformers.StringDataType},
+			oid:             16385,
+			typeName:        "mood",
+			enum:            mood,
+			want:            false,
+		},
+		{
+			// an array of an enum resolves to no enum, so it is rejected by
+			// name like any other array
+			name:            "enum array resolves to no enum and is rejected",
+			compatibleTypes: enumCompatible,
+			oid:             16386,
+			typeName:        "_mood",
+			enum:            nil,
+			want:            false,
+		},
+		{
+			name:            "enum with a transformer supporting all types",
+			compatibleTypes: []transformers.SupportedDataType{transformers.AllDataTypes},
+			oid:             16385,
+			typeName:        "mood",
+			enum:            mood,
+			want:            true,
+		},
 		{
 			name:            "numeric with a float compatible transformer",
 			compatibleTypes: floatCompatible,
@@ -753,7 +801,92 @@ func Test_pgTypeCompatibleWithTransformerType(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			require.Equal(t, tc.want, pgTypeCompatibleWithTransformerType(tc.compatibleTypes, tc.oid, tc.typeName))
+			require.Equal(t, tc.want, pgTypeCompatibleWithTransformerType(tc.compatibleTypes, tc.oid, tc.typeName, tc.enum))
+		})
+	}
+}
+
+func Test_applyEnumChoices(t *testing.T) {
+	t.Parallel()
+
+	mood := &pglib.EnumType{Name: "mood", Labels: []string{"sad", "ok", "happy"}}
+
+	tests := []struct {
+		name          string
+		params        transformers.ParameterValues
+		enum          *pglib.EnumType
+		wantChoices   any
+		wantDefaulted bool
+		wantErr       error
+	}{
+		{
+			name:          "choices default to the enum labels",
+			params:        transformers.ParameterValues{},
+			enum:          mood,
+			wantChoices:   []string{"sad", "ok", "happy"},
+			wantDefaulted: true,
+		},
+		{
+			name:          "nil parameters are populated",
+			params:        nil,
+			enum:          mood,
+			wantChoices:   []string{"sad", "ok", "happy"},
+			wantDefaulted: true,
+		},
+		{
+			// most often a template that rendered nothing: left alone so the
+			// builder rejects it, rather than silently widening to every label
+			name:        "an explicitly empty list is not defaulted",
+			params:      transformers.ParameterValues{"choices": []any{}},
+			enum:        mood,
+			wantChoices: []any{},
+		},
+		{
+			name:    "a malformed choices value is rejected",
+			params:  transformers.ParameterValues{"choices": "ok"},
+			enum:    mood,
+			wantErr: transformers.ErrInvalidParameters,
+		},
+		{
+			name:        "a subset of the labels is kept",
+			params:      transformers.ParameterValues{"choices": []any{"ok", "happy"}},
+			enum:        mood,
+			wantChoices: []any{"ok", "happy"},
+		},
+		{
+			name:    "a label the enum does not have is rejected",
+			params:  transformers.ParameterValues{"choices": []any{"ok", "elated"}},
+			enum:    mood,
+			wantErr: ErrInvalidEnumChoice,
+		},
+		{
+			name:        "a non enum column keeps its own choices",
+			params:      transformers.ParameterValues{"choices": []any{"a", "b"}},
+			enum:        nil,
+			wantChoices: []any{"a", "b"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &transformers.Config{Name: transformers.GreenmaskChoice, Parameters: tc.params}
+			parser := &PostgresTransformerParser{logger: loglib.NewNoopLogger()}
+
+			defaulted, err := parser.applyEnumChoices(cfg, tc.enum)
+			require.ErrorIs(t, err, tc.wantErr)
+			if tc.wantErr != nil {
+				return
+			}
+			require.Equal(t, tc.wantDefaulted, defaulted)
+			require.Equal(t, tc.wantChoices, cfg.Parameters["choices"])
+			if tc.wantDefaulted {
+				// cloned, so a later mutation cannot reach the mapper's cache
+				choices, ok := cfg.Parameters["choices"].([]string)
+				require.True(t, ok)
+				require.NotSame(t, &tc.enum.Labels[0], &choices[0])
+			}
 		})
 	}
 }
@@ -1031,6 +1164,10 @@ func TestPostgresTransformerParser_ParseAndValidate_arrayColumns(t *testing.T) {
 					require.True(t, ok)
 					*elementOID, *elementName = citextOID, citextTypeName
 					return nil
+				}
+				// citext is no enum, so the enum lookup finds nothing
+				if enumTypeQueryMatch(query) {
+					return pglib.ErrNoRows
 				}
 
 				require.Len(t, dest, 1)
@@ -1333,6 +1470,173 @@ func Test_arrayColumnWarnings(t *testing.T) {
 			for _, want := range tc.wantContains {
 				require.Contains(t, strings.Join(warnings, "\n"), want)
 			}
+		})
+	}
+}
+
+// enumTypeQueryMatch reports whether a mocked querier is being asked the enum
+// lookup, without pinning the exact SQL text the mapper uses.
+func enumTypeQueryMatch(query string) bool {
+	return strings.Contains(query, "pg_enum")
+}
+
+// the enum wiring inside ParseAndValidate had no unit coverage: passing a nil
+// enum to either the compatibility check or the choice defaulting, and
+// swallowing the lookup error, all went unnoticed without a live database.
+func TestPostgresTransformerParser_ParseAndValidate_enumColumns(t *testing.T) {
+	t.Parallel()
+
+	const moodOID = uint32(16385)
+	errTest := errors.New("catalog unavailable")
+
+	// a querier whose only enum column is "mood"; enumErr, when set, is what
+	// the enum lookup fails with
+	newQuerier := func(enumErr error) *pgmocks.Querier {
+		return &pgmocks.Querier{
+			QueryFn: func(ctx context.Context, _ uint, query string, args ...any) (pglib.Rows, error) {
+				switch query {
+				case "SELECT * FROM \"public\".\"test\" LIMIT 0":
+					return &pgmocks.Rows{
+						FieldDescriptionsFn: func() []pgconn.FieldDescription {
+							return []pgconn.FieldDescription{
+								{Name: "mood", DataTypeOID: moodOID, TypeModifier: -1},
+							}
+						},
+						CloseFn: func() {},
+						ErrFn:   func() error { return nil },
+					}, nil
+				// the mocked column is a scalar enum, not a multi-dimensional
+				// array
+				case multiDimensionalColumnsQuery, uniqueIndexQuery:
+					return &pgmocks.Rows{
+						CloseFn: func() {},
+						NextFn:  func(i uint) bool { return false },
+						ErrFn:   func() error { return nil },
+					}, nil
+				default:
+					return nil, fmt.Errorf("unexpected query: %s", query)
+				}
+			},
+			QueryRowFn: func(ctx context.Context, dest []any, query string, args ...any) error {
+				// the mocked enum column is a scalar, so it names no array
+				if strings.Contains(query, "a.typcategory = 'A'") {
+					return pglib.ErrNoRows
+				}
+				if enumTypeQueryMatch(query) {
+					if enumErr != nil {
+						return enumErr
+					}
+					require.Len(t, dest, 2)
+					name, ok := dest[0].(*string)
+					require.True(t, ok)
+					*name = "mood"
+					labels, ok := dest[1].(*[]string)
+					require.True(t, ok)
+					*labels = []string{"sad", "ok", "happy"}
+					return nil
+				}
+				dataTypeName, ok := dest[0].(*string)
+				require.True(t, ok)
+				*dataTypeName = "mood"
+				return nil
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		rules       TransformerRules
+		enumErr     error
+		wantChoices []string
+		wantErr     error
+		wantErrMsg  string
+	}{
+		{
+			name:        "choices default to the enum labels",
+			rules:       TransformerRules{Name: "greenmask_choice"},
+			wantChoices: []string{"sad", "ok", "happy"},
+		},
+		{
+			name: "an explicit subset is kept",
+			rules: TransformerRules{Name: "greenmask_choice", Parameters: map[string]any{
+				"choices": []any{"ok"},
+			}},
+			wantChoices: []string{"ok"},
+		},
+		{
+			name: "a label the enum does not have names the column",
+			rules: TransformerRules{Name: "greenmask_choice", Parameters: map[string]any{
+				"choices": []any{"elated"},
+			}},
+			wantErr:    ErrInvalidEnumChoice,
+			wantErrMsg: `column 'mood' in table "public"."test"`,
+		},
+		{
+			name:       "a transformer that cannot produce a label is rejected",
+			rules:      TransformerRules{Name: "masking", Parameters: map[string]any{"type": "default"}},
+			wantErrMsg: "does not support pg data type: mood",
+		},
+		{
+			name:       "a failing enum lookup names the column",
+			rules:      TransformerRules{Name: "greenmask_choice"},
+			enumErr:    errTest,
+			wantErr:    errTest,
+			wantErrMsg: `column 'mood' in table "public"."test"`,
+		},
+		{
+			// the builder error used to arrive with no column or table
+			name:       "a rule with no choices on a non enum column names the column",
+			rules:      TransformerRules{Name: "greenmask_choice"},
+			enumErr:    pglib.ErrNoRows,
+			wantErrMsg: `column 'mood' in table "public"."test"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			querier := newQuerier(tc.enumErr)
+			parser := PostgresTransformerParser{
+				conn:      querier,
+				builder:   builder.NewTransformerBuilder(),
+				pgtypeMap: pglib.NewMapper(querier),
+				logger:    loglib.NewNoopLogger(),
+			}
+
+			transformerMap, err := parser.ParseAndValidate(context.Background(), Rules{
+				Transformers: []TableRules{{
+					Schema:      "public",
+					Table:       "test",
+					ColumnRules: map[string]TransformerRules{"mood": tc.rules},
+				}},
+			})
+
+			if tc.wantErr != nil || tc.wantErrMsg != "" {
+				require.Error(t, err)
+				if tc.wantErr != nil {
+					require.ErrorIs(t, err, tc.wantErr)
+				}
+				require.Contains(t, err.Error(), tc.wantErrMsg)
+				return
+			}
+			require.NoError(t, err)
+			defer transformerMap.Close()
+
+			// the built transformer does not expose its choices, so exercise
+			// it until every configured one has come out
+			columnTransformers, found := transformerMap.GetActiveColumnTransformers("public", "test")
+			require.True(t, found)
+			seen := map[string]bool{}
+			for range 200 {
+				got, err := columnTransformers["mood"].Transform(context.Background(), transformers.NewValue("sad", "mood", nil))
+				require.NoError(t, err)
+				label, ok := got.(string)
+				require.True(t, ok, "expected a string label, got %T", got)
+				require.Contains(t, tc.wantChoices, label)
+				seen[label] = true
+			}
+			require.Len(t, seen, len(tc.wantChoices), "expected every choice to be reachable")
 		})
 	}
 }

--- a/pkg/wal/processor/transformer/wal_transformer_enum_integration_test.go
+++ b/pkg/wal/processor/transformer/wal_transformer_enum_integration_test.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package transformer
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pglib "github.com/xataio/pgstream/internal/postgres"
+	"github.com/xataio/pgstream/internal/testcontainers"
+	"github.com/xataio/pgstream/pkg/transformers"
+	"github.com/xataio/pgstream/pkg/transformers/builder"
+)
+
+// an enum's OID is assigned by the database, so which transformers a column of
+// one accepts cannot be decided without reading the catalog. The mocked unit
+// tests cannot cover that lookup, nor the labels it feeds greenmask_choice.
+func TestPostgresTransformerParser_EnumColumns_Integration(t *testing.T) {
+	if os.Getenv("PGSTREAM_INTEGRATION_TESTS") == "" {
+		t.Skip("skipping integration test...")
+	}
+
+	ctx := context.Background()
+
+	var pgURL string
+	cleanup, err := testcontainers.SetupPostgresContainer(ctx, &pgURL, testcontainers.Postgres17)
+	require.NoError(t, err)
+	defer cleanup()
+
+	adminConn, err := pglib.NewConn(ctx, pgURL)
+	require.NoError(t, err)
+	defer adminConn.Close(ctx)
+
+	_, err = adminConn.Exec(ctx, `
+		CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
+		CREATE DOMAIN mood_domain AS mood;
+		CREATE TABLE public.feelings (
+			id     bigint PRIMARY KEY,
+			mood   mood,
+			backup mood_domain,
+			moods  mood[],
+			note   text
+		);
+	`)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		column      string
+		rules       TransformerRules
+		wantErr     error
+		wantErrMsg  string
+		wantChoices []string
+		wantArray   bool
+	}{
+		{
+			name:        "choices default to the enum labels",
+			column:      "mood",
+			rules:       TransformerRules{Name: "greenmask_choice"},
+			wantChoices: []string{"sad", "ok", "happy"},
+		},
+		{
+			name:        "a domain over an enum resolves to the enum",
+			column:      "backup",
+			rules:       TransformerRules{Name: "greenmask_choice"},
+			wantChoices: []string{"sad", "ok", "happy"},
+		},
+		{
+			name:        "an explicit subset of the labels is kept",
+			column:      "mood",
+			rules:       TransformerRules{Name: "greenmask_choice", Parameters: map[string]any{"choices": []any{"ok"}}},
+			wantChoices: []string{"ok"},
+		},
+		{
+			name:    "a choice the enum does not have is rejected",
+			column:  "mood",
+			rules:   TransformerRules{Name: "greenmask_choice", Parameters: map[string]any{"choices": []any{"elated"}}},
+			wantErr: ErrInvalidEnumChoice,
+		},
+		{
+			// an array column resolves to its element type, so the labels
+			// reach it the same way they reach a scalar enum column
+			name:        "an array of the enum defaults its choices too",
+			column:      "moods",
+			rules:       TransformerRules{Name: "greenmask_choice"},
+			wantChoices: []string{"sad", "ok", "happy"},
+			wantArray:   true,
+		},
+		{
+			name:        "an array of the enum validates explicit choices",
+			column:      "moods",
+			rules:       TransformerRules{Name: "greenmask_choice", Parameters: map[string]any{"choices": []any{"sad"}}},
+			wantChoices: []string{"sad"},
+			wantArray:   true,
+		},
+		{
+			name:    "an array of the enum rejects a label the enum does not have",
+			column:  "moods",
+			rules:   TransformerRules{Name: "greenmask_choice", Parameters: map[string]any{"choices": []any{"elated"}}},
+			wantErr: ErrInvalidEnumChoice,
+		},
+		{
+			name:       "a transformer that cannot produce a label is rejected",
+			column:     "mood",
+			rules:      TransformerRules{Name: "masking", Parameters: map[string]any{"type": "default"}},
+			wantErrMsg: `does not support pg data type: mood`,
+		},
+		{
+			name:   "a transformer supporting every type is still accepted",
+			column: "mood",
+			rules:  TransformerRules{Name: "literal_string", Parameters: map[string]any{"literal": "ok"}},
+		},
+		{
+			name:        "a non enum column is unaffected",
+			column:      "note",
+			rules:       TransformerRules{Name: "greenmask_choice", Parameters: map[string]any{"choices": []any{"x", "y"}}},
+			wantChoices: []string{"x", "y"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parser, err := NewPostgresTransformerParser(ctx, pgURL, builder.NewTransformerBuilder(), nil)
+			require.NoError(t, err)
+			defer parser.Close()
+
+			transformerMap, err := parser.ParseAndValidate(ctx, Rules{
+				Transformers: []TableRules{{
+					Schema:      "public",
+					Table:       "feelings",
+					ColumnRules: map[string]TransformerRules{tc.column: tc.rules},
+				}},
+			})
+
+			switch {
+			case tc.wantErr != nil:
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			case tc.wantErrMsg != "":
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErrMsg)
+				return
+			}
+			require.NoError(t, err)
+			defer transformerMap.Close()
+
+			if tc.wantChoices == nil {
+				return
+			}
+
+			// the configured choices are not readable from the transformer, so
+			// exercise it until it has produced every one of them
+			columnTransformers, found := transformerMap.GetActiveColumnTransformers("public", "feelings")
+			require.True(t, found)
+			tr := columnTransformers[tc.column]
+			require.NotNil(t, tr)
+
+			if tc.wantArray {
+				// the map holds the wrapper, so validation and the transform
+				// both see the whole array
+				require.IsType(t, &transformers.ArrayTransformer{}, tr)
+				return
+			}
+
+			// 200 draws over at most three labels: the chance of missing one
+			// is about 3*(2/3)^200, far below any flake worth worrying about
+			seen := map[string]bool{}
+			for range 200 {
+				got, err := tr.Transform(ctx, transformers.NewValue("sad", "mood", nil))
+				require.NoError(t, err)
+				label, ok := got.(string)
+				require.True(t, ok, "expected a string label, got %T", got)
+				require.Contains(t, tc.wantChoices, label)
+				seen[label] = true
+			}
+			require.Len(t, seen, len(tc.wantChoices), "expected every choice to be reachable")
+		})
+	}
+}


### PR DESCRIPTION
#### Description

A transformation rule on a user-defined enum column was rejected at startup with `does not support pg data type: <enum> with OID: <n>`, unless it used a transformer declaring `AllDataTypes`.

An enum's OID is assigned by the database, so it reaches no case of the transformer type compatibility switch, whose fallback branch knows only `citext` and `hstore` by name. The name alone cannot identify an enum, so the parser had no way to decide what such a column accepts.

This builds on #1191, which added `Mapper.EnumForOID` and made `greenmask_choice` return a string. Those pieces had no caller; this wires them into the rules validation.

#### Type of Change

Please select the relevant option(s):

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement
- [ ] 🔨 Build/CI changes
- [ ] 🧹 Code cleanup

#### Changes Made

- The parser resolves the column type first, then asks the mapper for the enum the resolved type names. A rule that omits `choices` gets the enum's labels, using the hook that already injects `postgres_url` for `pg_anonymizer`.
- Choices listed explicitly are checked against the labels, so a typo stops the run rather than every insert.

#### Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

#### Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented
- [x] Documentation updated where necessary
